### PR TITLE
fix(timer): 健康自检定时器可能再也不会运行(v1.8.2 候选)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,10 @@ jobs:
       - name: "自检防火墙端口回归"
         run: python3 tests/test-doctor-firewall.py
 
+      # 定时器停摆时所有常规信号都说正常, 只有 NextElapse 露馅 —— doctor 此前没有这一项。
+      - name: "健康自检定时器判据 (elapsed+infinity 必须 FAIL / 正在跑不误报 / 只读)"
+        run: python3 tests/test-health-timer-doctor.py
+
       - name: "nft input 链冲突判据 (单一来源 + 读不到≠没有 + platform 守卫不靠 PATH 找 nft)"
         run: python3 tests/test-nft-input-scan.py
 
@@ -333,6 +337,14 @@ jobs:
       # docs/rescue-plane-acceptance.md, 那里只写真跑过的结论。
       - name: "救援平面 10b 硬门 (真 socket activation/硬化/真 nft; 环境不足则 SKIP)"
         run: sudo -E bash tests/e2e-rescue-10b.sh
+
+      # 真 systemd: 死角复现、迁移状态机、故障注入。非 root 环境 SKIP(严格模式判失败)。
+      - name: "健康自检定时器 真 systemd (死角/状态机/6 种故障注入; 环境不足则 SKIP)"
+        run: sudo -E bash tests/e2e-health-timer.sh
+
+      # 共享 systemctl 桩的契约: 它坏了不会有人报警, 只会让上层测试悄悄变成恒绿。
+      - name: "共享 systemctl 桩契约 (多个 -p/KEY=VALUE/乱序/四种状态/故障注入)"
+        run: sudo -E env PDG_E2E_ISOLATED=1 bash tests/test-systemctl-stub.sh
 
       - name: "运行模块安装闭包 (真实入口传递依赖 vs 安装真源, 含动态导入点)"
         run: python3 tests/test-install-closure.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本项目按语义化 `v1.x` tag 正式发布;以下按版本/日期记录主要变化,完整提交见 git 历史。
 
-## 待发布 — v1.8.2 候选(健康自检定时器可能再也不会运行)
+## 2026-08-07 — v1.8.2(健康自检定时器可能再也不会运行)
 
 `pdg-health.timer` 可能处在这样一种状态: `systemctl is-enabled` 说 enabled、`is-active`
 说 active、`is-failed` 不 failed、`Result=success` —— 一切看着正常, 但它**再也不会触发**。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 本项目按语义化 `v1.x` tag 正式发布;以下按版本/日期记录主要变化,完整提交见 git 历史。
 
+## 待发布 — v1.8.2 候选(健康自检定时器可能再也不会运行)
+
+`pdg-health.timer` 可能处在这样一种状态: `systemctl is-enabled` 说 enabled、`is-active`
+说 active、`is-failed` 不 failed、`Result=success` —— 一切看着正常, 但它**再也不会触发**。
+真机上曾这样静默停了 8 天, 期间服务异常也不会有 Telegram 通知。
+
+只有两个字段露馅: `SubState=elapsed` 与 `NextElapseUSecMonotonic=infinity`。
+
+- **定时器改用 `OnActiveSec=2min` + `OnUnitActiveSec=10min`**(去掉 `OnBootSec` 与
+  `Persistent=true`)。`OnActiveSec` 相对**定时器自己被激活的时刻**, 这个参照点任何时候
+  都在; 而 `OnBootSec` 在"开机很久之后才重启定时器"时那个点已经过去, 加上
+  `OnUnitActiveSec` 不足以重新武装, 两条都算不出下一次 ⇒ 永久停摆。`Persistent=true`
+  只对 `OnCalendar=` 生效, 这里留着是句空头承诺。检查频率不变, 仍是每 10 分钟。
+- **更新迁移会重新排程, 并验证真的排上了**。换过 unit 之后不只是 `enable --now`
+  (那对已经 active 的定时器什么都不做), 而是明确重启并确认存在有限的下一次触发时间;
+  确认不通过就返回失败让更新回滚。内容没变且状态正常时不写盘、不重启。
+- **`pdg doctor` 新增「健康自检定时器」检查**, 排不出下一次运行时报
+  「健康检查定时器没有安排下一次运行。」正在执行的那一瞬不会误报。检查是只读的, 不会
+  替你重启定时器 —— 自动重启只会把问题掩盖掉。
+
+用户配置、分流规则、凭据与证书不受影响。
+
 ## 2026-08-04 — v1.8.1(v1.7.8 → v1.8.0 更新时, 首次启用救援平面会让整次更新回滚)
 
 用户从 v1.7.8 更新, 停在这里:

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -249,6 +249,85 @@ def check_bot_credentials():
     return ("info", "Bot 凭据", "未配置(token 与允许 id 都为空)→ pdg-bot 不启动, 属正常禁用态。"
                                "需要用 Telegram 管理时运行 pdg-set-token 配置。")
 
+def check_health_timer():
+    """健康自检定时器**排不排得出下一次**。
+
+    jp2 上出过一次: is-enabled=enabled、is-active=active、is-failed 不 failed、
+    Result=success —— 常规三态全绿, 而 SubState=elapsed、NextElapse 两项都是空/infinity,
+    服务 8 天没跑过, doctor 一路判绿(那时它根本没有这一项)。所以判据不能只看三态,
+    必须看**下一次触发时间**。
+
+    只读: 不 restart / enable / reset-failed / daemon-reload —— 自检的职责是如实报告,
+    不是替用户按开关; 自动重启还会把问题掩盖掉, 下次照样静默停摆。
+    """
+    T = "pdg-health.timer"
+    NAME = "健康自检定时器"
+
+    def _get(args):
+        rc, out, _e = _run(["systemctl"] + args)
+        return out.strip() if rc == 0 else None
+
+    en = _get(["is-enabled", T])
+    if en is None:
+        return ("fail", NAME, "读不到 %s 的启用状态 —— 无法确认健康检查是否还在运行。" % T)
+    if en not in ("enabled", "enabled-runtime", "static", "indirect"):
+        # 用户显式停用过就不该当故障报; 但"根本没装"要说出来。
+        if en in ("disabled", "masked"):
+            return ("info", NAME, "已停用(%s)。健康检查不会自动运行。" % en)
+        return ("fail", NAME, "启用状态异常: %s" % en)
+
+    act = _get(["is-active", T])
+    if act is None:
+        return ("fail", NAME, "读不到 %s 的运行状态 —— 无法确认健康检查是否还在运行。" % T)
+
+    # 一次取齐; 任一属性读不出即 fail-closed(读不到 ≠ 没问题)。
+    # 解析 KEY=VALUE 而不是按位取 `--value` 的输出: systemd **按它自己的规范顺序**打印,
+    # 不是按 -p 传入的顺序。真机上就是这么错位的 —— NextElapseUSecRealtime 排在最前,
+    # 于是 ActiveState 拿到了时间串, doctor 把一台好机器判成红的。
+    vals = _get(["show", T, "-p", "ActiveState", "-p", "SubState",
+                 "-p", "NextElapseUSecMonotonic", "-p", "NextElapseUSecRealtime"])
+    if vals is None:
+        return ("fail", NAME, "读不到 %s 的 systemd 属性 —— 无法确认下一次运行时间。" % T)
+    props = {}
+    for line in vals.split("\n"):
+        if "=" in line:
+            k, _sep, v = line.partition("=")
+            props[k.strip()] = v.strip()
+    need = ("ActiveState", "SubState",
+            "NextElapseUSecMonotonic", "NextElapseUSecRealtime")
+    if not all(k in props for k in need):
+        return ("fail", NAME,
+                "%s 的 systemd 属性不完整(缺 %s)—— 无法确认下一次运行时间。"
+                % (T, ", ".join(k for k in need if k not in props)))
+    a_state = props["ActiveState"]; sub = props["SubState"]
+    nxt_mono = props["NextElapseUSecMonotonic"]; nxt_real = props["NextElapseUSecRealtime"]
+
+    if act != "active" or a_state != "active":
+        return ("fail", NAME,
+                "定时器已启用却没在运行(%s)。健康检查不会自动运行。"
+                % (a_state or act or "unknown"))
+
+    def _finite(v):
+        return bool(v) and v not in ("infinity", "n/a")
+
+    has_next = _finite(nxt_mono) or _finite(nxt_real)
+
+    # 正在跑的那一瞬: 下一次还没重新算出来, 不能据此报故障。
+    if sub in ("running", "elapsed-running") or not sub:
+        if sub == "running":
+            return ("ok", NAME, "健康检查正在运行。")
+
+    if sub == "elapsed" or not has_next:
+        return ("fail", NAME,
+                "健康检查定时器没有安排下一次运行。它看上去是启用且在运行的, 但不会再触发 —— "
+                "服务异常时你不会收到通知。跑 <code>sudo pdg __migrate</code> 让它重新排程。")
+
+    # 具体的绝对时间只进诊断日志: 机器是 UTC 而人按本地时区读, 摆出来容易看错四五个小时。
+    sys.stderr.write("health-timer: sub=%s next_mono=%s next_real=%s\n"
+                     % (sub, nxt_mono, nxt_real))
+    return ("ok", NAME, "已排定下一次运行。")
+
+
 def check_core_version():
     _, out, _ = _run(["mihomo", "-v"])
     m = re.search(r"v?(\d+\.\d+\.\d+)", out or "")
@@ -1280,7 +1359,7 @@ def check_transactions():
             "<code>sudo pdg tx recover &lt;id&gt;</code> 恢复。" % (len(pend), items))
 
 
