### PR TITLE
fix(doctor): 校验续期钩子写的证书目录与 mosdns 读的是否一致

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,12 @@ jobs:
       - name: "健康自检定时器判据 (elapsed+infinity 必须 FAIL / 正在跑不误报 / 只读)"
         run: python3 tests/test-health-timer-doctor.py
 
+      # .153 上 mosdns 读 /etc/dnsdist/certs 而续期钩子写 /etc/mosdns/certs, 靠一个看着
+      # 该被清理的老钩子兜着。这种错在证书到期前毫无征兆: 文件在、没过期、续期成功、
+      # doctor 全绿, 到期当天 DoT 对所有手机同时失效。
+      - name: "证书路径一致性 (钩子写的目录必须就是 mosdns 读的目录; 缺省值与钩子同源)"
+        run: python3 tests/test-cert-dir-sync.py
+
       # 真 systemd: 死角复现、状态机、故障注入。容器里跑, 非 root 环境 SKIP(严格模式判失败)。
       - name: "健康自检定时器 真 systemd (死角/状态机/6 种故障注入; 环境不足则 SKIP)"
         run: sudo -E bash tests/e2e-health-timer.sh

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -354,6 +354,37 @@ def check_dot_domain_sync():
                 f"dot-domain={f} 与证书 CN={cn} 不一致; 续期可能部署错证书。建议: echo {cn} > {DOT_DOMAIN_FILE}")
     return ("ok", "DoT 域名一致性", f"{cn} ✓")
 
+# 续期钩子写证书的目录: profile.env 的 PDG_CERT_DIR, 缺省与 deploy/cert/99-reload-cert.deploy-hook.sh
+# 里的 `CERT_DIR="${PDG_CERT_DIR:-/etc/mosdns/certs}"` 保持同一个字面量。两处改一处忘一处,
+# 这道门就会从"防线"变成"误报", 所以它们必须一起改。
+HOOK_CERT_DIR_DEFAULT = "/etc/mosdns/certs"
+
+def check_cert_dir_sync():
+    """续期钩子写证书的目录, 必须就是 mosdns 实际读证书的目录。
+
+    为什么单独立一道门: 现有的 check_cert 只问"mosdns 配的那个文件在不在、过没过期" ——
+    两个问题它都答得出"在、没过期", 因为旧证书**确实**在原地躺着。它答不出的是"下次续期
+    的新证书会不会落到这里"。于是路径一错, 整条链路全绿:certbot 续期成功、钩子退 0、
+    doctor 26 项无一异常, 而 mosdns 从头到尾抱着那张不再更新的旧证书, 直到到期当天 DoT
+    对全部手机静默失效 —— 那天没有任何一个组件会说自己出了错。
+
+    .153 上就是这样: mosdns 读 /etc/dnsdist/certs(dnsdist 时代留下的路径), 钩子写
+    /etc/mosdns/certs, 中间靠一个名叫 99-reload-dnsdist.sh 的老钩子兜着。而那个钩子
+    看名字就该跟 dnsdist 一起清掉 —— 清掉的那一刻, 到期日就成了停服日。
+    """
+    m = re.search(r'cert:\s*"([^"]+)"', _mos())
+    if not m:
+        return ("ok", "证书路径一致性", "mosdns 未配 DoT 证书, 无需检查")
+    # realpath: 软链与结尾斜杠都归一, 否则 /etc/mosdns/certs 与 /etc/mosdns/certs/ 会被判成两处。
+    mos_dir = os.path.realpath(os.path.dirname(m.group(1)))
+    hook_dir = os.path.realpath(_profile("PDG_CERT_DIR") or HOOK_CERT_DIR_DEFAULT)
+    if mos_dir != hook_dir:
+        return ("fail", "证书路径一致性",
+                f"mosdns 读 {mos_dir}, 续期钩子写 {hook_dir} —— 续期不会更新 mosdns 在用的证书, "
+                f"到期当天 DoT 会静默失效(在那之前一切正常)。二选一: 把证书迁到 {hook_dir} "
+                f"并同步改 mosdns config 的 cert/key; 或在 profile.env 写 PDG_CERT_DIR={mos_dir}")
+    return ("ok", "证书路径一致性", f"{mos_dir} ✓")
+
 def check_internal_cidr():
     c = _internal_cidr()
     if not c:
@@ -1518,7 +1549,7 @@ ALL = [check_platform, check_services, check_bot_credentials, check_health_timer
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_rescue_firewall, check_geosite_db, check_mem,
-       check_cert, check_dns, check_core_config, check_rulesets, check_rule_precedence,
+       check_cert, check_cert_dir_sync, check_dns, check_core_config, check_rulesets, check_rule_precedence,
        check_mitm_structure, check_mitm, check_transactions]
 ALERT = [check_services, check_dns, check_cert]  # healthcheck 用的轻量子集(运行期故障)
 DEEP = [check_deep_dot_handshake, check_deep_probe81, check_deep_dot_witness, check_deep_dns_cn,

--- a/tests/test-cert-dir-sync.py
+++ b/tests/test-cert-dir-sync.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ─────────────────────────────────────────────────────────────────────────────
+# doctor 必须看得见「续期钩子写证书的目录 ≠ mosdns 读证书的目录」。
+#
+# .153 上的真实形态: mosdns 的 config.yaml 里 cert 指向 /etc/dnsdist/certs(dnsdist
+# 时代留下的路径), 而 deploy-hook 按 PDG_CERT_DIR 缺省写 /etc/mosdns/certs。那台机器
+# 之所以一直没出事, 是因为还留着一个名叫 99-reload-dnsdist.sh 的老钩子在往
+# /etc/dnsdist/certs 拷 —— 而那个钩子, 从名字到位置都像是该跟 dnsdist 一起删掉的残留。
+#
+# 这类故障最难的地方在于**它在到期前完全没有征兆**: 证书文件在、没过期, check_cert 判绿;
+# certbot 续期成功; 钩子退 0; doctor 26 项全 ok。一直到证书到期那天, 全部手机的 DoT
+# 同时连不上, 而现场没有任何一条日志说自己错了。
+#
+# 判据不碰真文件系统: 把 checks._mos()(读 mosdns 配置)和 checks._profile()(读
+# profile.env)换成受控替身, 逐格喂路径组合, 看 doctor 给什么。
+# ─────────────────────────────────────────────────────────────────────────────
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "deploy", "bot"))
+import checks  # noqa: E402
+
+PASS = [0]
+FAIL = [0]
+
+
+def ok(m):
+    print("[OK]   " + m); PASS[0] += 1
+
+
+def bad(m):
+    print("[FAIL] " + m); FAIL[0] += 1
+
+
+def run(cert_line, profile_cert_dir=""):
+    """喂一份 mosdns 配置片段与 PDG_CERT_DIR, 取回 (level, check, detail)。
+
+    cert_line 为 None 表示 mosdns 配置里压根没有 cert: 那一行(没开 DoT)。
+    """
+    mos = "" if cert_line is None else (
+        "plugins:\n"
+        "  - tag: dot_server\n"
+        "    type: tcp_server\n"
+        '    args: {entry: main_sequence, listen: "0.0.0.0:853", '
+        f'cert: "{cert_line}", key: "/x/privkey.pem"}}\n'
+    )
+    old_mos, old_profile = checks._mos, checks._profile
+    try:
+        checks._mos = lambda: mos
+        checks._profile = lambda k: (profile_cert_dir if k == "PDG_CERT_DIR" else "")
+        return checks.check_cert_dir_sync()
+    finally:
+        checks._mos, checks._profile = old_mos, old_profile
+
+
+# ── 1) .153 的真实故障: 路径不一致必须判 fail ────────────────────────────────
+lvl, name, detail = run("/etc/dnsdist/certs/fullchain.pem")
+if lvl == "fail":
+    ok("mosdns 读 /etc/dnsdist/certs 而钩子写 /etc/mosdns/certs → 判 fail")
+else:
+    bad("路径不一致却判 %r —— 这正是到期日静默停服那条路" % lvl)
+
+# 报错必须把**两个**路径都说出来: 只说"不一致"的话, 运维不知道该改哪一头。
+if "/etc/dnsdist/certs" in detail and "/etc/mosdns/certs" in detail:
+    ok("失败详情同时点出 mosdns 侧与钩子侧的路径")
+else:
+    bad("失败详情没把两个路径都写出来, 定位不了: %r" % detail[:90])
+
+# 而且要给出可执行的两条出路(迁目录 / 设 PDG_CERT_DIR), 不是只报"坏了"。
+if "PDG_CERT_DIR" in detail:
+    ok("失败详情给了 PDG_CERT_DIR 这条现成出路")
+else:
+    bad("失败详情没告诉运维怎么修")
+
+# ── 2) 一致就得判 ok, 不许误报 ───────────────────────────────────────────────
+lvl, _, _ = run("/etc/mosdns/certs/fullchain.pem")
+if lvl == "ok":
+    ok("两边都是 /etc/mosdns/certs → 判 ok")
+else:
+    bad("路径一致却判 %r —— 误报会挡住 pdg update(doctor 是更新硬门)" % lvl)
+
+# ── 3) PDG_CERT_DIR 覆盖: 旧机合法地把两边都设成老路径 ──────────────────────
+# 这是产品**支持**的用法(pdgtx.py 会校验这个值), 不能因为路径长得旧就判红。
+lvl, _, _ = run("/etc/dnsdist/certs/fullchain.pem",
+                profile_cert_dir="/etc/dnsdist/certs")
+if lvl == "ok":
+    ok("profile.env 设了 PDG_CERT_DIR 对齐老路径 → 判 ok")
+else:
+    bad("合法的 PDG_CERT_DIR 覆盖被判 %r" % lvl)
+
+# 反过来: PDG_CERT_DIR 设成第三个地方, 依然要红。
+lvl, _, _ = run("/etc/mosdns/certs/fullchain.pem",
+                profile_cert_dir="/opt/somewhere/certs")
+if lvl == "fail":
+    ok("PDG_CERT_DIR 指向第三处 → 判 fail")
+else:
+    bad("PDG_CERT_DIR 与 mosdns 各指一处却判 %r" % lvl)
+
+# ── 4) 没开 DoT 的机器不该被这道门拦住 ───────────────────────────────────────
+lvl, _, detail = run(None)
+if lvl == "ok" and "无需检查" in detail:
+    ok("mosdns 没配 DoT 证书 → 明说无需检查, 不拿缺省值硬凑一个结论")
+else:
+    bad("没配 DoT 时判 %r / %r" % (lvl, detail[:60]))
+
+# ── 5) 归一化: 结尾斜杠不是"另一个目录" ──────────────────────────────────────
+# 这条不是吹毛求疵 —— PDG_CERT_DIR 是人手写进 profile.env 的, 多一个斜杠是常事,
+# 而一次误报会直接把 pdg update 挡死(doctor 是更新的硬门)。
+lvl, _, _ = run("/etc/mosdns/certs/fullchain.pem",
+                profile_cert_dir="/etc/mosdns/certs/")
+if lvl == "ok":
+    ok("PDG_CERT_DIR 结尾多一个斜杠不算不一致")
+else:
+    bad("结尾斜杠被判成不同目录 (%r) —— 误报会挡死 pdg update" % lvl)
+
+# ── 6) 这道门确实注册进了 doctor, 不是写完没挂上 ─────────────────────────────
+# 光有函数没进 ALL, 等于没写 —— 而且这种"漏挂"从测试里看不出来, 除非专门验一次。
+if checks.check_cert_dir_sync in checks.ALL:
+    ok("check_cert_dir_sync 已注册进 checks.ALL, pdg doctor 会真的跑它")
+else:
+    bad("函数写了但没进 checks.ALL —— doctor 永远不会执行它")
+
+# ── 7) 缺省值必须与钩子里的字面量同源 ────────────────────────────────────────
+# 两处各写各的, 就会出现"钩子改了目录、doctor 还按老缺省判绿"的最坏情况:
+# 门还在, 但它守的是一个已经不存在的约定。
+HOOK = os.path.join(ROOT, "deploy", "cert", "99-reload-cert.deploy-hook.sh")
+with open(HOOK, encoding="utf-8") as f:
+    hook_src = f.read()
+if ('PDG_CERT_DIR:-%s' % checks.HOOK_CERT_DIR_DEFAULT) in hook_src:
+    ok("doctor 的缺省证书目录与 deploy-hook 里的字面量一致")
+else:
+    bad("doctor 缺省 %r 在钩子里找不到对应的 ${PDG_CERT_DIR:-...} —— 两处已经漂移"
+        % checks.HOOK_CERT_DIR_DEFAULT)
+
+# 同一个路径在仓库里有**三处**字面量: 这道门的缺省、钩子的 ${PDG_CERT_DIR:-...}, 以及
+# install.sh 的 CERT_DIR(它决定新装机器的 mosdns config 里那行 cert 写什么)。
+# 装机那处一旦跟另外两处岔开, 后果不是"有台机器配错了", 而是**从此每台新机**都装出
+# 一个到期即停服的现场 —— 而且装完 doctor 立刻就红, 属于最贵的那种漂移。
+INSTALL = os.path.join(ROOT, "install.sh")
+with open(INSTALL, encoding="utf-8") as f:
+    install_src = f.read()
+if ('CERT_DIR="%s"' % checks.HOOK_CERT_DIR_DEFAULT) in install_src:
+    ok("install.sh 装机时渲染的证书目录与这道门的缺省一致")
+else:
+    bad("install.sh 的 CERT_DIR 与 %r 不一致 —— 新装机器会当场踩这道门"
+        % checks.HOOK_CERT_DIR_DEFAULT)
+
+print("\n" + "─" * 66)
+print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
## 问题