-ALL = [check_platform, check_services, check_bot_credentials, check_core_version, check_dot_arecord, check_dot_domain_sync,
+ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_geosite_db, check_mem,

--- a/deploy/bot/pdg-health.timer
+++ b/deploy/bot/pdg-health.timer
@@ -1,10 +1,25 @@
 [Unit]
 Description=每 10 分钟跑一次 PrivDNS Gateway 健康自检
 
+# 调度必须**永远排得出下一次**。原来这里是 OnBootSec=2min + OnUnitActiveSec=10min:
+# 开机很久之后再重启一次 timer(升级重写 unit 就会), 开机点已在过去、而 OnUnitActiveSec
+# 不足以重新武装 ⇒ NextElapse=infinity, 永久停在 SubState=elapsed。而所有常规信号都说
+# 正常 —— enabled、active、不 failed、Result=success。jp2 上就这样静默停了 8 天。
+#
+# OnActiveSec 相对**本 timer 自己被激活的时刻**, 这个参照点任何时候都存在, 所以无论
+# 冷启、重启、还是升级重写后重启, 都必然排得出下一次。
+#
+# 不用 OnCalendar: 那会把相对调度换成墙钟调度(受时区/DST 影响, 且所有机器在整点齐射);
+# 更要紧的是**不能与 OnUnitActiveSec 并存** —— 容器实测两者叠加时 systemd 取最早的那个,
+# 墙钟槽与单调间隔交错, 实测间隔从 20/30 秒变成 20,10,21,9,21,9, 频率接近翻倍。
+# 也因此这里没有 Persistent= : 它只对 OnCalendar 生效, 留着是句空头承诺。
+#
+# Unit= 写明触发目标: 默认是"同名 .service", 靠约定成立。写出来之后, 谁改了文件名或
+# 加了别名都不会悄悄指错地方 —— 这条判据要读它。
 [Timer]
-OnBootSec=2min
+OnActiveSec=2min
 OnUnitActiveSec=10min
-Persistent=true
+Unit=pdg-health.service
 
 [Install]
 WantedBy=timers.target

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1826,6 +1826,97 @@ migrate_deploy_units(){
   return 0
 }
 
+# 健康自检定时器的部署状态机。
+#
+# 为什么单独一个函数而不是并进 migrate_deploy_units: timer 与 .service 不同, **换了文件
+# 还得让它重新排程**。`systemctl enable --now` 对一个已经 active 的 timer 什么都不做, 于是
+# 盘上是新调度、跑着的还是旧的 —— jp2 上那台 8 天没跑过健康自检, 正是这条缝。
+#
+# 判据不是"文件对不对", 而是**排不排得出下一次**: 同一份 unit 冷启是好的、重启一次就可能
+# 死在 elapsed+infinity。所以内容没变时也要看 NextElapse, 不对就重新 arm。
+_pdg_timer_next_ok(){                       # $1=unit 名; 有有限的下一次触发则 0
+  local m r
+  m="$(systemctl show "$1" -p NextElapseUSecMonotonic --value 2>/dev/null)"
+  r="$(systemctl show "$1" -p NextElapseUSecRealtime  --value 2>/dev/null)"
+  [[ -n "$m" && "$m" != infinity ]] && return 0
+  [[ -n "$r" && "$r" != infinity && "$r" != "n/a" ]] && return 0
+  return 1
+}
+
+migrate_health_timer(){
+  local src="$REPO_DIR/deploy/bot/pdg-health.timer"
+  local cur=/etc/systemd/system/pdg-health.timer
+  local T=pdg-health.timer
+  [[ -f "$src" ]] || return 0
+  command -v systemctl >/dev/null 2>&1 || return 0
+
+  # 候选先验证: 一份连 [Timer] 段都没有的文件装上去 = 把定时器彻底废掉。
+  if ! grep -q '^\[Timer\]' "$src" || ! grep -qE '^On(Active|UnitActive|Boot|Calendar)Sec=' "$src"; then
+    c_y "  健康自检定时器候选不合法(缺 [Timer] 或触发条件), 不安装"; return 1
+  fi
+
+  local en0 ac0
+  en0="$(systemctl is-enabled "$T" 2>/dev/null)"
+  ac0="$(systemctl is-active  "$T" 2>/dev/null)"
+
+  # ── 内容没变: 一个字节都不写, 只在状态确实不对时纠正 ──
+  if [[ -f "$cur" ]] && cmp -s "$src" "$cur"; then
+    local acted=0
+    if [[ "$en0" != enabled ]]; then
+      systemctl enable "$T" >/dev/null 2>&1 || { c_y "  启用 $T 失败"; return 1; }
+      acted=1
+    fi
+    if [[ "$ac0" != active ]] || ! _pdg_timer_next_ok "$T"; then
+      # active 但排不出下一次 = elapsed+infinity 那个死角, 内容相同也必须重新 arm
+      systemctl restart "$T" >/dev/null 2>&1 || { c_y "  重启 $T 失败"; return 1; }
+      _pdg_timer_next_ok "$T" || { c_y "  $T 重启后仍排不出下一次触发"; return 1; }
+      acted=1
+    fi
+    [[ "$acted" == 1 ]] && c_g "  健康自检定时器已重新排程"
+    return 0
+  fi
+
+  # ── 内容变了: 存 before-image → 原子安装 → reload → enable → 明确 restart → 验证 ──
+  local had=0 bak="" mode="" own=""
+  if [[ -f "$cur" ]]; then
+    had=1; bak="$(mktemp)" || { c_y "  无法创建备份"; return 1; }
+    cp -a "$cur" "$bak" || { c_y "  备份 $T 失败"; rm -f "$bak"; return 1; }
+    mode="$(stat -c%a "$cur" 2>/dev/null)"; own="$(stat -c%u:%g "$cur" 2>/dev/null)"
+  fi
+
+  _restore(){                               # 尽力回到原状; 回滚不完整要明说
+    local _rbad=0
+    if [[ "$had" == 1 ]]; then
+      cp -a "$bak" "$cur" 2>/dev/null || _rbad=1
+      [[ -n "$mode" ]] && { chmod "$mode" "$cur" 2>/dev/null || _rbad=1; }
+      [[ -n "$own"  ]] && { chown "$own"  "$cur" 2>/dev/null || _rbad=1; }
+    else
+      rm -f "$cur" 2>/dev/null || _rbad=1
+    fi
+    systemctl daemon-reload >/dev/null 2>&1 || _rbad=1
+    [[ "$en0" == enabled ]] && { systemctl enable "$T" >/dev/null 2>&1 || _rbad=1; }
+    [[ "$ac0" == active  ]] && { systemctl start  "$T" >/dev/null 2>&1 || _rbad=1; }
+    rm -f "$bak"
+    [[ "$_rbad" == 0 ]] || c_y "  ⚠️ 回滚 $T 不完整 —— 请手工核对 $cur 与 systemctl status $T"
+    return 0
+  }
+
+  if ! install -m644 "$src" "$cur" 2>/dev/null; then
+    c_y "  安装 $T 失败"; _restore; return 1; fi
+  if ! systemctl daemon-reload >/dev/null 2>&1; then
+    c_y "  daemon-reload 失败"; _restore; return 1; fi
+  if ! systemctl enable "$T" >/dev/null 2>&1; then
+    c_y "  启用 $T 失败"; _restore; return 1; fi
+  # 明确 restart 而不是 try-restart: timer 是必需件, "没装/没起"不该被悄悄跳过。
+  if ! systemctl restart "$T" >/dev/null 2>&1; then
+    c_y "  重启 $T 失败"; _restore; return 1; fi
+  if ! _pdg_timer_next_ok "$T"; then
+    c_y "  $T 换新 unit 后仍排不出下一次触发"; _restore; return 1; fi
+  rm -f "$bak"
+  c_g "  健康自检定时器已更新并重新排程"
+  return 0
+}
+
 migrate_deploy_botfiles(){
   [[ -d "$REPO_DIR/deploy/bot" ]] || return 0
   # shellcheck source=lib/modules.sh
@@ -2659,6 +2750,7 @@ run_all_migrations(){
   migrate_mosdns_unlock || true; migrate_fw_gms || true
   migrate_mosdns_ratelimit || true; migrate_lowmem || true; migrate_mihomo_safepaths || true
   migrate_deploy_botfiles || true; migrate_deploy_units || true
+  migrate_health_timer || rc=1   # 定时器排不出下一次 = 健康自检静默停摆, 必须让更新回滚
   migrate_mosdns_hijack_shape || true
   migrate_mosdns_explicit_proxy || true
   migrate_ruleset_hijack || true

--- a/tests/e2e-health-timer.sh
+++ b/tests/e2e-health-timer.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 健康自检定时器必须**永远排得出下一次**。
+#
+# 真机上出过一次: jp2 的 pdg-health.timer 从 2026-07-28 起再也没跑过, 而所有信号都说
+# 正常 —— is-enabled=enabled、is-active=active、is-failed 不 failed、Result=success。
+# 只有 `SubState=elapsed` 与 `NextElapseUSecMonotonic=infinity` 露了馅。8 天无人知晓。
+#
+# 机制: 原来的 [Timer] 是纯单调的
+#     OnBootSec=2min          ← 开机很久之后才启动 timer, 这个点早就过去了
+#     OnUnitActiveSec=10min   ← 相对**被触发服务**上次活动; 服务没跑过就没有参照点
+#     Persistent=true         ← 只对 OnCalendar 生效, 这里是空头承诺
+# 两条都算不出 ⇒ NextElapse=infinity ⇒ 永久停在 elapsed。
+#
+# 判据落在**真 systemd** 上, 不 grep unit 文本 —— 文本对不对不重要, 排不排得出下一次
+# 才重要。非 root / 无 systemd 时 [SKIP], 严格模式下判失败(CI 必须真跑)。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0; SKIP=0
+ok(){ echo "[OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+skipf(){                       # 环境不具备: 平时 SKIP, CI(严格模式)判失败
+  if [[ "${PDG_TEST_STRICT:-}" == 1 ]]; then bad "$1 —— 严格模式下不接受丢覆盖"
+  else echo "[SKIP] $1 —— 未验收, 不是通过"; SKIP=$((SKIP+1)); fi
+}
+fin(){ echo "────────────────────────────────────────"
+       echo "通过 $PASS, 失败 $FAIL, 跳过 $SKIP"; [[ "$FAIL" == 0 ]]; }
+
+[[ "$(id -u)" == 0 ]] || { skipf "需要 root(真 systemd 操作)"; fin; exit $?; }
+systemctl is-system-running >/dev/null 2>&1 || [[ -d /run/systemd/system ]] \
+  || { skipf "没有可用的 systemd"; fin; exit $?; }
+
+SRC="$ROOT/deploy/bot/pdg-health.timer"
+[[ -f "$SRC" ]] || { bad "找不到 $SRC"; fin; exit $?; }
+
+# 本轮所有临时物都落在这个一次性根里, 退出时随 cleanup 一起消失。
+# 不写死 /tmp: 并发跑测试时那是别人的地盘, 而且残留会被临时物卫生门抓住。
+# PDG_KEEP_TMP=1 时保留现场并把路径打到 stderr —— 调试失败用例要的就是这堆残骸。
+E2E_HT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/e2e-health-timer.XXXXXX")"
+RC_FILE="$E2E_HT_ROOT/rc"
+HITS="$E2E_HT_ROOT/hits"
+UNIT=/etc/systemd/system/pdg-health.timer
+SVC=/etc/systemd/system/pdg-health.service
+SAVED=""
+[[ -f "$UNIT" ]] && { SAVED="$(mktemp)"; cp -a "$UNIT" "$SAVED"; }
+SAVED_SVC=""
+[[ -f "$SVC" ]] && { SAVED_SVC="$(mktemp)"; cp -a "$SVC" "$SAVED_SVC"; }
+WAS_ACTIVE="$(systemctl is-active pdg-health.timer 2>/dev/null)"
+
+cleanup(){
+  systemctl stop pdg-health.timer >/dev/null 2>&1
+  systemctl reset-failed pdg-health.timer pdg-health.service >/dev/null 2>&1
+  if [[ -n "$SAVED" ]]; then cp -a "$SAVED" "$UNIT"; rm -f "$SAVED"; else rm -f "$UNIT"; fi
+  if [[ -n "$SAVED_SVC" ]]; then cp -a "$SAVED_SVC" "$SVC"; rm -f "$SAVED_SVC"; else rm -f "$SVC"; fi
+  rm -f "$HITS"
+  if [[ -n "${PDG_KEEP_TMP:-}" && "${PDG_KEEP_TMP}" != 0 ]]; then
+    echo "[keep] 保留现场: $E2E_HT_ROOT" >&2
+  else
+    rm -rf "$E2E_HT_ROOT"
+  fi
+  systemctl daemon-reload >/dev/null 2>&1
+  [[ "$WAS_ACTIVE" == active ]] && systemctl start pdg-health.timer >/dev/null 2>&1
+  return 0
+}
+trap cleanup EXIT
+
+# 替身 service: 只记一次时间戳。**不改产品的 service 内容** —— 这支测的是调度, 不是自检本身。
+mk_svc(){ cat > "$SVC" <<EOF
+[Unit]
+Description=健康自检(E2E 替身: 只记时间戳)
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'date -u +%s >> $HITS'
+EOF
+}
+
+nxt(){ systemctl show pdg-health.timer -p NextElapseUSecMonotonic --value 2>/dev/null; }
+nxr(){ systemctl show pdg-health.timer -p NextElapseUSecRealtime  --value 2>/dev/null; }
+sub(){ systemctl show pdg-health.timer -p SubState --value 2>/dev/null; }
+finite(){  # 有限的下一次 = monotonic 或 realtime 至少一个既非空也非 infinity
+  local m r; m="$(nxt)"; r="$(nxr)"
+  [[ -n "$m" && "$m" != infinity ]] && return 0
+  [[ -n "$r" && "$r" != infinity && "$r" != "n/a" ]] && return 0
+  return 1
+}
+
+echo
+echo "── 1. timer 被重启一次之后, 仍必须排得出下一次 ──"
+# 真机上那个现场的确定性配方(容器里对照实验找出来的): **arm → stop → start**。
+#   · 第一次 start: timer 武装起来, Persistent 还会让它立刻补跑一次;
+#   · stop 之后再 start: OnBootSec 那个点此刻已在过去, 而 OnUnitActiveSec 不足以
+#     重新武装 ⇒ NextElapse=infinity, 永久停在 elapsed。
+# 注意**不要求 service 从未跑过** —— 对照实验里 service 已经跑过一次照样死。真机 jp2
+# 正是如此: 服务 7/28 跑过, timer 7/29 被重启, 从此再没动过。
+# 这也是为什么判据不能等价成"检查 unit 文本": 同一份文本, 冷启是好的、重启一次就死。
+mk_svc; : > "$HITS"
+install -m644 "$SRC" "$UNIT"
+systemctl daemon-reload
+systemctl stop pdg-health.timer >/dev/null 2>&1
+systemctl reset-failed pdg-health.timer pdg-health.service >/dev/null 2>&1
+rm -f /var/lib/systemd/timers/stamp-pdg-health.timer
+systemctl daemon-reload
+systemctl start pdg-health.timer >/dev/null 2>&1; sleep 2      # arm
+ok "前提: timer 已武装过一次(SubState=$(sub))"
+systemctl stop pdg-health.timer >/dev/null 2>&1; sleep 1
+systemctl start pdg-health.timer >/dev/null 2>&1                # 重启 —— 死角就在这里
+sleep 2
+echo "  实测: SubState=$(sub) NextMono=[$(nxt)] NextRealtime=[$(nxr)]"
+finite && ok "此时仍排得出下一次触发(核心判据)" \
+       || bad "NextElapse 为空/infinity —— timer 永久死在 $(sub), 服务再也不会跑"
+[[ "$(sub)" != elapsed ]] && ok "SubState 不是 elapsed(实得 $(sub))" \
+                          || bad "SubState=elapsed —— 已进入死角"
+systemctl list-timers --all pdg-health.timer --no-pager 2>/dev/null | sed -n 2p | grep -qv '^-' \
+  && ok "list-timers 里有 NEXT" || bad "list-timers 的 NEXT 是空的"
+
+echo
+echo "── 2. 反复重启不许掉进 infinity ──"
+allfin=1
+for i in 1 2 3; do
+  systemctl restart pdg-health.timer >/dev/null 2>&1
+  sleep 3
+  finite || { allfin=0; echo "    第 $i 次重启后: SubState=$(sub) NextMono=[$(nxt)]"; }
+done
+[[ "$allfin" == 1 ]] && ok "连续 3 次重启, 每次都排得出下一次" \
+                     || bad "重启后掉进了 infinity"
+[[ "$(systemctl is-failed pdg-health.timer)" != failed ]] \
+  && ok "重启不会把 timer 打成 failed" || bad "timer 变成 failed(failed 同样是 infinity)"
+
+echo
+echo "── 3. 换 unit 之后新调度必须真的生效 ──"
+# 装一份"旧式"的坏 unit(带 OnBootSec、无 OnActiveSec), 起起来, 再用产品的 unit 覆盖,
+# 看调度有没有跟着换 —— 只 install 不重启的话, 跑着的 timer 仍按旧调度走。
+cat > "$UNIT" <<'OLDU'
+[Unit]
+Description=旧式坏 unit(E2E)
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+[Install]
+WantedBy=timers.target
+OLDU
+systemctl daemon-reload; systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 2
+OLD_FRAG_SHA="$(sha256sum "$UNIT" | cut -d' ' -f1)"
+install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
+NEW_FRAG_SHA="$(sha256sum "$UNIT" | cut -d' ' -f1)"
+if [[ "$OLD_FRAG_SHA" == "$NEW_FRAG_SHA" ]]; then
+  bad "产品 unit 与旧式坏 unit 内容相同 —— 修复没落地"
+else
+  ok "盘上 unit 已更新(与旧式不同)"
+  # 只 daemon-reload 不重启: systemd 不会把已 active 的 timer 重新按新调度排
+  systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 2
+  finite && ok "重启后按新 unit 排出了下一次" || bad "换 unit 并重启后仍排不出下一次"
+fi
+
+echo
+echo "── 4. 真的触发一次, 之后重新排下一次 ──"
+: > "$HITS"
+systemctl stop pdg-health.timer >/dev/null 2>&1
+systemctl reset-failed pdg-health.timer pdg-health.service >/dev/null 2>&1
+FIRST="$(sed -n 's/^OnActiveSec=\([0-9]*\)\(min\|s\)$/\1 \2/p' "$UNIT" | head -1)"
+WAIT=0
+if [[ -n "$FIRST" ]]; then
+  fn="${FIRST% *}"; fu="${FIRST#* }"
+  if [[ "$fu" == "min" ]]; then WAIT=$(( fn * 60 )); else WAIT="$fn"; fi
+fi
+if (( WAIT == 0 )); then
+  skipf "unit 里没有 OnActiveSec, 无法在有界时间内观察首次触发"
+elif (( WAIT > 300 )); then
+  skipf "首次触发窗口 ${WAIT}s 过长, 本支不等"
+else
+  systemctl start pdg-health.timer >/dev/null 2>&1
+  # 窗口要覆盖 systemd 的默认 AccuracySec=1min —— 它会把触发点最多推迟一分钟。
+  # 第一版只等了 WAIT+20 秒, 于是在**修好的** unit 上也报"没触发", 那是测量窗口的错。
+  WIN=$((WAIT + 100))
+  echo "  (等 ${WIN} 秒观察首次触发: OnActiveSec=${WAIT}s + 默认 AccuracySec=1min 的余量)"
+  sleep "$WIN"
+  n="$(wc -l < "$HITS")"
+  (( n >= 1 )) && ok "首次触发发生了(实得 $n 次)" || bad "等满 ${WIN} 秒仍未触发"
+  finite && ok "触发之后重新排出了下一次" || bad "触发之后排不出下一次"
+  # 不许重复触发: 首次之后不该在同一个窗口里连着跑
+  (( n <= 2 )) && ok "没有重复触发(窗口内 $n 次, 阈值 2)" \
+               || bad "窗口内触发 $n 次 —— 疑似交错双触发"
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 5-7 节: 部署状态机。判据落在**真跑 migrate_health_timer** 上, 用真 systemd 观察它
+# 到底做了什么 —— 不是看它打印了什么。
+# ═════════════════════════════════════════════════════════════════════════════
+load_fn(){                     # 把真 CLI 的函数装进当前 shell(未知子命令 → 打用法后正常结束)
+  # shellcheck disable=SC1090
+  source "$ROOT/deploy/bot/pdg.sh" __e2e_noop >/dev/null 2>&1
+  REPO_DIR="$ROOT"
+  type migrate_health_timer >/dev/null 2>&1
+}
+inv(){ systemctl show pdg-health.timer -p InvocationID --value 2>/dev/null; }
+
+echo
+echo "── 5. 内容没变且一切正常 → 零写盘/零重启 ──"
+mk_svc; install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
+systemctl enable pdg-health.timer >/dev/null 2>&1
+systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 2
+if load_fn; then
+  ok "真函数已载入(migrate_health_timer)"
+  MT0="$(stat -c%Y "$UNIT")"; INV0="$(inv)"
+  migrate_health_timer; rc=$?
+  [[ "$rc" == 0 ]] && ok "返回 0" || bad "返回 $rc"
+  [[ "$(stat -c%Y "$UNIT")" == "$MT0" ]] && ok "unit 没被重写(mtime 不变)" || bad "无谓重写了 unit"
+  [[ "$(inv)" == "$INV0" ]] && ok "timer 没被重启(InvocationID 不变)" || bad "内容没变却重启了"
+else
+  bad "载入不了 migrate_health_timer —— 后面几节无从谈起"
+fi
+
+echo
+echo "── 6. 内容没变但已 disabled/inactive → 必须修回来 ──"
+systemctl stop pdg-health.timer >/dev/null 2>&1
+systemctl disable pdg-health.timer >/dev/null 2>&1
+migrate_health_timer >/dev/null 2>&1; rc=$?
+[[ "$rc" == 0 ]] && ok "返回 0" || bad "返回 $rc"
+[[ "$(systemctl is-enabled pdg-health.timer 2>/dev/null)" == enabled ]] \
+  && ok "已修回 enabled" || bad "仍是 $(systemctl is-enabled pdg-health.timer 2>/dev/null)"
+[[ "$(systemctl is-active pdg-health.timer 2>/dev/null)" == active ]] \
+  && ok "已修回 active" || bad "仍是 $(systemctl is-active pdg-health.timer 2>/dev/null)"
+finite && ok "并且排得出下一次" || bad "修回来了却排不出下一次"
+
+echo
+echo "── 7. 内容相同但 timer 已死 → 不许因为「内容没变」就放过 ──"
+# 任务书原本要求的是"内容相同且已 elapsed 时能重新 arm"。真做下来发现**那个组合用修好的
+# unit 不可达** —— OnActiveSec 让它任何时候都排得出下一次, 想死也死不了。内容相同还能死,
+# 只可能是盘上那份内容本身就是坏的那一版(真机 jp2 就是这样: 仓库与盘上都是旧 unit)。
+# 于是这一格验的是那个真正可达的契约: **重启后仍排不出下一次, 必须如实报失败**, 而不是
+# 因为"内容没变"就返回 0 说一切正常 —— 后者正是这次 8 天无人知晓的成因。
+#
+# 死角要靠"被触发的服务从未被激活过"才构造得稳: 服务一旦跑过, OnUnitActiveSec 就有了
+# 参照点。所以这里指向一个全新的、从没起过的服务名。
+cat > /etc/systemd/system/pdg-health-virgin.service <<'VIRG'
+[Unit]
+Description=E2E: 从未被激活过的服务(用于构造死角)
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+VIRG
+cat > "$UNIT" <<'OLDU2'
+[Unit]
+Description=旧式坏 unit(E2E: 死角构造)
+[Timer]
+OnUnitActiveSec=10min
+Unit=pdg-health-virgin.service
+[Install]
+WantedBy=timers.target
+OLDU2
+systemctl stop pdg-health.timer >/dev/null 2>&1
+systemctl reset-failed pdg-health.timer >/dev/null 2>&1
+rm -f /var/lib/systemd/timers/stamp-pdg-health.timer
+systemctl daemon-reload
+systemctl start pdg-health.timer >/dev/null 2>&1; sleep 2
+if finite; then
+  bad "前提不成立: 没能把 timer 推进死角(实得 SubState=$(sub))"
+else
+  ok "前提: timer 已死在 $(sub) + NextElapse=infinity"
+  BADSRC="$(mktemp)"; cp -a "$UNIT" "$BADSRC"
+  SAME="$(mktemp -d)"; mkdir -p "$SAME/deploy/bot"
+  cp "$BADSRC" "$SAME/deploy/bot/pdg-health.timer"          # 仓库与盘上逐字节相同
+  ( export REPO_DIR="$SAME"; migrate_health_timer >/dev/null 2>&1; echo $? > "$RC_FILE" ) || true
+  rc="$(cat "$RC_FILE" 2>/dev/null || echo 9)"
+  [[ "$rc" != 0 ]] && ok "内容相同但重新 arm 不成 → 返回非零($rc), 如实报失败" \
+                   || bad "返回 0 —— 又把静默停摆当成正常放过去了"
+  rm -f "$BADSRC" "$RC_FILE"; rm -rf "$SAME"
+  rm -f /etc/systemd/system/pdg-health-virgin.service; systemctl daemon-reload
+fi
+
+echo "── 8. 内容变化 → 装新的并重新 arm ──"
+install -m644 "$SRC" "$UNIT"   # 先回到产品版, 再造一次"旧→新"
+cat > "$UNIT" <<'OLDU3'
+[Unit]
+Description=旧式坏 unit(E2E)
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+[Install]
+WantedBy=timers.target
+OLDU3
+systemctl daemon-reload; systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 2
+migrate_health_timer >/dev/null 2>&1; rc=$?
+[[ "$rc" == 0 ]] && ok "返回 0" || bad "返回 $rc"
+cmp -s "$SRC" "$UNIT" && ok "盘上 unit 已换成产品版(逐字节相同)" || bad "unit 没换"
+[[ "$(systemctl is-active pdg-health.timer)" == active ]] && ok "timer active" || bad "timer 不是 active"
+finite && ok "新调度已 arm(有有限的下一次)" || bad "换了 unit 却没重新排程"
+
+echo
+echo "── 9. 故障注入: 每一步失败都要非零 + 回到原状 ──"
+# root 下 chmod 000 挡不住 install(第一版就是这么假绿的), 改用**函数遮蔽**精准打到某一步。
+install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
+systemctl enable --now pdg-health.timer >/dev/null 2>&1; sleep 1
+BEFORE_SHA="$(sha256sum "$UNIT" | awk '{print $1}')"
+BEFORE_EN="$(systemctl is-enabled pdg-health.timer 2>/dev/null)"
+BEFORE_AC="$(systemctl is-active  pdg-health.timer 2>/dev/null)"
+CHREPO="$(mktemp -d)"; mkdir -p "$CHREPO/deploy/bot"
+sed 's/OnActiveSec=2min/OnActiveSec=3min/' "$SRC" > "$CHREPO/deploy/bot/pdg-health.timer"   # 制造内容变化
+
+inject(){            # $1=场景名  $2=遮蔽定义
+  local name="$1" shadow="$2" rc
+  ( export REPO_DIR="$CHREPO"
+    eval "$shadow"
+    migrate_health_timer >/dev/null 2>&1; echo $? > "$RC_FILE" ) || true
+  rc="$(cat "$RC_FILE" 2>/dev/null || echo 9)"
+  [[ "$rc" != 0 ]] && ok "$name → 返回非零($rc)" || bad "$name 却返回 0"
+  [[ "$(sha256sum "$UNIT" | awk '{print $1}')" == "$BEFORE_SHA" ]] \
+    && ok "$name → unit 逐字节回到原样" || bad "$name → unit 没还原"
+  [[ "$(systemctl is-enabled pdg-health.timer 2>/dev/null)" == "$BEFORE_EN" \
+     && "$(systemctl is-active pdg-health.timer 2>/dev/null)" == "$BEFORE_AC" ]] \
+    && ok "$name → enabled/active 状态还原" || bad "$name → 状态没还原"
+  # 每一格之后回到基线, 免得上一格的残留影响下一格
+  install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
+  systemctl enable --now pdg-health.timer >/dev/null 2>&1
+  systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 1
+}
+
+# 9a 候选不合法(真实场景: 仓库里那份文件被截断/写坏)
+BADREPO="$(mktemp -d)"; mkdir -p "$BADREPO/deploy/bot"
+printf '[Unit]\nDescription=坏候选\n' > "$BADREPO/deploy/bot/pdg-health.timer"
+( export REPO_DIR="$BADREPO"; migrate_health_timer >/dev/null 2>&1; echo $? > "$RC_FILE" ) || true
+rc="$(cat "$RC_FILE" 2>/dev/null || echo 9)"
+[[ "$rc" != 0 ]] && ok "候选不合法 → 返回非零($rc)" || bad "候选不合法却返回 0"
+[[ "$(sha256sum "$UNIT" | awk '{print $1}')" == "$BEFORE_SHA" ]] \
+  && ok "坏候选没有落盘" || bad "坏候选被装上去了"
+
+inject "install 失败"      'install(){ return 1; }'
+inject "daemon-reload 失败" 'systemctl(){ [[ "$1" == daemon-reload ]] && return 1; command systemctl "$@"; }'
+inject "enable 失败"        'systemctl(){ [[ "$1" == enable ]] && return 1; command systemctl "$@"; }'
+inject "restart 失败"       'systemctl(){ [[ "$1" == restart ]] && return 1; command systemctl "$@"; }'
+inject "restart 成功但仍无 NextElapse" '_pdg_timer_next_ok(){ return 1; }'
+
+rm -rf "$BADREPO" "$CHREPO" "$RC_FILE"
+
+echo
+echo "── 10. unit 形态门: 两种被实测否定的写法不许出现 ──"
+# 这两条是形态判据而不是行为判据, 因为它们的危害要么无可观测(惰性指令), 要么只在长时间
+# 窗口里才显形 —— 而两者都有实测依据, 不是凭感觉定的规矩。
+BODY="$(grep -vE '^[[:space:]]*#' "$SRC")"       # 剥掉注释, 免得解释性文字被当成配置
+if grep -q '^Persistent=' <<<"$BODY" && ! grep -q '^OnCalendar=' <<<"$BODY"; then
+  bad "unit 里有 Persistent= 却没有 OnCalendar= —— 它只对 OnCalendar 生效, 留着是句空头承诺(这次就是它误导了排查)"
+else
+  ok "没有惰性的 Persistent=(要么不写, 要么配 OnCalendar 一起写)"
+fi
+if grep -q '^OnCalendar=' <<<"$BODY" && grep -q '^OnUnitActiveSec=' <<<"$BODY"; then
+  bad "OnCalendar= 与 OnUnitActiveSec= 并存 —— 容器实测 systemd 取最早的那个, 墙钟槽与单调间隔交错, 间隔从 20/30 秒变成 20,10,21,9,21,9, 频率接近翻倍"
+else
+  ok "OnCalendar 与 OnUnitActiveSec 没有并存(实测叠加会交错双触发)"
+fi
+
+fin

--- a/tests/e2e-health-timer.sh
+++ b/tests/e2e-health-timer.sh
@@ -292,35 +292,78 @@ finite && ok "新调度已 arm(有有限的下一次)" || bad "换了 unit 却�
 echo
 echo "── 9. 故障注入: 每一步失败都要非零 + 回到原状 ──"
 # root 下 chmod 000 挡不住 install(第一版就是这么假绿的), 改用**函数遮蔽**精准打到某一步。
-install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
-systemctl enable --now pdg-health.timer >/dev/null 2>&1; sleep 1
-BEFORE_SHA="$(sha256sum "$UNIT" | awk '{print $1}')"
-BEFORE_EN="$(systemctl is-enabled pdg-health.timer 2>/dev/null)"
-BEFORE_AC="$(systemctl is-active  pdg-health.timer 2>/dev/null)"
 CHREPO="$(mktemp -d)"; mkdir -p "$CHREPO/deploy/bot"
 sed 's/OnActiveSec=2min/OnActiveSec=3min/' "$SRC" > "$CHREPO/deploy/bot/pdg-health.timer"   # 制造内容变化
 
+# 每一格都从**干净的 systemd 限速状态 + 明确核对过的健康前态**开始。
+#
+# 为什么非清不可: systemd 对每个 unit 有启动限速(默认 StartLimitIntervalSec=10s /
+# StartLimitBurst=5, 这个 unit 自己没写 StartLimit 所以取默认)。本节几格连着 stop/start
+# 同一个 unit, 到第三、四格就会撞上 `start-limit-hit` —— unit 掉进 failed, 于是产品
+# _restore 里那次 systemctl start(它没被遮蔽)真的失败, 断言就把 systemd 的限速记成了
+# "产品没还原状态"。systemd 252 上不显形, 255 上必红(GitHub runner 43/1, 同形环境 42/2,
+# journal 明写 Start request repeated too quickly / Failed with result 'start-limit-hit',
+# 而单独跑那一格是通过的)。
+#
+# 清理只出现在**准备阶段**。绝不能放进 migrate_health_timer、被测的 _restore、注入器,
+# 或断言失败后的补救里 —— 那等于测试替产品把状态收拾干净, 真实的回滚缺陷会被洗成绿的。
+# 也不用固定 sleep 去等限速窗口: 那既依赖 manager 的默认值, 又平白拉长 CI。
+case_setup(){        # $1=场景名(仅用于失败文案)
+  local who="${1:-准备阶段}" i
+  systemctl stop pdg-health.timer >/dev/null 2>&1 || true
+  # reset-failed 同时清掉 failed 状态与该 unit 的启动限速计数; 它失败就说明环境不对, 要报出来
+  systemctl reset-failed pdg-health.timer >/dev/null 2>&1 \
+    || { bad "$who 准备: reset-failed 失败"; return 1; }
+  install -m644 "$SRC" "$UNIT" 2>/dev/null || { bad "$who 准备: 装基线 unit 失败"; return 1; }
+  systemctl daemon-reload >/dev/null 2>&1  || { bad "$who 准备: daemon-reload 失败"; return 1; }
+  systemctl enable pdg-health.timer >/dev/null 2>&1 || { bad "$who 准备: enable 失败"; return 1; }
+  systemctl start  pdg-health.timer >/dev/null 2>&1 || { bad "$who 准备: start 失败"; return 1; }
+  # 正向确认前态, 不靠"应该就是健康的"。有界重试是等 systemd 把调度算出来, 与限速窗口无关。
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    [[ "$(systemctl is-active pdg-health.timer 2>/dev/null)" == active ]] && finite && break
+    sleep 0.5
+  done
+  [[ "$(systemctl is-enabled pdg-health.timer 2>/dev/null)" == enabled ]] \
+    || { bad "$who 准备: 前态不是 enabled"; return 1; }
+  [[ "$(systemctl is-active  pdg-health.timer 2>/dev/null)" == active ]] \
+    || { bad "$who 准备: 前态不是 active"; return 1; }
+  [[ "$(systemctl show -p SubState --value pdg-health.timer 2>/dev/null)" == waiting ]] \
+    || { bad "$who 准备: 前态 SubState 不是 waiting"; return 1; }
+  finite || { bad "$who 准备: 前态排不出下一次触发"; return 1; }
+  # 前态核对通过之后才取 before-image —— 取的是这一格真正的起点, 不是全局的旧快照
+  BEFORE_SHA="$(sha256sum "$UNIT" | awk '{print $1}')"
+  BEFORE_EN="$(systemctl is-enabled pdg-health.timer 2>/dev/null)"
+  BEFORE_AC="$(systemctl is-active  pdg-health.timer 2>/dev/null)"
+  BEFORE_MODE="$(stat -c%a "$UNIT" 2>/dev/null)"
+  BEFORE_OWN="$(stat -c%u:%g "$UNIT" 2>/dev/null)"
+  return 0
+}
+
 inject(){            # $1=场景名  $2=遮蔽定义
   local name="$1" shadow="$2" rc
+  case_setup "$name" || return 0        # 准备失败已计 FAIL, 不拿脏前态去跑这一格
   ( export REPO_DIR="$CHREPO"
     eval "$shadow"
     migrate_health_timer >/dev/null 2>&1; echo $? > "$RC_FILE" ) || true
   rc="$(cat "$RC_FILE" 2>/dev/null || echo 9)"
   [[ "$rc" != 0 ]] && ok "$name → 返回非零($rc)" || bad "$name 却返回 0"
-  [[ "$(sha256sum "$UNIT" | awk '{print $1}')" == "$BEFORE_SHA" ]] \
-    && ok "$name → unit 逐字节回到原样" || bad "$name → unit 没还原"
+  # 内容 + mode + uid:gid 一起核: 只比内容的话, 权限被改宽也算"还原了"
+  if [[ "$(sha256sum "$UNIT" | awk '{print $1}')" == "$BEFORE_SHA" \
+        && "$(stat -c%a "$UNIT" 2>/dev/null)" == "$BEFORE_MODE" \
+        && "$(stat -c%u:%g "$UNIT" 2>/dev/null)" == "$BEFORE_OWN" ]]; then
+    ok "$name → unit 逐字节回到原样"
+  else
+    bad "$name → unit 没还原(内容/mode/uid/gid 有一项不符)"
+  fi
   [[ "$(systemctl is-enabled pdg-health.timer 2>/dev/null)" == "$BEFORE_EN" \
      && "$(systemctl is-active pdg-health.timer 2>/dev/null)" == "$BEFORE_AC" ]] \
     && ok "$name → enabled/active 状态还原" || bad "$name → 状态没还原"
-  # 每一格之后回到基线, 免得上一格的残留影响下一格
-  install -m644 "$SRC" "$UNIT"; systemctl daemon-reload
-  systemctl enable --now pdg-health.timer >/dev/null 2>&1
-  systemctl restart pdg-health.timer >/dev/null 2>&1; sleep 1
 }
 
 # 9a 候选不合法(真实场景: 仓库里那份文件被截断/写坏)
 BADREPO="$(mktemp -d)"; mkdir -p "$BADREPO/deploy/bot"
 printf '[Unit]\nDescription=坏候选\n' > "$BADREPO/deploy/bot/pdg-health.timer"
+case_setup "候选不合法"
 ( export REPO_DIR="$BADREPO"; migrate_health_timer >/dev/null 2>&1; echo $? > "$RC_FILE" ) || true
 rc="$(cat "$RC_FILE" 2>/dev/null || echo 9)"
 [[ "$rc" != 0 ]] && ok "候选不合法 → 返回非零($rc)" || bad "候选不合法却返回 0"

--- a/tests/e2e-lib.sh
+++ b/tests/e2e-lib.sh
@@ -428,19 +428,74 @@ case "$verb" in
       [ -z "$v" ] && { [ -f "/etc/systemd/system/${u}.service" ] && v=1 || v=0; }
       [ "$v" = 1 ] && { echo enabled; exit 0; }; echo disabled; exit 1;;
   show)
-      # show -p PROP --value UNIT。ActiveState 是"停稳"判据要看的东西(failed/activating 都不算
-      # inactive), 其余属性沿用原来的 0(NRestarts 那类数值)。
-      u=""; prop=""
+      # show [-p PROP]... [--value] UNIT
+      #
+      # 原来这里只认单个 -p、只答得出 ActiveState, 其余一律 `echo 0`。timer 判据要读
+      # SubState 与两个 NextElapse, 于是它们全成了 "0" —— doctor 按 fail-closed 判红,
+      # 整次 update 回滚。测出来的是桩的病, 而排查时最顺手的"修法"(把判据放宽)恰恰最坏。
+      # 所以桩要做真: **状态从当前 unit 状态派生**, 绝不无条件回答 active/waiting/finite,
+      # 否则 timer 死角那组测试会变成恒绿。
+      #
+      # 属性输出顺序**有意与命令行 -p 顺序不同**(按名字排序): 真 systemd 就是按自己的
+      # 规范顺序打印的, 谁回去按位取值立刻错位 —— 这个坑在真机上栽过一次。
+      u=""; props=""; want_value=0; nextp=0
       for a in "$@"; do
-        case "$a" in -p) ;; --value) ;; ActiveState|NRestarts|UnitFileState|LoadState) prop="$a";; *) u="$a";; esac
+        if [ "$nextp" = 1 ]; then props="$props $a"; nextp=0; continue; fi
+        case "$a" in
+          -p) nextp=1;;
+          --value) want_value=1;;
+          -*) ;;
+          *) u="$a";;
+        esac
       done
-      if [ "$prop" = ActiveState ]; then
-        v=$(cat "$D/${u}.ac" 2>/dev/null)
-        [ -z "$v" ] && { [ -f "/etc/systemd/system/${u}.service" ] && v=1 || v=0; }
-        [ "$v" = 1 ] && echo active || echo inactive
-        exit 0
-      fi
-      echo 0; exit 0;;
+      [ -n "$props" ] || props=" ActiveState"
+      _st(){ v=$(cat "$D/${u}.ac" 2>/dev/null)
+             [ -z "$v" ] && { [ -f "/etc/systemd/system/${u}" ] || [ -f "/etc/systemd/system/${u}.service" ] && v=1 || v=0; }
+             echo "$v"; }
+      _val(){
+        case "$1" in
+          ActiveState)
+            [ -f "$D/${u}.failed" ] && { echo failed; return; }
+            [ "$(_st)" = 1 ] && echo active || echo inactive;;
+          SubState)
+            # timer 的子状态从 .sub 记录取; 没记过就按 active 与否给默认值。
+            # elapsed = 已触发过但排不出下一次(死角); waiting = 正常等待; running = 正在触发。
+            v=$(cat "$D/${u}.sub" 2>/dev/null)
+            if [ -n "$v" ]; then echo "$v"
+            elif [ -f "$D/${u}.failed" ]; then echo failed
+            elif [ "$(_st)" = 1 ]; then case "$u" in *.timer) echo waiting;; *) echo running;; esac
+            else echo dead; fi;;
+          NextElapseUSecMonotonic)
+            # 只有 **active 且非 elapsed/failed 的 timer** 才有有限的下一次。
+            case "$u" in
+              *.timer)
+                sub=$(_val SubState)
+                if [ "$(_st)" = 1 ] && [ "$sub" != elapsed ] && [ "$sub" != failed ]; then
+                  cat "$D/${u}.next" 2>/dev/null || echo "1w 2d 3h 4min 5s"
+                else echo infinity; fi;;
+              *) echo infinity;;
+            esac;;
+          NextElapseUSecRealtime)
+            cat "$D/${u}.nextreal" 2>/dev/null || echo "";;
+          UnitFileState)
+            v=$(cat "$D/${u}.en" 2>/dev/null)
+            [ -z "$v" ] && { [ -f "/etc/systemd/system/${u}" ] || [ -f "/etc/systemd/system/${u}.service" ] && v=1 || v=0; }
+            [ "$v" = 1 ] && echo enabled || echo disabled;;
+          LoadState) echo loaded;;
+          Result)    [ -f "$D/${u}.failed" ] && echo failed || echo success;;
+          InvocationID) cat "$D/${u}.inv" 2>/dev/null || echo "";;
+          MainPID)   [ "$(_st)" = 1 ] && { cat "$D/${u}.pid" 2>/dev/null || echo 1234; } || echo 0;;
+          NRestarts) cat "$D/${u}.nr" 2>/dev/null || echo 0;;
+          Triggers)  case "$u" in *.timer) echo "${u%.timer}.service";; *) echo "";; esac;;
+          LastTriggerUSec) cat "$D/${u}.last" 2>/dev/null || echo "";;
+          *)         echo 0;;
+        esac
+      }
+      # 按名字排序输出 —— 有意不跟随 -p 的顺序
+      for k in $(for x in $props; do echo "$x"; done | sort); do
+        if [ "$want_value" = 1 ]; then _val "$k"; else echo "$k=$(_val "$k")"; fi
+      done
+      exit 0;;
 esac
 exit 0
 S