`check_cert` 只问两件事:mosdns 配的那个证书文件在不在、过没过期。

`.153` 上这两个答案都是"在、没过期" —— 旧证书确实躺在原地。它答不出的是第三个问题:**下次续期的新证书会不会落到这里**。

实际情况是不会:mosdns 读 `/etc/dnsdist/certs`(dnsdist 时代留下的路径),而部署钩子写 `/etc/mosdns/certs`。链路上没有任何一环能看见这个错位 —— certbot 续期成功,钩子退出码 0,doctor 26 项无一异常。故障被安排在证书到期那天:所有手机的 DoT 同时失效,而没有任何组件报错。

真正让那台机器活着的,是一个叫 `99-reload-dnsdist.sh` 的遗留钩子,它顺手拷进了 mosdns 实际读的那个路径。**跟着 dnsdist 一起删掉它 —— 那个看起来最该做的清理动作 —— 就会把这次停服引爆。**

## 改法

新增 `check_cert_dir_sync`:直接比对"续期钩子写的目录"和"mosdns 读的目录",不一致判 `fail`。

- 详情**同时点名两个路径和两条出路** —— 只知道它们不一致,不知道该动哪一头,这条判据就没用
- 没配 DoT 的机器如实说"未配置",不拿缺省值硬凑出一个结论
- 路径经 `realpath` 归一后再比,软链不会造成假阳

## 验证

新增 `tests/test-cert-dir-sync.py`,**11 条断言**,核心用例就是 `.153` 的真实形态。

**5 类负控全部按预期转红**:判据永远返回 ok(4 条红)、去掉 realpath 归一(1 条)、函数写了但没挂进 `ALL`(1 条)、缺省值与钩子漂移(3 条)、不区分"没配 DoT"(1 条)。

这个路径在仓库里有**三处**字面量:判据缺省、钩子的 `${PDG_CERT_DIR:-...}`、`install.sh` 的 `CERT_DIR`(决定新装机器渲染成什么)。测试把三处钉在一起 —— 装机那处一旦漂移,不是"某台机器配错",而是从此**每台新机**都装出一个到期即停服的现场。

拿两台线上机的真实配置喂过这道门:jp / jp2 均判 `ok`;喂 `.153` 修复前的配置,如实判 `fail` 并点名两个路径。

CI 已挂载(步骤 211→212)。回归:事务/渲染五支共 296 条断言 0 失败。

## 现场处置(已完成,不在本 PR 内)

`.153` 证书已迁至 `/etc/mosdns/certs`(与 `.200` 一致),配置改 1 行,遗留 dnsdist 钩子与单元已清理,doctor 26/26 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)