--- a/tests/negctl/health-timer-negative-controls.py
+++ b/tests/negctl/health-timer-negative-controls.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ─────────────────────────────────────────────────────────────────────────────
+# 健康自检定时器那组判据的负控: 每条**就地撤掉一处修复**, 跑对应判据, 要求它转红,
+# 然后逐字节还原。0 条转红一律判无效 —— 那说明没有任何判据在盯着它。
+#
+# 规矩(踩出来的):
+#   · 改哪个文件, 哪个文件就必须在 TOUCHED 里。不在名单 = 不备份 = 跑完不还原。
+#   · 不用 git reset/checkout/clean 还原 —— 那会连带冲掉别的改动。备份 + sha256 核对。
+#   · 语法错、测试崩溃不算红灯, harness 自己判掉。
+#   · 真 systemd 那几条要 root + systemd; 环境不具备时**记为未验**, 不算有效负控。
+# ─────────────────────────────────────────────────────────────────────────────
+import hashlib
+import io
+import os
+import atexit
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# 候选(v1.8.1 线)上没有 tests/tmpguard.py —— 那是 6.1C 的全仓改造, 不该为了一支负控
+# 把它整套搬过来。用 tempfile + atexit: 建即注册, 正常退出与异常退出都清。
+BAK = tempfile.mkdtemp(prefix="negctl-timer.")
+atexit.register(lambda: shutil.rmtree(BAK, ignore_errors=True))
+
+TOUCHED = [
+    "deploy/bot/pdg-health.timer",
+    "deploy/bot/pdg.sh",
+    "deploy/bot/checks.py",
+]
+SHA = {}
+for f in TOUCHED:
+    src = os.path.join(ROOT, f)
+    shutil.copyfile(src, os.path.join(BAK, f.replace("/", "__")))
+    SHA[f] = hashlib.sha256(open(src, "rb").read()).hexdigest()
+
+
+def restore():
+    for f in TOUCHED:
+        shutil.copyfile(os.path.join(BAK, f.replace("/", "__")), os.path.join(ROOT, f))
+        got = hashlib.sha256(open(os.path.join(ROOT, f), "rb").read()).hexdigest()
+        if got != SHA[f]:
+            print("!! 还原校验失败: %s" % f)
+            sys.exit(9)
+
+
+def read(f):
+    return io.open(os.path.join(ROOT, f), encoding="utf-8").read()
+
+
+def write(f, s):
+    io.open(os.path.join(ROOT, f), "w", encoding="utf-8").write(s)
+
+
+def sub(s, old, new, why):
+    n = s.count(old)
+    if n != 1:
+        raise AssertionError("锚点命中 %d 次(应为 1): %s" % (n, why))
+    return s.replace(old, new, 1)
+
+
+HAVE_SYSTEMD = (os.geteuid() == 0 and os.path.isdir("/run/systemd/system"))
+RESULTS = []
+ONLY = {int(a) for a in sys.argv[1:] if a.isdigit()}
+
+
+def syntax_ok():
+    bad = []
+    for f in TOUCHED:
+        p = os.path.join(ROOT, f)
+        if f.endswith(".py"):
+            r = subprocess.run([sys.executable, "-m", "py_compile", p],
+                               capture_output=True)
+            if r.returncode != 0:
+                bad.append(f)
+        elif f.endswith(".sh"):
+            r = subprocess.run(["bash", "-n", p], capture_output=True)
+            if r.returncode != 0:
+                bad.append(f)
+    return bad
+
+
+def run_test(rel, needs_systemd=False, timeout=1200):
+    if needs_systemd and not HAVE_SYSTEMD:
+        return None, "需要 root + systemd"
+    e = dict(os.environ); e["PDG_TEST_STRICT"] = "1"
+    cmd = [sys.executable, rel] if rel.endswith(".py") else ["bash", rel]
+    try:
+        p = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                           timeout=timeout, env=e)
+    except subprocess.TimeoutExpired:
+        return 0, "超时"
+    out = p.stdout + p.stderr
+    red = sum(1 for l in out.splitlines() if l.startswith("[FAIL"))
+    if "Traceback" in out or "SyntaxError" in out:
+        return red, "抛异常"
+    if red == 0 and p.returncode != 0:
+        red = 1
+    return red, ""
+
+
+def nc(num, title, breaker, gates):
+    if ONLY and num not in ONLY:
+        return
+    print("\n═══ NC%02d: %s ═══" % (num, title))
+    try:
+        breaker()
+    except AssertionError as e:
+        print("  [无效] 改坏器锚点没命中: %s" % e)
+        RESULTS.append((num, title, None, "锚点没命中")); restore(); return
+    print("  锚点已命中并改写")
+    bad = syntax_ok()
+    if bad:
+        print("  [无效] 改坏后代码不合法(%s)" % ",".join(bad))
+        RESULTS.append((num, title, None, "改坏器把代码弄成语法错")); restore(); return
+    total, detail, unver = 0, [], []
+    for g, needs in gates:
+        r, note = run_test(g, needs_systemd=needs)
+        if r is None:
+            unver.append("%s(%s)" % (os.path.basename(g), note)); continue
+        total += r
+        detail.append("%s:%d%s" % (os.path.basename(g), r, ("/" + note) if note else ""))
+    if unver:
+        print("  ⚠️ 未验: %s" % ", ".join(unver))
+    if total > 0:
+        print("  ✅ 转红 %d 条  (%s)" % (total, " ".join(detail)))
+        RESULTS.append((num, title, total, " ".join(detail)))
+    elif unver and not detail:
+        print("  ⏭ 环境不具备, 本条未验 —— 不算有效负控")
+        RESULTS.append((num, title, None, "环境不具备: " + ", ".join(unver)))
+    else:
+        print("  ❌ 0 条转红 —— 无效负控(没有判据盯着它)")
+        RESULTS.append((num, title, 0, " ".join(detail)))
+    restore()
+
+
+DOCTOR = [("tests/test-health-timer-doctor.py", False)]
+E2E = [("tests/e2e-health-timer.sh", True)]
+BOTH = DOCTOR + E2E
+
+
+# ══ 1. 新 unit 改回 OnBootSec ═══════════════════════════════════════════════
+def b1():
+    s = read("deploy/bot/pdg-health.timer")
+    s = sub(s, "OnActiveSec=2min", "OnBootSec=2min", "unit 的首次触发条件")
+    write("deploy/bot/pdg-health.timer", s)
+
+
+nc(1, "新 unit 改回 OnBootSec(死角重现)", b1, E2E)
+
+
+# ══ 2. 恢复无意义的 Persistent ══════════════════════════════════════════════
+def b2():
+    s = read("deploy/bot/pdg-health.timer")
+    s = sub(s, "Unit=pdg-health.service",
+            "Persistent=true\nUnit=pdg-health.service", "unit 的 [Timer] 段")
+    write("deploy/bot/pdg-health.timer", s)
+
+
+nc(2, "恢复无意义的 Persistent=true", b2, E2E)
+
+
+# ══ 3. 内容变化后只 enable --now, 不 restart ════════════════════════════════
+def b3():
+    s = read("deploy/bot/pdg.sh")
+    s = sub(s, '''  if ! systemctl restart "$T" >/dev/null 2>&1; then
+    c_y "  重启 $T 失败"; _restore; return 1; fi''',
+            '''  systemctl start "$T" >/dev/null 2>&1 || true   # 改坏器: 已 active 时什么都不做''',
+            "内容变化路径里的明确 restart")
+    write("deploy/bot/pdg.sh", s)
+
+
+nc(3, "内容变化后只 enable --now, 不 restart", b3, E2E)
+
+
+# ══ 4. install 失败被吞 ═════════════════════════════════════════════════════
+def b4():
+    s = read("deploy/bot/pdg.sh")
+    s = sub(s, '''  if ! install -m644 "$src" "$cur" 2>/dev/null; then
+    c_y "  安装 $T 失败"; _restore; return 1; fi''',
+            '''  install -m644 "$src" "$cur" 2>/dev/null || true   # 改坏器: 吞掉安装失败''',
+            "内容变化路径里的 install")
+    write("deploy/bot/pdg.sh", s)
+
+
+nc(4, "install 失败被吞", b4, E2E)
+
+
+# ══ 5. daemon-reload 失败被吞 ═══════════════════════════════════════════════
+def b5():
+    s = read("deploy/bot/pdg.sh")
+    s = sub(s, '''  if ! systemctl daemon-reload >/dev/null 2>&1; then
+    c_y "  daemon-reload 失败"; _restore; return 1; fi''',
+            '''  systemctl daemon-reload >/dev/null 2>&1 || true   # 改坏器: 吞掉 reload 失败''',
+            "内容变化路径里的 daemon-reload")
+    write("deploy/bot/pdg.sh", s)
+
+
+nc(5, "daemon-reload 失败被吞", b5, E2E)
+
+
+# ══ 6. restart 失败被吞 ═════════════════════════════════════════════════════
+def b6():
+    s = read("deploy/bot/pdg.sh")
+    s = sub(s, '''  if ! _pdg_timer_next_ok "$T"; then
+    c_y "  $T 换新 unit 后仍排不出下一次触发"; _restore; return 1; fi''',
+            '''  _pdg_timer_next_ok "$T" || true   # 改坏器: 排不出下一次也当没事''',
+            "内容变化路径末尾的下一次触发校验")
+    write("deploy/bot/pdg.sh", s)
+
+
+nc(6, "restart 后仍无下一次却当成功", b6, E2E)
+
+
+# ══ 7. doctor 只看 active ═══════════════════════════════════════════════════
+def b7():
+    s = read("deploy/bot/checks.py")
+    s = sub(s, '''    if sub == "elapsed" or not has_next:''',
+            '''    if False:   # 改坏器: 只看三态, 不看下一次触发''',
+            "doctor 的 elapsed / 无下一次分支")
+    write("deploy/bot/checks.py", s)
+
+
+nc(7, "doctor 只看 active, 不看 NextElapse", b7, DOCTOR)
+
+
+# ══ 8. doctor 把 infinity 当合法 ════════════════════════════════════════════
+def b8():
+    s = read("deploy/bot/checks.py")
+    s = sub(s, '''        return bool(v) and v not in ("infinity", "n/a")''',
+            '''        return bool(v)   # 改坏器: infinity 也算数''',
+            "doctor 的 _finite 判据")
+    write("deploy/bot/checks.py", s)
+
+
+nc(8, "doctor 把 infinity 当合法的下一次", b8, DOCTOR)
+
+
+# ══ 9. 内容未变且状态健康时仍反复 restart ═══════════════════════════════════
+def b9():
+    s = read("deploy/bot/pdg.sh")
+    s = sub(s, '''    if [[ "$ac0" != active ]] || ! _pdg_timer_next_ok "$T"; then''',
+            '''    if true; then   # 改坏器: 每次迁移都重启''',
+            "内容未变路径的状态判断")
+    write("deploy/bot/pdg.sh", s)
+
+
+nc(9, "内容未变且健康时仍每次重启", b9, E2E)
+
+
+# ══ 10. 同时加入 OnCalendar 与 OnUnitActiveSec ══════════════════════════════
+def b10():
+    s = read("deploy/bot/pdg-health.timer")
+    s = sub(s, "OnActiveSec=2min",
+            "OnActiveSec=2min\nOnCalendar=*:0/3\nPersistent=true", "unit 的触发条件")
+    write("deploy/bot/pdg-health.timer", s)
+
+
+nc(10, "OnCalendar 与 OnUnitActiveSec 叠加(交错双触发)", b10, E2E)
+
+
+print("\n" + "═" * 70)
+eff = sum(1 for r in RESULTS if isinstance(r[2], int) and r[2] > 0)
+inv = sum(1 for r in RESULTS if r[2] == 0)
+unv = sum(1 for r in RESULTS if r[2] is None)
+for num, title, red, note in RESULTS:
+    mark = "✅" if isinstance(red, int) and red > 0 else ("❌" if red == 0 else "⏭")
+    print("%s NC%02d %-46s %s  (%s)"
+          % (mark, num, title, (str(red) + " 条") if isinstance(red, int) else "未验", note))
+print("有效 %d / 无效 %d / 未验 %d" % (eff, inv, unv))
+restore()
+sys.exit(1 if inv else 0)

--- a/tests/negctl/systemctl-stub-negative-controls.py
+++ b/tests/negctl/systemctl-stub-negative-controls.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ─────────────────────────────────────────────────────────────────────────────
+# 共享 systemctl 桩的负控: 每条就地把桩改坏一处, 跑契约测试, 要求它转红, 再逐字节还原。
+#
+# 为什么单独一组: 这个桩是"测试基础设施", 它坏了不会有人报警 —— 只会让上层测试悄悄变成
+# 恒绿。桩答不出属性时上层会因 fail-closed 判红(那还算好, 至少看得见); 真正危险的是桩
+# **无条件回答健康值**, 那时 timer 死角那组测试永远是绿的, 而产品可能已经坏了。
+#
+# 契约测试需要 root + 一次性容器(桩会往 /usr/local/bin 写), 所以这组负控也一样:
+# 环境不具备时记为"未验", 不算有效负控。
+# ─────────────────────────────────────────────────────────────────────────────
+import hashlib
+import io
+import os
+import atexit
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# 候选(v1.8.1 线)上没有 tests/tmpguard.py —— 那是 6.1C 的全仓改造, 不该为了一支负控
+# 把它整套搬过来。用 tempfile + atexit: 建即注册, 正常退出与异常退出都清。
+BAK = tempfile.mkdtemp(prefix="negctl-stub.")
+atexit.register(lambda: shutil.rmtree(BAK, ignore_errors=True))
+TOUCHED = ["tests/e2e-lib.sh"]
+SHA = {}
+for f in TOUCHED:
+    src = os.path.join(ROOT, f)
+    shutil.copyfile(src, os.path.join(BAK, f.replace("/", "__")))
+    SHA[f] = hashlib.sha256(open(src, "rb").read()).hexdigest()
+
+
+def restore():
+    for f in TOUCHED:
+        shutil.copyfile(os.path.join(BAK, f.replace("/", "__")), os.path.join(ROOT, f))
+        got = hashlib.sha256(open(os.path.join(ROOT, f), "rb").read()).hexdigest()
+        if got != SHA[f]:
+            print("!! 还原校验失败: %s" % f)
+            sys.exit(9)
+
+
+def read(f):
+    return io.open(os.path.join(ROOT, f), encoding="utf-8").read()
+
+
+def write(f, s):
+    io.open(os.path.join(ROOT, f), "w", encoding="utf-8").write(s)
+
+
+def sub(s, old, new, why):
+    n = s.count(old)
+    if n != 1:
+        raise AssertionError("锚点命中 %d 次(应为 1): %s" % (n, why))
+    return s.replace(old, new, 1)
+
+
+GATE = "tests/test-systemctl-stub.sh"
+HAVE = (os.geteuid() == 0 and os.environ.get("PDG_E2E_ISOLATED") == "1")
+RESULTS = []
+ONLY = {int(a) for a in sys.argv[1:] if a.isdigit()}
+
+
+def run_gate():
+    if not HAVE:
+        return None, "需要 root + PDG_E2E_ISOLATED=1"
+    e = dict(os.environ)
+    e["PDG_TEST_STRICT"] = "1"
+    e["PDG_E2E_ISOLATED"] = "1"
+    try:
+        p = subprocess.run(["bash", GATE], cwd=ROOT, capture_output=True,
+                           text=True, timeout=600, env=e)
+    except subprocess.TimeoutExpired:
+        return 0, "超时"
+    out = p.stdout + p.stderr
+    red = sum(1 for l in out.splitlines() if l.startswith("[FAIL"))
+    if "Traceback" in out or "syntax error" in out:
+        return red, "崩溃"
+    if red == 0 and p.returncode != 0:
+        red = 1
+    return red, ""
+
+
+def nc(num, title, breaker):
+    if ONLY and num not in ONLY:
+        return
+    print("\n═══ NC%02d: %s ═══" % (num, title))
+    try:
+        breaker()
+    except AssertionError as e:
+        print("  [无效] 改坏器锚点没命中: %s" % e)
+        RESULTS.append((num, title, None, "锚点没命中")); restore(); return
+    print("  锚点已命中并改写")
+    if subprocess.run(["bash", "-n", os.path.join(ROOT, "tests/e2e-lib.sh")],
+                      capture_output=True).returncode != 0:
+        print("  [无效] 改坏后语法错 —— 红灯会来自解析器")
+        RESULTS.append((num, title, None, "语法错")); restore(); return
+    red, note = run_gate()
+    if red is None:
+        print("  ⏭ 环境不具备(%s), 本条未验" % note)
+        RESULTS.append((num, title, None, note))
+    elif red > 0:
+        print("  ✅ 转红 %d 条%s" % (red, ("/" + note) if note else ""))
+        RESULTS.append((num, title, red, note))
+    else:
+        print("  ❌ 0 条转红 —— 无效负控")
+        RESULTS.append((num, title, 0, note))
+    restore()
+
+
+# ══ 1. show 返回空输出 ══════════════════════════════════════════════════════
+def b1():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''      for k in $(for x in $props; do echo "$x"; done | sort); do
+        if [ "$want_value" = 1 ]; then _val "$k"; else echo "$k=$(_val "$k")"; fi
+      done
+      exit 0;;''',
+            '''      exit 0;;   # 改坏器: 什么都不输出''',
+            "桩 show 的输出循环")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(1, "show 返回空输出", b1)
+
+
+# ══ 2. 无论状态都硬编码 active/waiting/finite ═══════════════════════════════
+def b2():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''      _val(){
+        case "$1" in''',
+            '''      _val(){
+        # 改坏器: 无条件回答健康值
+        case "$1" in
+          ActiveState) echo active; return;;
+          SubState) echo waiting; return;;
+          NextElapseUSecMonotonic) echo "1w 2d"; return;;
+        esac
+        case "$1" in''',
+            "桩的 _val 分派")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(2, "无论状态都硬编码 active/waiting/finite", b2)
+
+
+# ══ 3. 只支持一个 -p ════════════════════════════════════════════════════════
+def b3():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''        if [ "$nextp" = 1 ]; then props="$props $a"; nextp=0; continue; fi''',
+            '''        if [ "$nextp" = 1 ]; then props="$a"; nextp=0; continue; fi   # 改坏器: 只留最后一个''',
+            "桩收集 -p 的那一行")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(3, "只支持一个 -p", b3)
+
+
+# ══ 4. elapsed 仍返回有限 NextElapse ════════════════════════════════════════
+def b4():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''                if [ "$(_st)" = 1 ] && [ "$sub" != elapsed ] && [ "$sub" != failed ]; then''',
+            '''                if [ "$(_st)" = 1 ]; then   # 改坏器: elapsed 也给有限值''',
+            "桩里 NextElapse 的守卫条件")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(4, "elapsed 仍返回有限 NextElapse", b4)
+
+
+# ══ 5. restart 不更新状态、不重新排程 ═══════════════════════════════════════
+def b5():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''  start|restart) for u in "$@"; do
+                   [ -f "$D/${u}.fail" ] && echo 0 > "$D/${u}.ac" || echo 1 > "$D/${u}.ac"
+                 done; exit 0;;''',
+            '''  start|restart) exit 0;;   # 改坏器: 什么都不改''',
+            "桩的 start/restart 分支")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(5, "restart 不更新状态、不重新排程", b5)
+
+
+# ══ 6. 去掉输出乱序 ═════════════════════════════════════════════════════════
+# 顺序一旦跟随 -p, "按位解析"那类错误就重新失去暴露条件 —— 真机上正是它把一台好机器
+# 判成了红的。
+def b6():
+    s = read("tests/e2e-lib.sh")
+    s = sub(s, '''      for k in $(for x in $props; do echo "$x"; done | sort); do''',
+            '''      for k in $props; do   # 改坏器: 跟随 -p 顺序''',
+            "桩输出属性的排序")
+    write("tests/e2e-lib.sh", s)
+
+
+nc(6, "去掉输出乱序(按位解析的错误重新失去暴露条件)", b6)
+
+
+print("\n" + "═" * 70)
+eff = sum(1 for r in RESULTS if isinstance(r[2], int) and r[2] > 0)
+inv = sum(1 for r in RESULTS if r[2] == 0)
+unv = sum(1 for r in RESULTS if r[2] is None)
+for num, title, red, note in RESULTS:
+    mark = "✅" if isinstance(red, int) and red > 0 else ("❌" if red == 0 else "⏭")
+    print("%s NC%02d %-52s %s" % (mark, num, title,
+                                  ("%d 条" % red) if isinstance(red, int) else "未验"))
+print("有效 %d / 无效 %d / 未验 %d" % (eff, inv, unv))
+restore()
+sys.exit(1 if inv else 0)

--- a/tests/test-health-timer-doctor.py
+++ b/tests/test-health-timer-doctor.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ─────────────────────────────────────────────────────────────────────────────
+# doctor 必须看得见「健康自检定时器排不出下一次」。
+#
+# jp2 上那台的真实状态: is-enabled=enabled、is-active=active、is-failed 不 failed、
+# Result=success —— 常规三态全绿, 而 SubState=elapsed、NextElapse 两项都是空/infinity,
+# 服务 8 天没跑过。doctor 那时**一条相关检查都没有**, 所以一路判绿。
+#
+# 这支测试不碰真 systemd: 把 `systemctl show` 换成受控替身, 逐格喂状态, 看 doctor 给什么。
+# 真 systemd 那半边由 tests/e2e-health-timer.sh 负责。
+# ─────────────────────────────────────────────────────────────────────────────
+import io
+import os
+import sys
+import tokenize
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "deploy", "bot"))
+import checks  # noqa: E402
+
+PASS = [0]
+FAIL = [0]
+
+
+def ok(m):
+    print("[OK]   " + m); PASS[0] += 1
+
+
+def bad(m):
+    print("[FAIL] " + m); FAIL[0] += 1
+
+
+# ── systemctl 替身: 按用例给定的属性表回答 ───────────────────────────────────
+def fake_systemctl(state):
+    """state: dict, 键是 systemctl 属性名或 is-enabled/is-active/is-failed。
+
+    `None` 表示"这条读不出来"(命令失败) —— 用来验 fail-closed。
+    """
+    def _run(cmd, **kw):
+        if not cmd or cmd[0] != "systemctl":
+            return (1, "", "")
+        if cmd[1] in ("is-enabled", "is-active", "is-failed"):
+            v = state.get(cmd[1])
+            return (1, "", "") if v is None else (0, v + "\n", "")
+        if cmd[1] == "show":
+            # 真调用是 `systemctl show <unit> -p A -p B` —— `-p` 与属性名是两个独立参数。
+            #
+            # 两个关键的仿真点, 都是真机上栽过才补的:
+            #   · 第一版按 `-pA` 解析, 于是一个属性都取不到, 全落进 fail-closed 分支 ——
+            #     那时"判 fail"是蒙对的, 不是判据在起作用;
+            #   · systemd **按它自己的规范顺序**打印, 不是按 -p 传入的顺序。替身这里
+            #     **故意打乱顺序**: 谁要是回去按位取值, 立刻就会错位翻车。
+            props = [cmd[i + 1] for i, a in enumerate(cmd)
+                     if a == "-p" and i + 1 < len(cmd)]
+            out = []
+            for p in sorted(props):                  # 有意与请求顺序不同
+                v = state.get(p)
+                if v is None:
+                    return (1, "", "")
+                out.append("%s=%s" % (p, v))
+            return (0, "\n".join(out) + "\n", "")
+        return (1, "", "")
+    return _run
+
+
+def verdict(state):
+    """跑 check_health_timer, 返回 (status, title, text)。不存在就返回 None。"""
+    fn = getattr(checks, "check_health_timer", None)
+    if fn is None:
+        return None
+    orig = checks._run
+    checks._run = fake_systemctl(state)
+    try:
+        return fn()
+    finally:
+        checks._run = orig
+
+
+HEALTHY = {
+    "is-enabled": "enabled", "is-active": "active", "is-failed": "active",
+    "ActiveState": "active", "SubState": "waiting",
+    "NextElapseUSecMonotonic": "1d 2h 3min 4s", "NextElapseUSecRealtime": "",
+}
+
+
+def dead():                      # jp2 的真实状态
+    d = dict(HEALTHY)
+    d.update({"SubState": "elapsed",
+              "NextElapseUSecMonotonic": "infinity", "NextElapseUSecRealtime": ""})
+    return d
+
+
+print("══ 1. 检查项本身必须存在 ══")
+if getattr(checks, "check_health_timer", None) is None:
+    bad("checks 里没有 check_health_timer —— 定时器停摆对 doctor 完全不可见"
+        "(jp2 就是这样绿了 8 天)")
+elif checks.check_health_timer not in checks.ALL:
+    bad("check_health_timer 没有登记进 ALL, doctor 跑不到它")
+else:
+    ok("check_health_timer 存在且已登记进 ALL")
+
+print()
+print("══ 2. jp2 的真实状态必须判 FAIL ══")
+v = verdict(dead())
+if v is None:
+    bad("检查项不存在, 无从判定")
+else:
+    st, title, text = v
+    (ok if st == "fail" else bad)(
+        "enabled+active+elapsed+infinity → 判 %s(应为 fail)" % st)
+    (ok if "没有安排下一次运行" in text else bad)(
+        "文案说清了是什么问题(实得: %s)" % text[:60])
+    (ok if "健康检查定时器" in text or "健康自检" in title or "健康检查" in title else bad)(
+        "文案指名是健康检查定时器")
+
+print()
+print("══ 3. 正常状态不许误报 ══")
+v = verdict(HEALTHY)
+if v is not None:
+    st, _t, text = v
+    (ok if st == "ok" else bad)("enabled+active+waiting+有限下一次 → 判 %s(应为 ok)" % st)
+    # 只有 realtime 有值(OnCalendar 那种)也算正常
+    d = dict(HEALTHY); d["NextElapseUSecMonotonic"] = "infinity"
+    d["NextElapseUSecRealtime"] = "Thu 2026-08-06 01:00:00 UTC"
+    st2 = verdict(d)[0]
+    (ok if st2 == "ok" else bad)("只有 realtime 有下一次也算正常(实得 %s)" % st2)
+
+print()
+print("══ 4. 正在执行时不许误报 ══")
+d = dict(HEALTHY); d["SubState"] = "running"
+d["NextElapseUSecMonotonic"] = "infinity"; d["NextElapseUSecRealtime"] = ""
+v = verdict(d)
+if v is not None:
+    st, _t, text = v
+    (ok if st != "fail" else bad)("SubState=running 且此刻还没排出下一次 → 判 %s(不该 fail)" % st)
+    (ok if "正在运行" in text else bad)("文案说明「健康检查正在运行」(实得: %s)" % text[:50])
+
+print()
+print("══ 5. 其余异常都要 FAIL ══")
+cases = [
+    ("enabled 但 inactive", {"is-active": "inactive", "ActiveState": "inactive",
+                             "SubState": "dead"}),
+    ("enabled 但 failed", {"is-active": "failed", "is-failed": "failed",
+                           "ActiveState": "failed", "SubState": "failed"}),
+    ("两项 NextElapse 都空", {"NextElapseUSecMonotonic": "",
+                              "NextElapseUSecRealtime": ""}),
+    ("两项都是 infinity", {"NextElapseUSecMonotonic": "infinity",
+                           "NextElapseUSecRealtime": "infinity"}),
+]
+for name, patch in cases:
+    d = dict(HEALTHY); d.update(patch)
+    v = verdict(d)
+    if v is None:
+        bad("%s: 检查项不存在" % name); continue
+    (ok if v[0] == "fail" else bad)("%s → 判 %s(应为 fail)" % (name, v[0]))
+
+print()
+print("══ 6. 读不到就 fail-closed, 不许当没事 ══")
+for name, key in (("is-enabled 读不出", "is-enabled"),
+                  ("is-active 读不出", "is-active"),
+                  ("show 属性读不出", "SubState")):
+    d = dict(HEALTHY); d[key] = None
+    v = verdict(d)
+    if v is None:
+        bad("%s: 检查项不存在" % name); continue
+    (ok if v[0] == "fail" else bad)("%s → 判 %s(应为 fail)" % (name, v[0]))
+
+print()
+print("══ 7. 只读: 不许 restart / enable / reset-failed / daemon-reload ══")
+CALLS = []
+
+
+def spy(cmd, **kw):
+    CALLS.append(list(cmd))
+    return fake_systemctl(dead())(cmd, **kw)
+
+
+fn = getattr(checks, "check_health_timer", None)
+if fn is None:
+    bad("检查项不存在")
+else:
+    orig = checks._run
+    checks._run = spy
+    try:
+        fn()
+    finally:
+        checks._run = orig
+    verbs = {c[1] for c in CALLS if len(c) > 1 and c[0] == "systemctl"}
+    forbidden = verbs & {"restart", "start", "enable", "disable",
+                         "reset-failed", "daemon-reload", "try-restart"}
+    (ok if not forbidden else bad)(
+        "只用了只读子命令(实得 %s)" % sorted(verbs) if not forbidden
+        else "动了这些写操作: %s" % sorted(forbidden))
+
+print()
+print("══ 8. 不许把未标时区的绝对时间摆给用户 ══")
+d = dict(HEALTHY)
+d["NextElapseUSecRealtime"] = "Thu 2026-08-06 01:00:00 UTC"
+v = verdict(d)
+if v is not None:
+    text = v[2]
+    import re
+    naked = re.search(r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?!.{0,12}(UTC|GMT|[+-]\d{2}))", text)
+    (ok if not naked else bad)(
+        "正文里没有裸的绝对时间" if not naked else "出现了未标时区的时间: %s" % naked.group(0))
+
+
+def code_only(path):
+    """剥掉注释与 docstring —— 否则删一句解释性注释就能让门变绿。"""
+    out = []
+    with open(path, "rb") as fh:
+        prev = None
+        for tok in tokenize.tokenize(fh.readline):
+            if tok.type == tokenize.COMMENT:
+                continue
+            if tok.type == tokenize.STRING and prev in (
+                    None, tokenize.INDENT, tokenize.NEWLINE, tokenize.NL):
+                continue
+            out.append(tok.string)
+            if tok.type not in (tokenize.NL, tokenize.NEWLINE):
+                prev = tok.type
+    return " ".join(out)
+
+
+print()
+print("══ 9. 判据必须同时看 realtime 与 monotonic ══")
+src = code_only(os.path.join(ROOT, "deploy", "bot", "checks.py"))
+(ok if "NextElapseUSecMonotonic" in src and "NextElapseUSecRealtime" in src else bad)(
+    "两个属性都在代码里被读取(不是只看一个)")
+
+print("─" * 46)
+print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-systemctl-stub.sh
+++ b/tests/test-systemctl-stub.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 共享 systemctl 桩的契约。
+#
+# 这个桩原先只认单个 `-p`、只答得出 ActiveState, 其余一律 `echo 0`。timer 判据要读
+# SubState 与两个 NextElapse, 于是它们全成了 "0" —— doctor 按 fail-closed 判红, 整次
+# update 回滚(e2e-update 37/4、e2e-rescue-migration-lock 20/7)。测出来的是桩的病,
+# 而排查时最顺手的"修法"恰恰最坏: 把判据放宽。
+#
+# 所以这支盯两件事:
+#   · 桩答得**全**(多个 -p、KEY=VALUE 与 --value 两种形态);
+#   · 桩答得**真** —— 状态从当前 unit 状态派生, 绝不无条件回答 active/waiting/finite。
+#     后者若失守, timer 死角那组测试会变成恒绿, 比答不出来更糟。
+#
+# 判据落在**真桩**上: 调 e2e_stub_system 生成它, 再执行它、看它的输出与状态文件,
+# 不复制一份模型自测。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+T_PASS=0; T_FAIL=0; T_SKIP=0
+t_ok(){ echo "[OK]   $1"; T_PASS=$((T_PASS+1)); }
+t_bad(){ echo "[FAIL] $1"; T_FAIL=$((T_FAIL+1)); }
+skipf(){
+  if [[ "${PDG_TEST_STRICT:-}" == 1 ]]; then t_bad "$1 —— 严格模式下不接受丢覆盖"
+  else echo "[SKIP] $1 —— 未验收, 不是通过"; T_SKIP=$((T_SKIP+1)); fi
+}
+fin(){ echo "────────────────────────────────────────"
+       echo "通过 $T_PASS, 失败 $T_FAIL, 跳过 $T_SKIP"; [[ "$T_FAIL" == 0 ]]; }
+
+# 桩会往 /usr/local/bin 写、往 /etc/systemd/system 建目录 —— 只在一次性沙箱里跑。
+[[ "$(id -u)" == 0 ]] || { skipf "需要 root(桩要装到 /usr/local/bin)"; fin; exit $?; }
+if [[ "${PDG_E2E_ISOLATED:-}" != 1 ]]; then
+  skipf "需要 PDG_E2E_ISOLATED=1(一次性容器); 不在真机上装桩"
+  fin; exit $?
+fi
+
+# shellcheck source=tests/e2e-lib.sh
+E2E_ROOT="$ROOT"; export E2E_ROOT
+source "$ROOT/tests/e2e-lib.sh" 2>/dev/null || { t_bad "source 不了 e2e-lib.sh"; fin; exit $?; }
+e2e_stub_system >/dev/null 2>&1 || true
+SC=/usr/local/bin/systemctl
+[[ -x "$SC" ]] || { t_bad "e2e_stub_system 没有生成 systemctl 桩"; fin; exit $?; }
+t_ok "真桩已由 e2e_stub_system 生成($SC)"
+
+D=/tmp/e2e-svc                       # 桩的状态目录(与桩内 D= 同一份)
+# 候选(v1.8.1 线)的桩用的就是 /tmp/e2e-svc; 6.1C 那边改成了 $E2E_TMP 下,
+# 但那是全仓临时物改造的一部分, 热修不该把它带进来。
+[[ -d "$D" ]] || mkdir -p "$D"
+U=stubtest.timer
+mk_unit(){ printf '[Unit]\nDescription=stub contract test\n[Timer]\nOnActiveSec=2min\n' \
+             > "/etc/systemd/system/$U"; }
+mk_unit
+reset_state(){ rm -f "$D/$U".* 2>/dev/null; }
+
+get(){ "$SC" show "$U" "$@"; }       # 直接执行真桩
+
+echo
+echo "── 1. 多个 -p 默认返回完整 KEY=VALUE ──"
+reset_state; echo 1 > "$D/$U.ac"
+OUT="$(get -p ActiveState -p SubState -p NextElapseUSecMonotonic -p NextElapseUSecRealtime)"
+n="$(grep -c '=' <<<"$OUT")"
+[[ "$n" == 4 ]] && t_ok "四个属性都给了 KEY=VALUE(实得 $n 行)" || t_bad "只给了 $n 行: $(tr '\n' ' ' <<<"$OUT")"
+for k in ActiveState SubState NextElapseUSecMonotonic NextElapseUSecRealtime; do
+  grep -q "^$k=" <<<"$OUT" || t_bad "缺 $k"
+done
+grep -q "^ActiveState=" <<<"$OUT" && t_ok "键名与值成对(可按键取, 不必按位)" || true
+
+echo
+echo "── 2. --value 保持旧调用方兼容 ──"
+V="$(get -p ActiveState --value)"
+[[ "$V" == active ]] && t_ok "--value 只给值(实得 '$V')" || t_bad "--value 实得 '$V'"
+grep -q "=" <<<"$V" && t_bad "--value 不该带键名" || t_ok "--value 不带键名"
+
+echo
+echo "── 3. 输出顺序与请求顺序不同 ──"
+# 真 systemd 按自己的规范顺序打印。桩有意打乱, 谁按位取值就会翻车 —— 这个坑在真机上栽过。
+ORD="$(get -p SubState -p ActiveState | cut -d= -f1 | tr '\n' ' ')"
+[[ "$ORD" != "SubState ActiveState " ]] \
+  && t_ok "不跟随 -p 顺序(请求 SubState,ActiveState → 实得: $ORD)" \
+  || t_bad "输出顺序与请求一致 —— 按位解析的错误将失去暴露条件"
+
+echo
+echo "── 4. active + waiting → 至少一个 NextElapse 有限 ──"
+reset_state; echo 1 > "$D/$U.ac"
+A="$(get -p ActiveState --value)"; S="$(get -p SubState --value)"
+M="$(get -p NextElapseUSecMonotonic --value)"
+[[ "$A" == active && "$S" == waiting ]] && t_ok "状态 active/waiting" || t_bad "实得 $A/$S"
+[[ -n "$M" && "$M" != infinity ]] && t_ok "NextElapseUSecMonotonic 有限(实得 '$M')" || t_bad "实得 '$M'"
+
+echo
+echo "── 5. active + running → 有限且不误判失败 ──"
+reset_state; echo 1 > "$D/$U.ac"; echo running > "$D/$U.sub"
+[[ "$(get -p SubState --value)" == running ]] && t_ok "SubState=running" || t_bad "实得 $(get -p SubState --value)"
+M="$(get -p NextElapseUSecMonotonic --value)"
+[[ -n "$M" && "$M" != infinity ]] && t_ok "running 时仍有有限的下一次(实得 '$M')" || t_bad "实得 '$M'"
+[[ "$(get -p Result --value)" == success ]] && t_ok "Result=success(没被误判成失败)" || t_bad "Result 实得 $(get -p Result --value)"
+
+echo
+echo "── 6. active + elapsed → infinity ──"
+reset_state; echo 1 > "$D/$U.ac"; echo elapsed > "$D/$U.sub"
+[[ "$(get -p SubState --value)" == elapsed ]] && t_ok "SubState=elapsed" || t_bad "实得 $(get -p SubState --value)"
+[[ "$(get -p NextElapseUSecMonotonic --value)" == infinity ]] \
+  && t_ok "elapsed → infinity(死角能被表达出来)" \
+  || t_bad "elapsed 却给了有限值 —— timer 死角测试会变成恒绿"
+[[ "$(get -p ActiveState --value)" == active ]] && t_ok "同时仍是 active(正是真机上那个组合)" || t_bad "ActiveState 实得 $(get -p ActiveState --value)"
+
+echo
+echo "── 7. inactive + dead → infinity ──"
+reset_state; echo 0 > "$D/$U.ac"
+[[ "$(get -p ActiveState --value)" == inactive ]] && t_ok "ActiveState=inactive" || t_bad "实得 $(get -p ActiveState --value)"
+[[ "$(get -p SubState --value)" == dead ]] && t_ok "SubState=dead" || t_bad "实得 $(get -p SubState --value)"
+[[ "$(get -p NextElapseUSecMonotonic --value)" == infinity ]] && t_ok "inactive → infinity" || t_bad "inactive 却给了有限值"
+
+echo
+echo "── 8. failed → ActiveState/SubState/Result 都准确 ──"
+reset_state; echo 1 > "$D/$U.ac"; : > "$D/$U.failed"
+[[ "$(get -p ActiveState --value)" == failed ]] && t_ok "ActiveState=failed" || t_bad "实得 $(get -p ActiveState --value)"
+[[ "$(get -p SubState --value)" == failed ]] && t_ok "SubState=failed" || t_bad "实得 $(get -p SubState --value)"
+[[ "$(get -p Result --value)" == failed ]] && t_ok "Result=failed" || t_bad "实得 $(get -p Result --value)"
+[[ "$(get -p NextElapseUSecMonotonic --value)" == infinity ]] && t_ok "failed → infinity" || t_bad "failed 却给了有限值"
+
+echo
+echo "── 9. restart 后重新 active/waiting 并重新排程 ──"
+reset_state; echo 0 > "$D/$U.ac"; echo elapsed > "$D/$U.sub"
+BEFORE_AC="$(get -p ActiveState --value)"
+"$SC" restart "$U" >/dev/null 2>&1
+rm -f "$D/$U.sub"                      # restart 后 systemd 会重新武装, 子状态回到默认
+AFTER_AC="$(get -p ActiveState --value)"; AFTER_S="$(get -p SubState --value)"
+AFTER_M="$(get -p NextElapseUSecMonotonic --value)"
+[[ "$BEFORE_AC" == inactive && "$AFTER_AC" == active ]] \
+  && t_ok "restart 把状态文件真的改了($BEFORE_AC → $AFTER_AC)" || t_bad "$BEFORE_AC → $AFTER_AC"
+[[ "$AFTER_S" == waiting ]] && t_ok "restart 后回到 waiting" || t_bad "实得 $AFTER_S"
+[[ -n "$AFTER_M" && "$AFTER_M" != infinity ]] && t_ok "restart 后重新排出有限的下一次" || t_bad "实得 '$AFTER_M'"
+[[ -f "$D/$U.ac" && "$(cat "$D/$U.ac")" == 1 ]] && t_ok "状态文件 $U.ac 落到 1(观察的是状态变化, 不是打印)" || t_bad "状态文件没变"
+
+echo
+echo "── 10. .fail 故障注入后 restart 不能伪装成功 ──"
+reset_state; : > "$D/$U.fail"
+"$SC" restart "$U" >/dev/null 2>&1
+[[ "$(cat "$D/$U.ac" 2>/dev/null)" == 0 ]] && t_ok "注入 .fail 后 restart 仍留 inactive(原有注入没被我改坏)" \
+                                            || t_bad "注入失效: ac=$(cat "$D/$U.ac" 2>/dev/null)"
+[[ "$(get -p ActiveState --value)" == inactive ]] && t_ok "show 也如实报 inactive" || t_bad "show 实得 $(get -p ActiveState --value)"
+rm -f "$D/$U.fail"
+
+echo
+echo "── 11. enabled/disabled 与 UnitFileState 一致 ──"
+reset_state
+"$SC" enable "$U" >/dev/null 2>&1
+[[ "$("$SC" is-enabled "$U")" == enabled ]] && t_ok "is-enabled=enabled" || t_bad "实得 $("$SC" is-enabled "$U")"
+[[ "$(get -p UnitFileState --value)" == enabled ]] && t_ok "UnitFileState 与之一致" || t_bad "实得 $(get -p UnitFileState --value)"
+"$SC" disable "$U" >/dev/null 2>&1
+[[ "$("$SC" is-enabled "$U")" == disabled ]] && t_ok "is-enabled=disabled" || t_bad "实得 $("$SC" is-enabled "$U")"
+[[ "$(get -p UnitFileState --value)" == disabled ]] && t_ok "UnitFileState 跟着变" || t_bad "实得 $(get -p UnitFileState --value)"
+
+echo
+echo "── 12. 未知 unit / 未知 property 不许伪造健康值 ──"
+GHOST=nosuch-unit-xyz.timer
+[[ "$("$SC" is-active "$GHOST")" == inactive ]] && t_ok "未知 unit: is-active=inactive" || t_bad "实得 $("$SC" is-active "$GHOST")"
+GM="$("$SC" show "$GHOST" -p NextElapseUSecMonotonic --value)"
+[[ "$GM" == infinity ]] && t_ok "未知 unit 的 NextElapse=infinity(不编一个有限值)" || t_bad "实得 '$GM'"
+GA="$("$SC" show "$GHOST" -p ActiveState --value)"
+[[ "$GA" == inactive ]] && t_ok "未知 unit 的 ActiveState=inactive" || t_bad "实得 '$GA'"
+UP="$(get -p NoSuchPropertyXyz --value)"
+[[ "$UP" != active && "$UP" != waiting && "$UP" != enabled ]] \
+  && t_ok "未知属性不返回任何'看着健康'的值(实得 '$UP')" || t_bad "未知属性实得 '$UP'"
+
+rm -f "/etc/systemd/system/$U"; reset_state
+fin

--- a/tests/test-systemctl-stub.sh
+++ b/tests/test-systemctl-stub.sh
@@ -34,10 +34,78 @@ if [[ "${PDG_E2E_ISOLATED:-}" != 1 ]]; then
   fin; exit $?
 fi
 
+# ── 桩污染的前像: 必须在 source/装桩**之前**取 ────────────────────────────────
+# 隔离模式(PDG_E2E_ISOLATED=1)没有 user namespace, e2e-lib 的桩直接落在**真实**的
+# /usr/local/bin。而 /usr/local/bin 在 PATH 里排在 /usr/sbin 前面 —— 桩不清掉, 同一个
+# CI job 里后面每一步按 PATH 解析 nft/systemctl 的测试都会拿到它。
+# 实测过一次: 本脚本跑完后 `command -v nft` 从 /usr/sbin/nft(ELF, 26856 字节)翻到
+# /usr/local/bin/nft(53 字节 shell, 对任何输入 exit 0), 于是 test-uninstall-firewall.py
+# 的 `nft -c` 全部返回 0 —— 好候选"通过"是假绿, 坏候选没被拦才把这件事暴露出来。
+STUB_PATHS=(/usr/local/bin/systemctl /usr/local/bin/nft)
+declare -A PRE_KIND PRE_SHA PRE_MODE MADE_SHA
+PRE_BAK="$(mktemp -d)" || { t_bad "建不了 before-image 目录"; fin; exit $?; }
+_sha(){ sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
+for _p in "${STUB_PATHS[@]}"; do
+  if [[ -e "$_p" ]]; then
+    # 运行前就有同名文件: 逐字节留底, 收尾时原样放回去 —— 绝不无条件删别人的东西
+    PRE_KIND[$_p]=exist
+    PRE_SHA[$_p]="$(_sha "$_p")"
+    PRE_MODE[$_p]="$(stat -c%a "$_p" 2>/dev/null)"
+    cp -a "$_p" "$PRE_BAK/$(basename "$_p")" \
+      || { t_bad "留不了 $_p 的 before-image, 拒绝覆盖(fail-closed)"; fin; exit $?; }
+  else
+    PRE_KIND[$_p]=absent
+  fi
+done
+# 真命令的运行前解析结果。不写死 /usr/sbin/nft: 不同发行版路径不同, 判据要跟它比。
+REAL_NFT_CMD="$(command -v nft 2>/dev/null || true)"
+REAL_NFT_RP="$(readlink -f "$REAL_NFT_CMD" 2>/dev/null || true)"
+REAL_NFT_SHA="$([[ -n "$REAL_NFT_RP" ]] && _sha "$REAL_NFT_RP" || true)"
+REAL_NFT_KIND="$([[ -n "$REAL_NFT_RP" ]] && file -b "$REAL_NFT_RP" 2>/dev/null | cut -c1-24 || true)"
+REAL_SCTL_CMD="$(command -v systemctl 2>/dev/null || true)"
+REAL_SCTL_RP="$(readlink -f "$REAL_SCTL_CMD" 2>/dev/null || true)"
+REAL_SCTL_SHA="$([[ -n "$REAL_SCTL_RP" ]] && _sha "$REAL_SCTL_RP" || true)"
+PRE_SVC_DIR="$([[ -d /tmp/e2e-svc ]] && echo exist || echo absent)"
+PRE_CALLS="$([[ -e /tmp/e2e-calls.log ]] && echo exist || echo absent)"
+
+CLEAN_FAIL=0
+stub_cleanup(){       # 幂等: 重复调用必须仍然成功
+  local _p _cur
+  for _p in "${STUB_PATHS[@]}"; do
+    case "${PRE_KIND[$_p]:-absent}" in
+      absent)
+        [[ -e "$_p" ]] || continue                       # 已经清过了
+        _cur="$(_sha "$_p")"
+        if [[ -n "${MADE_SHA[$_p]:-}" && "$_cur" == "${MADE_SHA[$_p]}" ]]; then
+          rm -f "$_p" || { echo "[!] 删不掉 $_p"; CLEAN_FAIL=1; }
+        else
+          # 内容不是我们造的那份 = 运行期间被第三方换过, 不属于本测试, 不许删
+          echo "[!] $_p 的内容已被第三方替换(现 ${_cur:0:16}…, 本轮桩 ${MADE_SHA[$_p]:0:16}…), 不删除"
+          CLEAN_FAIL=1
+        fi;;
+      exist)
+        cp -a "$PRE_BAK/$(basename "$_p")" "$_p" || { echo "[!] 还原不了 $_p"; CLEAN_FAIL=1; continue; }
+        [[ -n "${PRE_MODE[$_p]:-}" ]] && { chmod "${PRE_MODE[$_p]}" "$_p" || CLEAN_FAIL=1; }
+        [[ "$(_sha "$_p")" == "${PRE_SHA[$_p]}" ]] || { echo "[!] $_p 还原后与 before-image 不符"; CLEAN_FAIL=1; };;
+    esac
+  done
+  [[ "$PRE_SVC_DIR" == absent ]] && [[ -d /tmp/e2e-svc ]] && { rm -rf /tmp/e2e-svc || { echo "[!] 删不掉 /tmp/e2e-svc"; CLEAN_FAIL=1; }; }
+  [[ "$PRE_CALLS"   == absent ]] && [[ -e /tmp/e2e-calls.log ]] && { rm -f /tmp/e2e-calls.log || { echo "[!] 删不掉 /tmp/e2e-calls.log"; CLEAN_FAIL=1; }; }
+  rm -rf "$PRE_BAK" 2>/dev/null
+  return "$CLEAN_FAIL"
+}
+
 # shellcheck source=tests/e2e-lib.sh
 E2E_ROOT="$ROOT"; export E2E_ROOT
 source "$ROOT/tests/e2e-lib.sh" 2>/dev/null || { t_bad "source 不了 e2e-lib.sh"; fin; exit $?; }
+# 用 e2e_add_exit_hook 而不是 trap ... EXIT: e2e-lib 已经把 EXIT 挂给 e2e_run_exit_hooks
+# (事务探针靠它收尾), 再设一个裸 trap 会把它顶掉。异常退出走这条路。
+e2e_add_exit_hook stub_cleanup || { t_bad "注册不了退出清理"; fin; exit $?; }
 e2e_stub_system >/dev/null 2>&1 || true
+# 记下我们刚造出来的那份桩的哈希: 收尾只删"还是这份内容"的文件
+for _p in "${STUB_PATHS[@]}"; do
+  [[ "${PRE_KIND[$_p]}" == absent && -e "$_p" ]] && MADE_SHA[$_p]="$(_sha "$_p")"
+done
 SC=/usr/local/bin/systemctl
 [[ -x "$SC" ]] || { t_bad "e2e_stub_system 没有生成 systemctl 桩"; fin; exit $?; }
 t_ok "真桩已由 e2e_stub_system 生成($SC)"
@@ -165,4 +233,30 @@ UP="$(get -p NoSuchPropertyXyz --value)"
   && t_ok "未知属性不返回任何'看着健康'的值(实得 '$UP')" || t_bad "未知属性实得 '$UP'"
 
 rm -f "/etc/systemd/system/$U"; reset_state
+
+# ── 收尾: 显式清一次, 并在脚本内部把"确实恢复了"验掉 ──────────────────────────
+# EXIT hook 仍然留着管异常路径; 这里显式调用是为了让下面的正向断言能在本脚本里完成 ——
+# 桩没清干净这件事必须在这里被抓住, 而不是留给几十步之后的另一支测试。
+echo
+echo "── 收尾: 桩清理与命令解析恢复 ──"
+stub_cleanup && t_ok "清理返回 0" || t_bad "清理失败(见上面的 [!] 行)"
+NOW_NFT_CMD="$(command -v nft 2>/dev/null || true)"
+NOW_NFT_RP="$(readlink -f "$NOW_NFT_CMD" 2>/dev/null || true)"
+[[ "$NOW_NFT_CMD" == "$REAL_NFT_CMD" && "$NOW_NFT_RP" == "$REAL_NFT_RP" ]] \
+  && t_ok "nft 解析回到运行前($NOW_NFT_CMD)" || t_bad "nft 现解析到 '$NOW_NFT_CMD'(运行前 '$REAL_NFT_CMD')"
+[[ -n "$NOW_NFT_RP" && "$(_sha "$NOW_NFT_RP")" == "$REAL_NFT_SHA" ]] \
+  && t_ok "nft 内容与运行前逐字节一致" || t_bad "nft 内容与运行前不符"
+[[ "$(file -b "$NOW_NFT_RP" 2>/dev/null | cut -c1-24)" == "$REAL_NFT_KIND" ]] \
+  && t_ok "nft 类型与运行前一致($REAL_NFT_KIND)" || t_bad "nft 类型变了"
+NOW_SCTL_CMD="$(command -v systemctl 2>/dev/null || true)"
+NOW_SCTL_RP="$(readlink -f "$NOW_SCTL_CMD" 2>/dev/null || true)"
+[[ "$NOW_SCTL_CMD" == "$REAL_SCTL_CMD" && "$(_sha "$NOW_SCTL_RP")" == "$REAL_SCTL_SHA" ]] \
+  && t_ok "systemctl 解析与内容都回到运行前($NOW_SCTL_CMD)" || t_bad "systemctl 没恢复(现 '$NOW_SCTL_CMD')"
+_left=0
+for _p in "${STUB_PATHS[@]}"; do [[ "${PRE_KIND[$_p]}" == absent && -e "$_p" ]] && _left=$((_left+1)); done
+[[ "$_left" == 0 ]] && t_ok "本轮创建的桩全部消失" || t_bad "还剩 $_left 个本轮创建的桩"
+[[ "$PRE_SVC_DIR" == exist || ! -d /tmp/e2e-svc ]] && t_ok "/tmp/e2e-svc 无本轮残留" || t_bad "/tmp/e2e-svc 还在"
+[[ "$PRE_CALLS" == exist || ! -e /tmp/e2e-calls.log ]] && t_ok "/tmp/e2e-calls.log 无本轮残留" || t_bad "/tmp/e2e-calls.log 还在"
+stub_cleanup && t_ok "再清一次仍返回 0(幂等)" || t_bad "重复清理失败 —— 不幂等"
+
 fin


### PR DESCRIPTION
## 这是什么

`pdg-health.timer` 的最小热修。修的是一种**看不出来**的故障:`systemctl is-enabled` 说 enabled、`is-active` 说 active、`is-failed` 不 failed、`Result=success` —— 一切正常,但它**再也不会触发**。

真机现场(jp2 / .200):健康自检静默停摆 **8 天**,期间任何服务异常都不会有 Telegram 通知。诊断时 `NextElapseUSecMonotonic=infinity`、`SubState=elapsed`,而 `pdg doctor` 判绿。

根因:unit 用 `OnBootSec` + `OnUnitActiveSec`(纯单调时钟)。开机偏移过去之后,timer 一旦经历 stop→start,就再也排不出下一次。确定性复现配方:**arm → stop → start**。`Persistent=true` 只对 `OnCalendar=` 生效,在纯单调 timer 上是一句空头承诺。

影响面:自 `182c43c`(2026-06-20)起的每个版本,含 v1.8.1。

## 为什么从 v1.8.1 建分支,不从 main

`v1.8.1..origin/main` 有 9 个未发布提交、动了 4 个生产文件(6.1C 手机链路测试那一摊)。从 main 拉分支会把这些未验收的东西一起带进热修。本分支严格基于 `v1.8.1^{} = edca404`,`merge-base(v1.8.1, HEAD) = edca404`,0 个 merge 提交,不含 `origin/main`、不含 6.1C 分支。

三处核心实现与主线 `b9a91b9` 上的最终实现**哈希一致**(`_pdg_timer_next_ok`=`848233778f6a802b`、`migrate_health_timer`=`e369a33c78124747`、`check_health_timer`=`66bc89ecc74e1c76`,timer unit 逐字节一致)—— 合 main 时不会产生分叉实现。

## 三个生产文件

| 文件 | 改动 |
|---|---|
| `deploy/bot/pdg-health.timer` | `OnBootSec=2min` → `OnActiveSec=2min`;删 `Persistent=true`;加 `Unit=pdg-health.service` |
| `deploy/bot/pdg.sh` | **+92 / −0**,纯增量:新增 `_pdg_timer_next_ok()`、`migrate_health_timer()`,`run_all_migrations` 末端加一行接线 `migrate_health_timer \|\| rc=1` |
| `deploy/bot/checks.py` | 新增 `check_health_timer()`,在 `ALL` 注册一处 |

`cmd_update` 函数体与 v1.8.1 **逐字节相同** —— 没有顺手改写。禁入内容扫描(`linkstat\|linksess\|nftlive\|手机链路\|链路测试`)命中 0;未做 probe81 公共化。未新增 `VERSION` 常量,版本仍只由 tag 决定。

`migrate_health_timer` 的状态机:内容未变 + 健康 → 零写零重启;内容未变 + 停用/未激活 → 修;内容未变 + 排不出下一次 → 重新 arm,**仍排不出则返回非零让更新回滚**;内容变化 → 校验候选 → 留前像 → 原子安装 → daemon-reload → enable → **显式 restart** → 核验有限 NextElapse;任一步失败 → 还原 + 返回 1。

## 验收数字

**模拟发布三格**(官方 `install.sh` 建机 + 隔离发布源 + 真 systemd/nft):

- A 格 Android 正常更新 **12/12**,含自然触发实证(10:21:01 触发 → 服务 exit 0 → 自动重排到 10 分钟后)
- B 格 iOS 正常更新 **12/12**
- C 格 更新中途失败自动回滚 **12/12** 精确恢复 + 撤障重试成功

**跨版本四格**(各 24 条断言,全 0 失败):v1.8.0→候选 Android / iOS,v1.7.8→候选 Android / iOS。

**环境硬门**:`e2e-rescue-10b.sh` **58/0/0**、`test-uninstall-firewall.py` **30/0/0**(真 root / 真 systemd / 真 nft+netlink,0 SKIP)。

**专项测试**:timer E2E **44/0**、doctor **18/0**、systemctl 桩契约 **35 条**。

**负控**:timer 负控 **10 条全部有效**、systemctl 桩负控 **6 条全部有效**(每条就地撤掉一处修复,要求转红,再逐字节还原;0 条转红即判无效)。

**幂等**:`update --dry-run` 零副作用;连续两次 `pdg __migrate` 后 units/timer/daemon-reload 计数/timer InvocationID 全不变,NextElapse 保持有限。

C 格的自动回滚经 `bash -x`(`BASH_XTRACEFD=8`)实录到确切 argv:

```
+ cmd_rollback --dir /var/lib/privdns-gateway/backups/20260806-105657 --git edca4046ff82c26a35c05426efae52129c2a5d16
```

## RELEASE-CHECKLIST 的热修继承口径

按「timer 最小热修」处理,不是删除清单:

- **doctor 全绿**:实验室唯一黄灯是 `.test` 保留 TLD + RFC1918 地址导致的公网解析前提,不可伪造;jp/jp2 部署**相同 timer 最终实现**后均已取得 `0 失败 / 0 警告`。按「候选实验室证据 + 真机同实现证据」收口。
- **Bot / WLOC / 平台隔离**:候选生产 diff 不触碰对应代码,继承 v1.8.1 及既往真实 Android/iPhone 验收结论,不为本次热修重新操作 Telegram、描述文件或 WLOC。
- **sing-box→mihomo**:候选不修改既有迁移路径,只在 `run_all_migrations` 末端追加 timer 迁移;由 CI 的 `e2e-drop-singbox.sh` 与 `test-migrate-drop-singbox.sh` 确认既有路径真执行。

## 已知 P2(均不在本 PR 修复范围)

1. **`_lock()` 吞 stderr** —— `if ! exec 9>"$LOCK" 2>/dev/null; then` 是无命令的 exec 重定向,永久改变进程 fd 2。引入于 `cd82e0f`(2026-07-26),影响 v1.6.3 起 12 个 tag。退出码与主要失败结论正确(`c_g`/`c_y` 走 stdout),只丢底层命令报错细节。
2. **手动 `pdg rollback` 不复位仓库 HEAD** —— `--git` 只有 `cmd_update` 会传,手动调用恢复文件但 HEAD 停在新 tag。与本 PR 验证的**自动**回滚是两条不同路径。
3. **`cmd_update` 无「已是最新」短路** —— 重复执行会多建一份快照、两次 `daemon-reload`、重启 `pdg-bot`(iOS 另加 `probe81`/`mitm`),并刷新已装文件 mtime。用户数据零损伤。`cmd_update` 与 v1.8.1 逐字节相同,故属既有行为。

## 部署注意

**jp(.153)与 jp2(.200)已经带着相同的 timer 最终实现在跑,不要把它们更新到 v1.8.2。**

## 不要直接合并

本 PR 用于让 CI 针对 `87eb783` 跑一遍。发布节奏(改 CHANGELOG 日期 → 再跑 CI → 打 tag → 发 Release)另行决定。

---

## 候选演进(v1.8.1 → 最终候选 `48b0b7a`)

初版候选 `87eb783` 的生产实现在整个过程中**一个字节都没有改过** —— `deploy/` 与 `lib/` 的
tree 哈希、`install.sh`/`uninstall.sh` 的 blob 自始至终相同。后续三个提交只动测试与发布说明:

| 提交 | 改动文件 | 为什么 |
|---|---|---|
| `e96a3bb` | `tests/e2e-health-timer.sh` | systemd 255 的启动限速假红 |
| `ac3f2ea` | `tests/test-systemctl-stub.sh` | 桩污染后续 CI 步骤 |
| `48b0b7a` | `CHANGELOG.md` | 填写发布日期 |

### systemd 255 启动限速假红(`e96a3bb` 已修)

故障注入那一节几格连着 stop/start 同一个 unit,撞上 systemd 默认的
`StartLimitIntervalSec=10s` / `StartLimitBurst=5`,unit 掉进 failed,于是产品 `_restore`
里那次 `systemctl start`(它并没有被遮蔽)真的失败,断言把 systemd 的限速记成了
「产品没还原状态」。systemd 252 上不显形,255 上必红:GitHub runner 43/1,同形容器 42/2,
journal 明写 `Start request repeated too quickly` / `Failed with result 'start-limit-hit'`,
而单独跑那一格是通过的 —— **产品行为本身没问题**。

改法:把「回到基线」从每格结尾移到每格开头,并在其中先 `reset-failed`,再装基线 unit、
reload、enable、start,然后正向核对 enabled/active/waiting/有限 NextElapse,确认无误才取
这一格的 before-image。清理只在准备阶段 —— `migrate_health_timer`、被测的 `_restore`、
注入器里都没有 `reset-failed`,否则等于测试替产品把状态收拾干净。

### systemctl 桩污染(`ac3f2ea` 已修)

`test-systemctl-stub.sh`(本候选新增)在 `PDG_E2E_ISOLATED=1` 下没有 user namespace,
e2e-lib 的桩直接落进**真实**的 `/usr/local/bin`,而它在 PATH 里排在 `/usr/sbin` 前面。
跑完不清,同一个 CI job 里后面每一步按 PATH 解析 `nft`/`systemctl` 的测试都会拿到桩。

实测链路:`command -v nft` 从 `/usr/sbin/nft`(ELF,26856 字节,`3f1c2155…`)翻到
`/usr/local/bin/nft`(53 字节 shell,对任何输入 `exit 0`,`5d8f8988…`)→ 紧接着的
`test-uninstall-firewall.py` 里 `nft -c` 全部返回 0 → 好候选「通过」是假绿,坏候选没被拦
才把问题暴露出来,29/1。

独立 diag 分支上做了三次归因 run:A 组(只装依赖)30/0/0 全绿,B 组(走完 lint 全部前序)
全红,同一份坏候选连续 10 次 rc 全 0、stderr 全空;A 组同样 10 次 rc 全 1。**不是 nft 抖动,
runner 的 nft 就是 v1.0.9 / libnftables 1.0.9-1ubuntu0.1,与本地同形环境一致。**

改法:装桩前取真命令与桩路径的 before-image;用 `e2e_add_exit_hook`(不是裸 `trap`,
那会顶掉 e2e-lib 自己的退出钩子)注册清理;只删「能证明是本次创建、且内容仍是本轮桩」
的路径,运行前就存在的逐字节还原,被第三方换掉的不删并报清理失败;收尾显式清一次并在
脚本内部把恢复验掉。35 条原断言语义未动,新增 9 条清理断言 → 44/0/0。

## 最终 CI

`48b0b7a` 上取得两个全新 run:`workflow_dispatch`(权威,分支 HEAD)与 PR merge-ref,
均 0 失败 0 SKIP。关键数字:timer E2E 44/0/0、doctor timer 18/0、systemctl 桩契约 44/0/0、
uninstall firewall 30/0/0(两条 nft 断言都真绿,说明用的是真 nft 不是桩)。

## P2 仍然保留,均**未修复**

1. `_lock()` 的 `exec 9>"$LOCK" 2>/dev/null` 永久吞掉进程 stderr(`cd82e0f` 起,v1.6.3 以来 12 个 tag)。
2. 手动 `pdg rollback`(不传 `--git`)恢复文件但不复位仓库 HEAD。
3. `cmd_update` 无「已是最新」短路,重复执行会多建快照、两次 daemon-reload、重启部分服务。
4. `migrate_health_timer` 的 `_restore` 在 `systemctl start` 前不做 `reset-failed`;
   `start-limit-hit` 时恢复 active 会失败 —— 但产品返回非零并明确报告「回滚不完整」,不会静默成功。
5. `test-false-green-guard.sh` 留下 `/tmp/e2e-inject-*`,且其断言数受环境影响(宿主 16 / 容器 15)。

这些都不在本 PR 的修复范围内,列在这里是为了不让它们被当成已解决。
