### PR TITLE
fix(tailscale): keep tailnet traffic out of the PDG data plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,10 @@ jobs:
       - name: "E2E 夹具模板渲染闭包 (模板每个占位符夹具都得替换)"
         run: python3 tests/test-e2e-seed-render.py
 
+      # 本地只查几个手挑的文件, 新增的 tests/*.sh 就永远进不了门 —— 本地全绿, CI 判红。
+      - name: "ShellCheck 范围守卫 (本地门必须与 CI 同范围, 范围从 ci.yml 读出)"
+        run: bash tests/test-shellcheck-scope.sh
+
       - name: "Tailscale 入口隔离 负控 (撤排除/挪顺序/过度排除必须转红; 无关注释仍绿)"
         run: sudo -n python3 tests/negctl/tailscale-isolation-negative-controls.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,6 +411,10 @@ jobs:
       - name: "Tailscale 入口隔离 (真 netns: tailnet 不进数据面, 物理 CGNAT 照旧)"
         run: sudo -n python3 tests/test-tailscale-ingress-isolation.py
 
+      # 模板改了却传不到已装机器上 —— 那条缺口让 v1.10.1→本分支的升级在六个 E2E 里同时红。
+      - name: "防火墙按模板重建 (已迁移的机器也要收到模板改动; 参数反解 fail-closed)"
+        run: sudo -n python3 tests/test-firewall-template-sync.py
+
       - name: "Tailscale 入口隔离 负控 (撤排除/挪顺序/过度排除必须转红; 无关注释仍绿)"
         run: sudo -n python3 tests/negctl/tailscale-isolation-negative-controls.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,15 @@ jobs:
       - name: "证书路径一致性 (钩子写的目录必须就是 mosdns 读的目录; 缺省值与钩子同源)"
         run: python3 tests/test-cert-dir-sync.py
 
+      # Tailscale 节点地址与运营商 SIM/APN 都用 100.64.0.0/10 —— 只看源地址分不开。
+      # 判据必须同时看入口接口, 所以这支用真 netns + 真 veth + 真 nft 加载 + 真流量;
+      # 两侧客户端地址都在同一个配置段内, 换源 IP 冒充不了。环境不足会 SKIP 并说明原因。
+      - name: "Tailscale 入口隔离 (真 netns: tailnet 不进数据面, 物理 CGNAT 照旧)"
+        run: sudo -n python3 tests/test-tailscale-ingress-isolation.py
+
+      - name: "Tailscale 入口隔离 负控 (撤排除/挪顺序/过度排除必须转红; 无关注释仍绿)"
+        run: sudo -n python3 tests/negctl/tailscale-isolation-negative-controls.py
+
       # 真 systemd: 死角复现、状态机、故障注入。容器里跑, 非 root 环境 SKIP(严格模式判失败)。
       - name: "健康自检定时器 真 systemd (死角/状态机/6 种故障注入; 环境不足则 SKIP)"
         run: sudo -E bash tests/e2e-health-timer.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,18 @@ jobs:
       - name: "防火墙按模板重建 (已迁移的机器也要收到模板改动; 参数反解 fail-closed)"
         run: sudo -n python3 tests/test-firewall-template-sync.py
 
+      # 磁盘已是新版而内核仍跑旧规则 —— 据磁盘判 no-op 会让防火墙停在旧规则上。
+      - name: "防火墙磁盘/内核漂移 (C 态只 reload 不写盘; B 态真 no-op; 失败注入)"
+        run: sudo -n python3 tests/test-firewall-live-drift.py
+
+      # 转换器认不出的匹配会被静默丢弃, 判据据此看不见内核里确实存在的规则。
+      - name: "nftjson 表达式覆盖 (iifname 等匹配不得在转换时丢失)"
+        run: python3 tests/test-nftjson-coverage.py
+
+      # 夹具渲染不全会造出"不像真机"的沙箱: 漏一个占位符, 参数反解就失败。
+      - name: "E2E 夹具模板渲染闭包 (模板每个占位符夹具都得替换)"
+        run: python3 tests/test-e2e-seed-render.py
+
       - name: "Tailscale 入口隔离 负控 (撤排除/挪顺序/过度排除必须转红; 无关注释仍绿)"
         run: sudo -n python3 tests/negctl/tailscale-isolation-negative-controls.py
 
@@ -726,6 +738,7 @@ jobs:
           - e2e-snapshot-meta.sh
           - e2e-config-transaction.sh
           - e2e-config-transaction-recovery.sh
+          - e2e-firewall-template-sync.sh
           # v1.8.1 修的那条: v1.7.8 的更新器持着全局锁, 新版迁移在首次启用救援平面时
           # 撞上这把锁 → __migrate 退出 → 整次更新回滚。它只在"旧脚本装新版"这条路上
           # 出现, 而且 --dry-run 复现不了(不跑迁移), 所以必须在 CI 里真跑一遍五种救援状态。

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -533,6 +533,77 @@ def check_nft():
         return ("warn", "防火墙", "; ".join(extra) + "(不影响手机基础链路)")
     return ("ok", "防火墙", platform_ports_text() + " 仅限内网卡来源")
 
+
+TS_IFACE = "tailscale0"
+
+
+def _ts_isolation_scan(obj):
+    """在内核 nft JSON 里找每条链的「tailscale0 排除规则」与「首个来源匹配」的位置。
+
+    返回 {链名: (排除规则序号, 首个 saddr 规则序号)}, 找不到的用 None。
+    序号按该链内的规则出现顺序, 顺序本身就是判据 —— 先匹配再排除等于没排除。
+    """
+    pos = {}
+    idx = {}
+    for item in (obj or {}).get("nftables", []):
+        r = item.get("rule")
+        if not r or r.get("table") != "pdg":
+            continue
+        ch = r.get("chain")
+        i = idx[ch] = idx.get(ch, -1) + 1
+        ex, src = pos.get(ch, (None, None))
+        for e in r.get("expr", []):
+            m = e.get("match") or {}
+            left = m.get("left") or {}
+            if left.get("meta", {}).get("key") == "iifname" and m.get("right") == TS_IFACE:
+                if ex is None:
+                    ex = i
+            p = left.get("payload") or {}
+            if p.get("protocol") == "ip" and p.get("field") == "saddr":
+                if src is None:
+                    src = i
+        pos[ch] = (ex, src)
+    return pos
+
+
+def check_tailscale_isolation():
+    """Tailscale 入口隔离: 从 tailscale0 进来的流量不得进入 SIM/APN 数据面。
+
+    为什么单独一项: Tailscale 节点地址来自 100.64.0.0/10, 而运营商 SIM/APN 也合法用
+    同一个段(RFC 6598) —— **只看源地址分不开这两者**。所以判据不能是"看见 CGNAT 段就
+    报错"(那会误伤真实运营商用户, 也是本项目明确不接受的做法), 而必须是"排除规则在不在、
+    排得对不对"。
+
+    这一项与 Tailscale 装没装无关: 规则来自模板, 任何时候都该在。没装 Tailscale 时
+    iifname 只是永不命中, 不会因此产生告警 —— 否则每台没用 Tailscale 的机器都会平白多一条红。
+    """
+    v = _nft_view()
+    if not v.disk_ok:
+        return ("fail", "Tailscale 入口隔离", "磁盘上的防火墙配置无效: %s" % v.disk_why)
+    import nftlive
+    obj, why = nftlive.read_kernel(runner=lambda cmd: _run(cmd, 15))
+    if obj is None:
+        return ("fail", "Tailscale 入口隔离",
+                "读不到内核里的防火墙规则(%s) —— 无法确认隔离是否生效" % (why or "原因未知"))
+    pos = _ts_isolation_scan(obj)
+    if not pos:
+        return ("fail", "Tailscale 入口隔离", "内核里没有 inet pdg 的规则")
+    bad = []
+    for ch in ("prerouting", "input"):
+        if ch not in pos:
+            bad.append("%s 链不存在" % ch)
+            continue
+        ex, src = pos[ch]
+        if ex is None:
+            bad.append("%s 缺少 iifname %s 的排除规则" % (ch, TS_IFACE))
+        elif src is not None and ex > src:
+            bad.append("%s 的排除规则排在来源匹配之后(第 %d 条 > 第 %d 条)" % (ch, ex, src))
+    if bad:
+        return ("fail", "Tailscale 入口隔离",
+                "; ".join(bad) + " —— tailnet 流量可能被当成内网卡来源接管")
+    return ("ok", "Tailscale 入口隔离", "prerouting/input 均在来源匹配前排除 %s" % TS_IFACE)
+
+
 def _filesha(path):
     """文件 SHA256(读不到返回空串)。用于比对部署文件与仓库文件是否同一版本。"""
     import hashlib
@@ -1547,6 +1618,7 @@ def check_transactions():
 
 ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
+       check_tailscale_isolation,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_rescue_firewall, check_geosite_db, check_mem,
        check_cert, check_cert_dir_sync, check_dns, check_core_config, check_rulesets, check_rule_precedence,

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -537,6 +537,22 @@ def check_nft():
 TS_IFACE = "tailscale0"
 
 
+RESCUE_MARK = "pdg-rescue"
+
+
+def _rule_has_rescue_mark(rule):
+    """这条规则是不是救援平面注入的(带 comment "pdg-rescue")。
+
+    nft JSON 里 comment 既可能挂在规则上, 也可能作为表达式出现, 两处都认。
+    """
+    if rule.get("comment") == RESCUE_MARK:
+        return True
+    for e in rule.get("expr", []) or []:
+        if isinstance(e, dict) and e.get("comment") == RESCUE_MARK:
+            return True
+    return False
+
+
 def _ts_isolation_scan(obj):
     """在内核 nft JSON 里找每条链的「tailscale0 排除规则」与「首个来源匹配」的位置。
 
@@ -551,6 +567,16 @@ def _ts_isolation_scan(obj):
             continue
         ch = r.get("chain")
         i = idx[ch] = idx.get(ch, -1) + 1
+        # 救援平面的放行不算"数据面来源匹配"。它按设计插在 input 链首(见 rescue_nft.py),
+        # 带 `ip saddr` 但也带具体 `ip daddr` —— 是对单个绑定地址的点状放行, 不是把一整个
+        # 网段接管进 SIM/APN 数据面。把它当成来源匹配, 结论就成了"排除规则排在来源匹配
+        # 之后", 于是**任何启用过救援的机器一升级就判红** —— 实测 e2e-rescue-migration-lock
+        # 正是这么红的, 而规则本身一条不少、顺序也没问题。
+        #
+        # 认标记, 不认端口或地址: 用户完全可能自己写过同端口的放行, 而标记是我们自己注入的
+        # 凭证(rescue_nft.MARK), 也是别处精确撤销时用的同一个依据。
+        if _rule_has_rescue_mark(r):
+            continue
         ex, src = pos.get(ch, (None, None))
         for e in r.get("expr", []):
             m = e.get("match") or {}

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -697,6 +697,34 @@ migrate_firewall_template_sync(){
     return 0
   fi
 
+  # 救援平面启用时会往这个文件里注入带 `comment "pdg-rescue"` 标记的放行(见 rescue_nft.py),
+  # 那些规则**不在模板里**。按模板重建会把它们一起抹掉 —— 后果不是"少一条规则", 而是
+  # 一台正处在救援状态的机器, 救援通道被一次常规更新切断。
+  # breakglass.py 开头记的就是同型事故: 恢复末尾 `nft -f`, 而那份配置没有救援放行。
+  #
+  # 所以重建之后、校验之前, 把标记规则原样并回候选。识别与插入都走 rescue_nft.py ——
+  # 它是唯一知道"哪条是我们的、该插在链里哪个位置"的地方, 这里不另写一套正则。
+  if grep -q 'comment "pdg-rescue"' "$f" 2>/dev/null; then
+    if ! python3 - "$f" "$tmp" <<PYEOF 2>/dev/null; then
+import re, sys
+sys.path.insert(0, "/opt/pdg-bot")
+sys.path.insert(0, __import__("os").path.join(__import__("os").environ.get("REPO_DIR", ""), "deploy", "bot"))
+import rescue_nft
+old_txt = open(sys.argv[1], encoding="utf-8").read()
+cand = open(sys.argv[2], encoding="utf-8").read()
+keep = rescue_nft._INLINE_RE.findall(old_txt)
+if not keep:
+    sys.exit(0)
+m = rescue_nft._INPUT_CHAIN_RE.search(cand)
+if not m:
+    sys.exit(1)
+out = cand[:m.end()] + "\n" + "".join(keep).rstrip("\n") + cand[m.end():]
+open(sys.argv[2], "w", encoding="utf-8").write(out)
+PYEOF
+      c_y "防火墙模板同步: 保留救援放行失败 → 不重建(不切断救援通道)。"
+      rm -f "$tmp"; return 1
+    fi
+  fi
   if ! nft -c -f "$tmp" >/dev/null 2>&1; then
     c_y "防火墙模板同步: 新规则 nft -c 未过, 保留现有防火墙不动。"
     rm -f "$tmp"; return 1

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -585,6 +585,77 @@ PY
 # 老装迁移: 防火墙内网放行集补 5228-5230(GMS/FCM 推送 mtalk.google.com 的原生端口;
 # mihomo 靠 nft 把它们 REDIRECT 进 redir 端口再嗅 SNI 分流)。幂等。
 # 只动"原装形态"的那一行(严格匹配现行端口集); 自定义端口集不碰, 提示手动加。
+# 把**模板的后续改动**同步到已经在 inet pdg 上的机器。
+#
+# migrate_firewall_to_pdg 是一次性搬迁(旧 inet filter → 独立表 inet pdg), 开头就写着
+# 「已是新表 → 无需迁移」并 return。于是已迁移的机器**再也收不到任何模板改动** ——
+# 它跑的永远是当初装机那一版渲染结果。模板里那句「本表每次更新都会按模板重建」是写了
+# 却没实现的契约。
+#
+# 平时看不出来。直到有判据开始查具体规则在不在(Tailscale 入口隔离是第一个), 升级就变成:
+# 新判据要新规则, 而没有任何一步会装上去 → doctor 判红 → cmd_update 自检门整次回滚 →
+# **新版本在所有旧机器上都装不上**。CI 的 e2e-update / e2e-upgrade-from-release 六个 job
+# 同时红, 报的就是这一条。
+#
+# 重建是安全的, 因为用户自定义规则本来就不放在这个文件里: 它们走 nft-input.d/*.conf,
+# 由模板末尾的 include 带进来, 重建不碰那个目录。这也正是模板注释承诺过的边界。
+#
+# 参数从**机器现状**里取(SSH 端口 / 内网段 / 救援端口), 不从模板猜 —— 取不到就不动,
+# 宁可这次不同步, 也不拿错参数去重建一台正在服务的机器的防火墙。
+# $1 可指定文件(供测试), 默认 /etc/nftables.conf。
+# shellcheck disable=SC2120  # $1 仅测试注入, 生产调用不传参
+migrate_firewall_template_sync(){
+  local f="${1:-/etc/nftables.conf}"
+  [[ -f "$f" ]] || return 0
+  grep -q 'table inet pdg' "$f" || return 0        # 还没迁到 inet pdg 的先走 migrate_firewall_to_pdg
+  local tpl="$REPO_DIR/deploy/firewall/nftables-mihomo.conf"
+  [[ -f "$tpl" ]] || return 0
+
+  # 现状参数: 从正在用的这份配置里反解, 而不是从 profile 猜 —— 两者不一致时, 机器上
+  # 跑着的那份才是事实。任一解不出就整体放弃本次同步。
+  local port cidr rport
+  port="$(grep -oE 'tcp dport [{] ?[0-9]+ ?[}] accept' "$f" | head -1 | grep -oE '[0-9]+')"
+  cidr="$(grep -oE 'ip saddr [0-9.]+/[0-9]+' "$f" | head -1 | awk '{print $3}')"
+  _rescue_load 2>/dev/null || true
+  rport="${PDG_RESCUE_PORT:-}"
+  if [[ -z "$port" || -z "$cidr" || -z "$rport" ]]; then
+    c_y "防火墙模板同步: 解不出 SSH端口/内网段/救援端口, 本次跳过(不拿错参数重建)。"
+    return 0
+  fi
+
+  local tmp; tmp="$(mktemp)" || return 0
+  sed -e "s|__SSH_PORT__|$port|g" -e "s|__INTERNAL_CIDR__|$cidr|g" \
+      -e "s|__RESCUE_PORT__|$rport|g" "$tpl" > "$tmp"
+
+  # 已经一致就什么都不做: 幂等, 且避免每次更新都白重启防火墙。
+  if cmp -s "$tmp" "$f"; then rm -f "$tmp"; return 0; fi
+
+  if ! nft -c -f "$tmp" >/dev/null 2>&1; then
+    c_y "防火墙模板同步: 新规则 nft -c 未过, 保留现有防火墙不动。"
+    rm -f "$tmp"; return 1
+  fi
+
+  # 先备份再落位。备份失败就不动 —— 与二进制安装同一条口径: 不在没有退路的前提下改。
+  local bak="$f.pre-tplsync"
+  if ! cp -a "$f" "$bak" 2>/dev/null || ! cmp -s "$f" "$bak"; then
+    c_y "防火墙模板同步: 备份现有配置失败, 不动。"
+    rm -f "$tmp"; return 1
+  fi
+  c_g "防火墙按模板重建(同步模板改动; 你在 nft-input.d/ 里的规则不受影响)…"
+  if ! cat "$tmp" > "$f"; then
+    c_y "防火墙模板同步: 写入失败, 从备份恢复。"
+    cat "$bak" > "$f" 2>/dev/null; rm -f "$tmp"; return 1
+  fi
+  rm -f "$tmp"
+  if ! nft -f "$f" >/dev/null 2>&1; then
+    c_y "防火墙模板同步: 加载新规则失败 → 回滚到同步前那份并重新加载。"
+    cat "$bak" > "$f" 2>/dev/null
+    nft -f "$f" >/dev/null 2>&1 || c_y "  ⚠️ 回滚后的规则也没加载成功, 请人工检查 $f"
+    return 1
+  fi
+  return 0
+}
+
 # $1 可指定文件(供测试), 默认 /etc/nftables.conf; 测试时 nft 可用函数打桩。
 # shellcheck disable=SC2120  # $1 仅测试注入, 生产调用不传参
 migrate_fw_gms(){
@@ -3157,7 +3228,10 @@ run_all_migrations(){
   migrate_rescue_plane || true             # 老机首次获得救援平面(用户停用过则不动)
   migrate_backend_marker || true           # 再把内核标记落地(别再靠默认值兜底)
   migrate_cidr_single_source || true       # 先立真源: 后续 nft/mosdns/救援都从它读
-  migrate_botenv || true; migrate_firewall_to_pdg || true; migrate_mosdns_concurrent || true
+  migrate_botenv || true; migrate_firewall_to_pdg || true
+  # 搬迁之后紧接着同步模板改动: 前者管"换表", 后者管"换表之后模板又变了"。
+  migrate_firewall_template_sync || true
+  migrate_mosdns_concurrent || true
   migrate_mosdns_unlock || true; migrate_fw_gms || true
   migrate_mosdns_ratelimit || true; migrate_lowmem || true; migrate_mihomo_safepaths || true
   migrate_deploy_botfiles || true; migrate_deploy_units || true

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -613,13 +613,28 @@ migrate_firewall_template_sync(){
 
   # 现状参数: 从正在用的这份配置里反解, 而不是从 profile 猜 —— 两者不一致时, 机器上
   # 跑着的那份才是事实。任一解不出就整体放弃本次同步。
+  # 三个参数全部从**这台机器正在用的这份配置**反解。救援端口也一样 —— 用常量的话,
+  # 常量和机器现状不一致时会拿常量去重建, 那等于悄悄改掉这台机器的救援端口放行。
+  #
+  # 判据是"唯一且合法", 不是"非空": `head -1` 那种写法会在配置里出现多个不同值时
+  # 静默取第一个, 而那恰恰是最该停下来的情形(配置被手改过 / 上一次同步没干净)。
   local port cidr rport
-  port="$(grep -oE 'tcp dport [{] ?[0-9]+ ?[}] accept' "$f" | head -1 | grep -oE '[0-9]+')"
-  cidr="$(grep -oE 'ip saddr [0-9.]+/[0-9]+' "$f" | head -1 | awk '{print $3}')"
-  _rescue_load 2>/dev/null || true
-  rport="${PDG_RESCUE_PORT:-}"
-  if [[ -z "$port" || -z "$cidr" || -z "$rport" ]]; then
-    c_y "防火墙模板同步: 解不出 SSH端口/内网段/救援端口, 本次跳过(不拿错参数重建)。"
+  port="$(grep -oE 'tcp dport [{] ?[0-9]+ ?[}] accept' "$f" | grep -oE '[0-9]+' | sort -u)"
+  cidr="$(grep -oE 'ip saddr [0-9.]+/[0-9]+' "$f" | awk '{print $3}' | sort -u)"
+  rport="$(grep -oE 'ip saddr [0-9./]+ tcp dport [0-9]+ accept' "$f" \
+           | grep -oE 'dport [0-9]+' | grep -oE '[0-9]+' | sort -u)"
+  local why=""
+  [[ "$(printf '%s\n' "$port"  | grep -c .)" == 1 ]] || why="SSH 端口不唯一"
+  [[ "$(printf '%s\n' "$cidr"  | grep -c .)" == 1 ]] || why="${why:-内网段不唯一}"
+  [[ "$(printf '%s\n' "$rport" | grep -c .)" == 1 ]] || why="${why:-救援端口不唯一}"
+  if [[ -z "$why" ]]; then
+    [[ "$port"  =~ ^[0-9]+$ ]] && [[ "$port"  -ge 1 && "$port"  -le 65535 ]] || why="SSH 端口不合法"
+    [[ "$rport" =~ ^[0-9]+$ ]] && [[ "$rport" -ge 1 && "$rport" -le 65535 ]] || why="${why:-救援端口不合法}"
+    [[ "$cidr" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]] || why="${why:-内网段不合法}"
+  fi
+  if [[ -n "$why" ]]; then
+    # 只说哪一类参数有问题, 不回显具体值 —— 日志里不该出现这台机器的网段和端口。
+    c_y "防火墙模板同步: $why, 本次跳过(不写盘、不加载、不重启)。"
     return 0
   fi
 
@@ -636,9 +651,15 @@ migrate_firewall_template_sync(){
   fi
 
   # 先备份再落位。备份失败就不动 —— 与二进制安装同一条口径: 不在没有退路的前提下改。
-  local bak="$f.pre-tplsync"
-  if ! cp -a "$f" "$bak" 2>/dev/null || ! cmp -s "$f" "$bak"; then
-    c_y "防火墙模板同步: 备份现有配置失败, 不动。"
+  # before-image 要能把文件**完整**还原: 内容之外, 权限位与属主也得对得上, 否则"恢复了"
+  # 的是一个 root 只读或属主不对的 nftables.conf, 下次更新会在别处莫名其妙地失败。
+  local bak="$f.pre-tplsync" pre_mode pre_own
+  pre_mode="$(stat -c %a "$f" 2>/dev/null)"; pre_own="$(stat -c %u:%g "$f" 2>/dev/null)"
+  if [[ -z "$pre_mode" || -z "$pre_own" ]] || ! cp -a "$f" "$bak" 2>/dev/null \
+     || ! cmp -s "$f" "$bak" \
+     || [[ "$(stat -c %a "$bak" 2>/dev/null)" != "$pre_mode" ]] \
+     || [[ "$(stat -c %u:%g "$bak" 2>/dev/null)" != "$pre_own" ]]; then
+    c_y "防火墙模板同步: 备份现有配置失败(内容/权限/属主未能完整留存), 不动。"
     rm -f "$tmp"; return 1
   fi
   c_g "防火墙按模板重建(同步模板改动; 你在 nft-input.d/ 里的规则不受影响)…"
@@ -649,8 +670,15 @@ migrate_firewall_template_sync(){
   rm -f "$tmp"
   if ! nft -f "$f" >/dev/null 2>&1; then
     c_y "防火墙模板同步: 加载新规则失败 → 回滚到同步前那份并重新加载。"
-    cat "$bak" > "$f" 2>/dev/null
-    nft -f "$f" >/dev/null 2>&1 || c_y "  ⚠️ 回滚后的规则也没加载成功, 请人工检查 $f"
+    local rb=0
+    cat "$bak" > "$f" 2>/dev/null || rb=1
+    chmod "$pre_mode" "$f" 2>/dev/null || rb=1
+    chown "$pre_own" "$f" 2>/dev/null || rb=1
+    cmp -s "$bak" "$f" || rb=1
+    nft -f "$f" >/dev/null 2>&1 || rb=1
+    if [[ "$rb" != 0 ]]; then
+      c_y "  ⚠️ 回滚**不完整**(内容/权限/属主/加载 至少一项没成) —— 请人工检查 $f"
+    fi
     return 1
   fi
   return 0

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -604,6 +604,32 @@ PY
 # 宁可这次不同步, 也不拿错参数去重建一台正在服务的机器的防火墙。
 # $1 可指定文件(供测试), 默认 /etc/nftables.conf。
 # shellcheck disable=SC2120  # $1 仅测试注入, 生产调用不传参
+# 内核里是否满足模板承诺的关键不变量。判据复用 doctor 那条读取链(checks.py 的 Tailscale
+# 隔离扫描), 而不是把磁盘文本与内核输出硬比 —— nft 会自行规范化写法, 硬比必出假漂移,
+# nftlive.py 开头记过这条实验。
+#
+# 覆盖面是**审计覆盖到的属性**, 不是整表一致性: 这是刻意的取舍。要做整表比较就得把候选
+# 真加载一次才能拿到规范形态, 那会给生产路径新增 netns 依赖, 代价大于收益。
+# 读不到内核 / 读不到 checks 一律非零(fail-closed), 绝不把"不知道"当成"一致"。
+_fw_live_has_template_invariants(){
+  python3 - <<PYEOF >/dev/null 2>&1
+import sys
+# 运行模块优先(线上真源), 仓库副本次之 —— cmd_update 期间新代码已在 REPO_DIR 而
+# /opt/pdg-bot 可能还是上一版; 两处都读不到就 fail-closed, 不猜。
+import os
+for _d in ("/opt/pdg-bot", os.path.join(os.environ.get("REPO_DIR", ""), "deploy", "bot")):
+    if _d and os.path.isdir(_d):
+        sys.path.insert(0, _d)
+try:
+    import checks
+    lvl = checks.check_tailscale_isolation()[0]
+except Exception:
+    sys.exit(2)
+sys.exit(0 if lvl == "ok" else 1)
+PYEOF
+}
+
+# shellcheck disable=SC2120  # $1 仅测试注入, 生产调用不传参
 migrate_firewall_template_sync(){
   local f="${1:-/etc/nftables.conf}"
   [[ -f "$f" ]] || return 0
@@ -643,7 +669,33 @@ migrate_firewall_template_sync(){
       -e "s|__RESCUE_PORT__|$rport|g" "$tpl" > "$tmp"
 
   # 已经一致就什么都不做: 幂等, 且避免每次更新都白重启防火墙。
-  if cmp -s "$tmp" "$f"; then rm -f "$tmp"; return 0; fi
+  if cmp -s "$tmp" "$f"; then
+    rm -f "$tmp"
+    # 磁盘已经是当前模板 —— 但这只说明**盘上**是新的, 不代表内核在跑它。
+    # 装机中断、配置写了没 load、快照只还原文件, 都会留下"磁盘新、内核旧"的现场:
+    # 防火墙实际按旧规则放行, 而这里若据磁盘判 no-op, 就再也没有人会把它们拉回来。
+    #
+    # 判据放在**内核一侧**, 不做"磁盘逐条 vs 内核逐条": nftables v1.0.6 下
+    # `nft -c -j -f` 输出 0 字节, 候选的规范化形态拿不到, 除非真加载(见 nftlive.py)。
+    if _fw_live_has_template_invariants; then
+      return 0                     # B 态: 磁盘新、内核新 —— 真 no-op, 不写盘不加载
+    fi
+    # C 态: 磁盘新、内核旧 → 只 reload, **不重写磁盘**(盘上那份已经是对的)
+    if ! nft -c -f "$f" >/dev/null 2>&1; then
+      c_y "内核规则落后于磁盘, 但磁盘配置 nft -c 未过 → 不加载, 请人工检查。"
+      return 1
+    fi
+    c_g "内核规则落后于磁盘配置 → 重新加载一次(不改磁盘; nft-input.d 规则不受影响)…"
+    if ! nft -f "$f" >/dev/null 2>&1; then
+      c_y "防火墙重新加载失败 —— 内核仍是加载前那份, 磁盘未动。"
+      return 1
+    fi
+    if ! _fw_live_has_template_invariants; then
+      c_y "重新加载后内核仍未收敛到模板承诺的规则 —— 不当作成功, 请人工检查。"
+      return 1
+    fi
+    return 0
+  fi
 
   if ! nft -c -f "$tmp" >/dev/null 2>&1; then
     c_y "防火墙模板同步: 新规则 nft -c 未过, 保留现有防火墙不动。"

--- a/deploy/firewall/nftables-mihomo.conf
+++ b/deploy/firewall/nftables-mihomo.conf
@@ -33,12 +33,16 @@ table inet pdg {
         iif "lo" accept
         ct state established,related accept
         tcp dport { __SSH_PORT__ } accept
-        # Tailscale 入口隔离(理由同 prerouting)。位置是刻意的: 排在 SSH 放行**之后**、
-        # 所有来源匹配**之前** —— 于是经 tailnet 的 SSH 仍然放行(上一行已 accept), 而 tailnet
-        # 到 53/81/853/7893/8445/救援端口的流量走到这里就 return, 由本链 policy drop 收口。
-        # 副作用(有意接受): 从 tailnet **主动发起**的 ICMP 会被 drop, 因为 icmp accept 排在
-        # 来源匹配之后。已建连的回包由上面的 ct established,related 放行, 不受影响;
-        # tailscale ping 走 TSMP 也不受影响。fail-closed 优先。
+        # ICMP/ICMPv6 放在这里而不是链尾: 它们是**无条件 accept**, 上移跨过的全是按
+        # tcp/udp 端口匹配的规则, 而 ICMP 没有端口、本来就不会命中那些规则 —— 所以位置
+        # 变了、语义逐条不变。这么排是为了让下面那条 tailnet 排除能同时满足两件事:
+        # 保住 ping 这条管理通道的基本可达性, 又把 tailnet 挡在数据面之外。
+        ip protocol icmp accept
+        ip6 nexthdr icmpv6 accept
+        # Tailscale 入口隔离(理由同 prerouting)。位置是刻意的: 排在 SSH 与 ICMP 放行
+        # **之后**、所有来源匹配与数据面规则**之前**。于是经 tailnet 的 SSH 与 ping 照常
+        # 可用(上面几行已 accept), 而 tailnet 到 53/81/853/7893/8445/救援端口的流量走到
+        # 这里就 return, 由本链 policy drop 收口。
         iifname "tailscale0" return
         # 80/443/5228-5230 已在 prerouting 被改写为 7893, 故这里放行 7893(仅内网来源);
         # 53/81/853/8445 仍由各自服务直接监听(mosdns DoT / iOS 探测 / tg-proxy)。
@@ -48,8 +52,6 @@ table inet pdg {
         ip saddr __INTERNAL_CIDR__ tcp dport __RESCUE_PORT__ accept
         ip saddr __INTERNAL_CIDR__ udp dport { 53 } accept
         ip saddr __INTERNAL_CIDR__ udp dport 443 reject   # QUIC/HTTP3: 拒掉, 逼客户端回落 TCP 443(可嗅 SNI 分流)
-        ip protocol icmp accept
-        ip6 nexthdr icmpv6 accept
         # 你自己的放行规则放这里(每个 .conf 一行一条, 如 `tcp dport 80 accept`):
         #     /etc/privdns-gateway/nft-input.d/*.conf
         # 本表每次更新都会按模板重建, 但那个目录不会被碰 —— 手加在本文件里的规则会丢, 加在

--- a/deploy/firewall/nftables-mihomo.conf
+++ b/deploy/firewall/nftables-mihomo.conf
@@ -19,6 +19,13 @@ table inet pdg {
     # 内网来源的被劫持端口 → mihomo redir(7893)。dstnat 优先级早于 filter input。
     chain prerouting {
         type nat hook prerouting priority dstnat; policy accept;
+        # Tailscale 节点地址来自 100.64.0.0/10, 运营商 SIM/APN 也合法用同一个段(RFC 6598),
+        # 所以**只看源地址分不开这两者**。真正的判据是"从哪个接口进来": 从 tailscale0 来的
+        # 一律不进数据面。必须排在下面的来源匹配之前 —— 先匹配再排除等于没排除。
+        # 用 iifname 不用 iif: iif 在加载时把接口名解析成索引, 接口不存在会让整份规则加载
+        # 失败, 而生产机在装 Tailscale **之前**就得能加载这份规则。iifname 是运行时按名字比,
+        # 没有该接口时它只是永不命中, 行为与本改动前逐条相同。
+        iifname "tailscale0" return
         ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 } redirect to :7893
     }
     chain input {
@@ -26,6 +33,13 @@ table inet pdg {
         iif "lo" accept
         ct state established,related accept
         tcp dport { __SSH_PORT__ } accept
+        # Tailscale 入口隔离(理由同 prerouting)。位置是刻意的: 排在 SSH 放行**之后**、
+        # 所有来源匹配**之前** —— 于是经 tailnet 的 SSH 仍然放行(上一行已 accept), 而 tailnet
+        # 到 53/81/853/7893/8445/救援端口的流量走到这里就 return, 由本链 policy drop 收口。
+        # 副作用(有意接受): 从 tailnet **主动发起**的 ICMP 会被 drop, 因为 icmp accept 排在
+        # 来源匹配之后。已建连的回包由上面的 ct established,related 放行, 不受影响;
+        # tailscale ping 走 TSMP 也不受影响。fail-closed 优先。
+        iifname "tailscale0" return
         # 80/443/5228-5230 已在 prerouting 被改写为 7893, 故这里放行 7893(仅内网来源);
         # 53/81/853/8445 仍由各自服务直接监听(mosdns DoT / iOS 探测 / tg-proxy)。
         ip saddr __INTERNAL_CIDR__ tcp dport { 53, 81, 853, 7893, 8445 } accept

--- a/lib/detect-internal-range.sh
+++ b/lib/detect-internal-range.sh
@@ -26,11 +26,36 @@ cat >&2 <<EOF
 ──────────────────────────────────────────────
 EOF
 
+# Tailscale 的节点地址同样落在 100.64.0.0/10 —— 和运营商 CGNAT 用的是同一个段, 只看源地址
+# 分不开。若把 tailnet 的样本当成内网卡来源推成 /16 写进 PDG_INTERNAL_CIDR, nft 的 REDIRECT
+# 就会改挂到 tailnet 上, 管理流量被送进透明代理。所以这里按**入口接口**排除, 不按地址段
+# (按段排除会连真实运营商 CGNAT 一起误伤)。
+#
+# `tcpdump -i any` 从 4.99 起把接口名打在第二个字段。老版本不打 —— 那种情况下我们**拿不到
+# 入口接口这个事实**, 于是无从排除。此时:
+#   · 机器上没有 tailscale0 → 与本改动前完全等价, 照常抓(不因装没装 Tailscale 改变行为);
+#   · 机器上有 tailscale0   → 宁可不猜: 直接失败并让调用方走手输, 而不是冒险选到 tailnet。
+TS_IF="tailscale0"
+have_ts=0; ip -o link show "$TS_IF" >/dev/null 2>&1 && have_ts=1
+ifname_ok=0
+if timeout 3 tcpdump -ni any -c 1 2>/dev/null | grep -qE '^[0-9:.]+ +[A-Za-z][A-Za-z0-9_.:-]* +(In|Out|P|M|B) '; then
+  ifname_ok=1
+fi
+if [[ "$have_ts" == 1 && "$ifname_ok" == 0 ]]; then
+  cat >&2 <<EOF
+ ⚠️  本机存在 $TS_IF, 但这台的 tcpdump 不在 -i any 的输出里给接口名 ——
+     无法把 tailnet 的样本从候选里排除。为避免把 tailnet 地址误认成内网卡来源,
+     这里**不猜**。请直接手输内网卡网段(如 172.22.0.0/16), 或用 PDG_INTERNAL_CIDR 指定。
+EOF
+  echo ""; exit 1
+fi
+
 # 抓"打到网关服务端口(53/80/443/853)或 ICMP"且源/目的在私网/CGNAT 段的包; 不限 SYN, 已建连的 DoT 也能抓到
 src=$(timeout "$DUR" tcpdump -ni any -c 60 \
         '((tcp port 53 or tcp port 80 or tcp port 443 or tcp port 853) or icmp or udp port 53 or udp port 443)
          and (net 10.0.0.0/8 or net 172.16.0.0/12 or net 192.168.0.0/16 or net 100.64.0.0/10)' \
         2>/dev/null \
+      | awk -v ts="$TS_IF" '$2 != ts' \
       | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' \
       | awk -F. '($1==10)||($1==172&&$2>=16&&$2<=31)||($1==192&&$2==168)||($1==100&&$2>=64&&$2<=127)' \
       | grep -vE '\.(255|0)$' \

--- a/tests/e2e-firewall-template-sync.sh
+++ b/tests/e2e-firewall-template-sync.sh
@@ -59,9 +59,13 @@ OLD_SHA="$(sha256sum "$CONF" | cut -d' ' -f1)"
 
 # ── 调**生产函数本身** ────────────────────────────────────────────────────────
 # 只抽函数, 不复制实现; REPO_DIR 指向被测仓库。c_g/c_y 打桩避免颜色码干扰断言。
+# shellcheck disable=SC2034  # 由下面 eval 进来的生产函数读取, 静态分析看不到那层引用
 REPO_DIR="$ROOT"
 # shellcheck disable=SC1090
 eval "$(sed -n '/^_rescue_load()/,/^}/p' "$ROOT/deploy/bot/pdg.sh")" 2>/dev/null || true
+# 判据 helper 必须一并抽出: 第一次调用走 A 态(重建)不碰它, 第二次走 B/C 态才会调 ——
+# 漏了它, 幂等那格会以 command-not-found 的非零失败, 而现象看着像"同步不幂等"。
+eval "$(sed -n '/^_fw_live_has_template_invariants()/,/^}/p' "$ROOT/deploy/bot/pdg.sh")"
 eval "$(sed -n '/^migrate_firewall_template_sync()/,/^}/p' "$ROOT/deploy/bot/pdg.sh")"
 c_g(){ echo "    [prod] $*"; }; c_y(){ echo "    [prod] $*"; }
 
@@ -122,6 +126,6 @@ SHA2="$(sha256sum "$CONF" | cut -d' ' -f1)"; MT2="$(stat -c %Y "$CONF")"
 SIG2="$(nft -j list table inet pdg | python3 -c 'import json,sys,hashlib;d=json.load(sys.stdin)["nftables"];print(hashlib.sha256("".join(json.dumps(x["rule"]["expr"],sort_keys=True) for x in d if "rule" in x).encode()).hexdigest())')"
 [[ "$RC2" == 0 && "$SHA1" == "$SHA2" && "$MT1" == "$MT2" && "$SIG1" == "$SIG2" ]] \
   && ok "二次调用完全幂等(摘要/mtime/内核语义指纹均不变)" \
-  || bad "二次调用不幂等(rc=$RC2 sha:$([[ $SHA1 == $SHA2 ]] && echo 同 || echo 变) mtime:$([[ $MT1 == $MT2 ]] && echo 同 || echo 变) sig:$([[ $SIG1 == $SIG2 ]] && echo 同 || echo 变))"
+  || bad "二次调用不幂等(rc=$RC2 sha:$([[ "$SHA1" == "$SHA2" ]] && echo 同 || echo 变) mtime:$([[ "$MT1" == "$MT2" ]] && echo 同 || echo 变) sig:$([[ "$SIG1" == "$SIG2" ]] && echo 同 || echo 变))"
 
 fin

--- a/tests/e2e-firewall-template-sync.sh
+++ b/tests/e2e-firewall-template-sync.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 防火墙模板同步 —— **真执行**回归。
+#
+# 为什么要单独一支: tests/test-firewall-template-sync.py 验的是静态形状(函数在不在、
+# 挂没挂进调度、顺序对不对、参数 fail-closed)和"两版模板的内核指纹不同"。那些全绿, 却
+# **从没真的调用过这个迁移函数、也没检查过调用之后规则变了没有** —— 于是本地 14/14 全绿,
+# CI 六个升级类 job 全红, 报的还是"缺少 tailscale0 排除规则"。
+#
+# 这支补的就是那一步: 造一台"已装旧版 inet pdg"的真机现场, 调**生产函数本身**(不复制实现),
+# 然后看内核里的规则到底有没有变。
+#
+# 需要真 nft + 真 /etc/nftables.conf + 仓库在 REPO_DIR —— 也就是 E2E 沙箱那种环境。
+# 环境不足就 SKIP 并说明缺什么, 不假装验过。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${PDG_REPO_OVERRIDE:-$(cd "$HERE/.." && pwd)}"
+
+pass=0; nfail=0; nskip=0
+ok(){   echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){  echo "[FAIL] $1"; nfail=$((nfail+1)); }
+skip(){ echo "[SKIP] $1"; nskip=$((nskip+1)); }
+fin(){ echo; echo "──────────────────────────────────────────────"; \
+       echo "通过 $pass, 失败 $nfail, 跳过 $nskip"; exit $(( nfail ? 1 : 0 )); }
+
+command -v nft >/dev/null 2>&1 || { skip "缺 nft"; fin; }
+[[ $EUID -eq 0 ]] || { skip "需要 root(要真加载 nft 并改 /etc/nftables.conf)"; fin; }
+TPL="$ROOT/deploy/firewall/nftables-mihomo.conf"
+[[ -f "$TPL" ]] || { skip "找不到模板 $TPL"; fin; }
+
+CONF=/etc/nftables.conf
+INCD=/etc/privdns-gateway/nft-input.d
+BACKUP="$(mktemp -d)"
+restore(){
+  [[ -f "$BACKUP/nftables.conf" ]] && cp -a "$BACKUP/nftables.conf" "$CONF"
+  rm -f "$INCD/zz-e2e-tplsync.conf"
+  nft -f "$CONF" >/dev/null 2>&1 || true
+  rm -rf "$BACKUP"
+}
+trap restore EXIT
+[[ -f "$CONF" ]] && cp -a "$CONF" "$BACKUP/nftables.conf"
+
+# ── 造"升级前"现场: 已在 inet pdg, 但规则里没有 Tailscale 隔离 ──────────────────
+mkdir -p "$INCD"
+echo 'tcp dport 65000 accept   # e2e 用户自定义规则(必须原样保留)' > "$INCD/zz-e2e-tplsync.conf"
+USER_SHA="$(sha256sum "$INCD/zz-e2e-tplsync.conf" | cut -d' ' -f1)"
+
+port=22; cidr=172.22.0.0/16
+rport="$(python3 "$ROOT/deploy/bot/rescue_const.py" --port 2>/dev/null)"
+[[ -n "$rport" ]] || { skip "读不到救援端口常量"; fin; }
+sed -e "s|__SSH_PORT__|$port|g" -e "s|__INTERNAL_CIDR__|$cidr|g" -e "s|__RESCUE_PORT__|$rport|g" \
+    "$TPL" | grep -v 'iifname "tailscale0"' > "$CONF"
+if ! nft -f "$CONF" >/dev/null 2>&1; then bad "旧版现场加载失败(夹具问题)"; fin; fi
+OLD_SHA="$(sha256sum "$CONF" | cut -d' ' -f1)"
+[[ "$(nft list table inet pdg | grep -c tailscale0)" == 0 ]] \
+  && ok "现场就绪: 已在 inet pdg, 内核里没有 tailscale0 排除规则" \
+  || { bad "现场没造对(内核里已有 tailscale0 规则)"; fin; }
+
+# ── 调**生产函数本身** ────────────────────────────────────────────────────────
+# 只抽函数, 不复制实现; REPO_DIR 指向被测仓库。c_g/c_y 打桩避免颜色码干扰断言。
+REPO_DIR="$ROOT"
+# shellcheck disable=SC1090
+eval "$(sed -n '/^_rescue_load()/,/^}/p' "$ROOT/deploy/bot/pdg.sh")" 2>/dev/null || true
+eval "$(sed -n '/^migrate_firewall_template_sync()/,/^}/p' "$ROOT/deploy/bot/pdg.sh")"
+c_g(){ echo "    [prod] $*"; }; c_y(){ echo "    [prod] $*"; }
+
+set +e
+migrate_firewall_template_sync
+RC=$?
+set -e
+
+[[ "$RC" == 0 ]] && ok "生产函数返回 0" || bad "生产函数返回 $RC(应为 0)"
+
+# ── 直接检查真实结果 ──────────────────────────────────────────────────────────
+NEW_SHA="$(sha256sum "$CONF" | cut -d' ' -f1)"
+[[ "$NEW_SHA" != "$OLD_SHA" ]] && ok "持久规则文件已更新" \
+  || bad "持久规则文件**没变** —— 同步没有真的发生"
+
+k_pre="$(nft -j list table inet pdg 2>/dev/null | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["nftables"]; i=0
+for x in d:
+    r=x.get("rule")
+    if not r or r["chain"]!="prerouting": continue
+    if "tailscale0" in json.dumps(r["expr"]): print(i); break
+    i+=1
+' 2>/dev/null)"
+k_in="$(nft -j list table inet pdg 2>/dev/null | python3 -c '
+import json,sys
+d=json.load(sys.stdin)["nftables"]; i=0; ex=None; sa=None
+for x in d:
+    r=x.get("rule")
+    if not r or r["chain"]!="input": continue
+    e=json.dumps(r["expr"])
+    if "tailscale0" in e and ex is None: ex=i
+    if "\"saddr\"" in e and sa is None: sa=i
+    i+=1
+print("%s %s" % (ex,sa))
+' 2>/dev/null)"
+[[ -n "$k_pre" ]] && ok "内核 prerouting 出现 tailscale0 排除规则(第 $k_pre 条)" \
+  || bad "内核 prerouting **仍没有** tailscale0 排除规则"
+read -r ex sa <<<"$k_in"
+if [[ "$ex" != None && "$sa" != None && "$ex" -lt "$sa" ]]; then
+  ok "内核 input 的排除规则排在来源匹配之前(第 $ex 条 < 第 $sa 条)"
+else
+  bad "内核 input 排除规则缺失或顺序不对(ex=$ex saddr=$sa)"
+fi
+
+[[ -f "$INCD/zz-e2e-tplsync.conf" ]] && \
+  [[ "$(sha256sum "$INCD/zz-e2e-tplsync.conf" | cut -d' ' -f1)" == "$USER_SHA" ]] \
+  && ok "用户 include 文件逐字节保留" || bad "用户 include 被改写或删除"
+nft list table inet pdg 2>/dev/null | grep -q 'dport 65000' \
+  && ok "用户自定义规则仍在内核里生效" || bad "用户自定义规则丢了"
+nft -c -f "$CONF" >/dev/null 2>&1 && ok "同步后的配置 nft -c 通过" || bad "同步后的配置 nft -c 不过"
+
+# ── 幂等 ─────────────────────────────────────────────────────────────────────
+SHA1="$(sha256sum "$CONF" | cut -d' ' -f1)"; MT1="$(stat -c %Y "$CONF")"
+SIG1="$(nft -j list table inet pdg | python3 -c 'import json,sys,hashlib;d=json.load(sys.stdin)["nftables"];print(hashlib.sha256("".join(json.dumps(x["rule"]["expr"],sort_keys=True) for x in d if "rule" in x).encode()).hexdigest())')"
+set +e; migrate_firewall_template_sync; RC2=$?; set -e
+SHA2="$(sha256sum "$CONF" | cut -d' ' -f1)"; MT2="$(stat -c %Y "$CONF")"
+SIG2="$(nft -j list table inet pdg | python3 -c 'import json,sys,hashlib;d=json.load(sys.stdin)["nftables"];print(hashlib.sha256("".join(json.dumps(x["rule"]["expr"],sort_keys=True) for x in d if "rule" in x).encode()).hexdigest())')"
+[[ "$RC2" == 0 && "$SHA1" == "$SHA2" && "$MT1" == "$MT2" && "$SIG1" == "$SIG2" ]] \
+  && ok "二次调用完全幂等(摘要/mtime/内核语义指纹均不变)" \
+  || bad "二次调用不幂等(rc=$RC2 sha:$([[ $SHA1 == $SHA2 ]] && echo 同 || echo 变) mtime:$([[ $MT1 == $MT2 ]] && echo 同 || echo 变) sig:$([[ $SIG1 == $SIG2 ]] && echo 同 || echo 变))"
+
+fin

--- a/tests/e2e-lib.sh
+++ b/tests/e2e-lib.sh
@@ -884,8 +884,22 @@ e2e_seed_mosdns(){
 # 渲染真实防火墙配置(switch-core 要从中提取 SSH 端口)。$1=内核(singbox|mihomo)
 # v1.6.0: 只剩 mihomo 一套模板($1 保留但已无意义, 调用方不必改)。
 e2e_seed_nft(){
-  sed -e "s|__SSH_PORT__|22|g" -e "s|__INTERNAL_CIDR__|$E2E_CIDR|g" -e "s|__SERVER_IP__|$E2E_SIP|g" \
+  # 救援端口取正式常量, 不在这里写字面量 —— 写死一个数字, 常量一改夹具就造出一台
+  # 端口对不上的"机器", 而这正是最难查的那类夹具失真。
+  local _rp; _rp="$(python3 "$E2E_ROOT/deploy/bot/rescue_const.py" --port 2>/dev/null)"
+  if [[ -z "$_rp" ]]; then
+    echo "e2e_seed_nft: 读不到救援端口常量, 无法完整渲染防火墙模板" >&2; return 1
+  fi
+  sed -e "s|__SSH_PORT__|22|g" -e "s|__INTERNAL_CIDR__|$E2E_CIDR|g" -e "s|__RESCUE_PORT__|$_rp|g" \
       "$E2E_ROOT/deploy/firewall/nftables-mihomo.conf" > /etc/nftables.conf
+  # fail-closed: 真机装完不会留下未替换的占位符, 沙箱也不许。漏一个就当场失败 ——
+  # 上一次漏的是 __RESCUE_PORT__, 后果是六个升级类 E2E 同时红而现象指向别处。
+  # 只报 token 名, 不回显渲染后的配置内容。
+  local _left
+  _left="$(grep -oE '__[A-Z][A-Z0-9_]*__' /etc/nftables.conf | sort -u | tr '\n' ' ')"
+  if [[ -n "${_left// /}" ]]; then
+    echo "e2e_seed_nft: 模板未完整渲染, 残留占位符: $_left" >&2; return 1
+  fi
   # 真机上装完会 `nft -f` 应用一次, 内核里于是有这份规则。桩的"内核状态"同步过去,
   # 否则磁盘有、内核空, doctor 会如实判"读不到内核规则"——那是夹具不像真的。
   cp /etc/nftables.conf "$E2E_TMP/e2e-nft-ruleset" 2>/dev/null || true

--- a/tests/negctl/live-convergence-negative-controls.py
+++ b/tests/negctl/live-convergence-negative-controls.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""磁盘/内核收敛判据的负控: 把三态逐项改坏, 守卫必须转红。
+
+纪律与其它 negctl 一致: 锚点命中且只命中一次; 语法损坏不算有效红; 反向格必须仍绿;
+收尾证明正式树逐字节、mode、git 状态干净。在工作副本里改, 不碰正式树。
+"""
+import hashlib, os, re, shutil, subprocess, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import tmpguard
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+PDG = "deploy/bot/pdg.sh"
+TEST = "tests/test-firewall-live-drift.py"
+TOUCHED = [PDG]
+npass = nfail = 0
+
+
+def ok(m):
+    global npass; npass += 1; print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail; nfail += 1; print("[FAIL] %s" % m)
+
+
+def sha(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for c in iter(lambda: f.read(65536), b""): h.update(c)
+    return h.hexdigest()
+
+
+if os.geteuid() != 0 and subprocess.run("sudo -n true", shell=True,
+                                        capture_output=True).returncode != 0:
+    print("[SKIP] 需要 root 或免密 sudo —— 这支要真建 netns 并加载 nft")
+    print("\n有效 0, 失败 0"); sys.exit(0)
+
+BASE_SHA = {r: sha(os.path.join(ROOT, r)) for r in TOUCHED}
+MODE = {r: os.stat(os.path.join(ROOT, r)).st_mode & 0o777 for r in TOUCHED}
+WCROOT = tmpguard.mkdtemp(prefix="pdg-lcnc-")
+WC = os.path.join(WCROOT, "repo")
+shutil.copytree(ROOT, WC, symlinks=True,
+                ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+
+
+def run_suite():
+    p = subprocess.run("python3 %s" % os.path.join(WC, TEST), shell=True,
+                       capture_output=True, text=True, cwd=WC)
+    out = (p.stdout or "") + (p.stderr or "")
+    fails = [L for L in out.splitlines() if L.startswith("[FAIL]")]
+    m = re.search(r"通过 (\d+), 失败 (\d+)", out)
+    return (int(m.group(1)) if m else -1), fails, out
+
+
+print("── 基线: 修复到位时必须全绿 ──")
+b_pass, b_fails, b_out = run_suite()
+if b_fails or b_pass <= 0:
+    bad("基线不绿(通过 %d, 失败 %d), 后面每格都无从判断" % (b_pass, len(b_fails)))
+    for L in b_fails[:3]: print("       " + L[:100])
+    sys.exit(1)
+ok("基线绿: 通过 %d, 失败 0" % b_pass)
+
+
+def cell(n, name, old, new, want, expect_red=True):
+    path = os.path.join(WC, PDG)
+    with open(path, encoding="utf-8") as f: src = f.read()
+    if src.count(old) != 1:
+        bad("NC-LC-%d %s → 锚点命中 %d 次, 预期 1" % (n, name, src.count(old))); return
+    with open(path, "w", encoding="utf-8") as f: f.write(src.replace(old, new, 1))
+    try:
+        if subprocess.run("bash -n %s" % path, shell=True, capture_output=True).returncode != 0:
+            bad("NC-LC-%d %s → 改坏后语法不合法, 不算有效负控" % (n, name)); return
+        np_, fails, out = run_suite()
+        if "Traceback" in out:
+            bad("NC-LC-%d %s → Traceback, 不算转红" % (n, name)); return
+        if not expect_red:
+            (ok if not fails else bad)(
+                "NC-LC-%d %-26s → %s" % (n, name, "仍全绿(通过 %d)" % np_ if not fails
+                                         else "**不该红却红了**: " + fails[0][:60])); return
+        if not fails:
+            bad("NC-LC-%d %s → **没有新增失败**, 这条判据没有守卫" % (n, name)); return
+        if want and not any(want in L for L in fails):
+            bad("NC-LC-%d %s → 转红但没点名 %r: %s" % (n, name, want, fails[0][:70])); return
+        ok("NC-LC-%d %-26s → 转红 %d 条: %s" % (n, name, len(fails), fails[0][7:80]))
+    finally:
+        with open(path, "w", encoding="utf-8") as f: f.write(src)
+
+
+NOOP = '''    if _fw_live_has_template_invariants; then
+      return 0                     # B 态: 磁盘新、内核新 —— 真 no-op, 不写盘不加载
+    fi'''
+RECHECK = '''    if ! _fw_live_has_template_invariants; then
+      c_y "重新加载后内核仍未收敛到模板承诺的规则 —— 不当作成功, 请人工检查。"
+      return 1
+    fi'''
+PRECHECK = '''    if ! nft -c -f "$f" >/dev/null 2>&1; then
+      c_y "内核规则落后于磁盘, 但磁盘配置 nft -c 未过 → 不加载, 请人工检查。"
+      return 1
+    fi'''
+
+# 1) 退回"磁盘相同就直接 no-op" → C 态红灯必须转红
+cell(1, "退回磁盘相同即 no-op", NOOP + "\n", "    return 0\n", "内核")
+# 2) 摘掉 reload 后复核 → 不收敛时不再被抓
+cell(2, "摘掉 reload 后复核", RECHECK + "\n", "", "")
+# 3) B 态改成无条件 reload → 幂等/不写盘判据必须转红
+cell(3, "B 态改成无条件 reload", NOOP, "    :", "")
+# 4) 不设此格: reload 前那道 nft -c 守的是**不可达状态**。
+#    C 态成立的前提是"磁盘 == 候选", 而候选是模板渲染的产物, 必然通过 nft -c。
+#    把磁盘改成非法就不再等于候选, 函数走 A 态去了 —— 那验的是别的分支。
+#    留着那道检查是纵深防御, 但这里不假装能触发它: 造不出的红不算负控。
+# 5) reload 失败仍返回 0
+cell(5, "reload 失败仍返回 0",
+     '      c_y "防火墙重新加载失败 —— 内核仍是加载前那份, 磁盘未动。"\n      return 1',
+     '      c_y "防火墙重新加载失败 —— 内核仍是加载前那份, 磁盘未动。"\n      return 0', "")
+# 6) 反向格: 无关注释
+cell(6, "追加无关注释", "migrate_firewall_template_sync(){\n",
+     "migrate_firewall_template_sync(){\n  # 负控用的无关注释\n", "", expect_red=False)
+
+print("\n── 收尾 ──")
+for rel in TOUCHED:
+    (ok if sha(os.path.join(ROOT, rel)) == BASE_SHA[rel] else bad)("正式树 %s 逐字节一致" % rel)
+    (ok if os.stat(os.path.join(ROOT, rel)).st_mode & 0o777 == MODE[rel] else bad)(
+        "%s mode 恢复为 %o" % (rel, MODE[rel]))
+g = subprocess.run("git -C %s status --porcelain -- %s" % (ROOT, PDG),
+                   shell=True, capture_output=True, text=True)
+(ok if not g.stdout.strip() else bad)("git 干净: %s" % (g.stdout.strip() or "(是)"))
+shutil.rmtree(WCROOT, ignore_errors=True)
+print("\n" + "─" * 62); print("有效 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/negctl/seed-render-negative-controls.py
+++ b/tests/negctl/seed-render-negative-controls.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""E2E 夹具渲染闭包判据的负控: 把修复逐项改坏, 守卫必须转红。
+
+纪律与 firewall-render-negative-controls.py 一致:
+  · 改坏器必须**命中且只命中一次**; 打空了却"看见红"证明红来自别处。
+  · 语法损坏造成的红不算 —— 那证明的是"bash 不认识乱码", 不是判据在守卫。
+  · 反向格: 无关改动必须仍绿, 否则判据认的是"任何改动"而非语义。
+  · 收尾必须证明正式树逐字节、mode、git 状态都没被弄脏。
+
+在工作副本里改, 不碰正式树。
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import tmpguard
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+LIB = "tests/e2e-lib.sh"
+TPL = "deploy/firewall/nftables-mihomo.conf"
+TEST = "tests/test-e2e-seed-render.py"
+TOUCHED = [LIB, TPL]
+
+npass = nfail = 0
+
+
+def ok(m):
+    global npass
+    npass += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail
+    nfail += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for c in iter(lambda: f.read(65536), b""):
+            h.update(c)
+    return h.hexdigest()
+
+
+BASE_SHA = {r: sha(os.path.join(ROOT, r)) for r in TOUCHED}
+MODE = {r: os.stat(os.path.join(ROOT, r)).st_mode & 0o777 for r in TOUCHED}
+
+WCROOT = tmpguard.mkdtemp(prefix="pdg-seednc-")
+WC = os.path.join(WCROOT, "repo")
+shutil.copytree(ROOT, WC, symlinks=True,
+                ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+
+
+def run_guard():
+    p = subprocess.run("python3 %s" % os.path.join(WC, TEST), shell=True,
+                       capture_output=True, text=True, cwd=WC)
+    out = (p.stdout or "") + (p.stderr or "")
+    fails = [L for L in out.splitlines() if L.startswith("[FAIL]")]
+    m = re.search(r"通过 (\d+), 失败 (\d+)", out)
+    return (int(m.group(1)) if m else -1), fails, out
+
+
+print("── 基线: 修复到位时守卫必须全绿 ──")
+b_pass, b_fails, b_out = run_guard()
+if b_fails:
+    bad("基线就红了(%d 条), 后面每格都无从判断" % len(b_fails))
+    for L in b_fails[:3]:
+        print("       " + L[:100])
+    sys.exit(1)
+if b_pass <= 0:
+    bad("基线一条断言都没跑出来 —— '0 条失败'不等于绿")
+    sys.exit(1)
+ok("基线绿: 通过 %d, 失败 0" % b_pass)
+
+
+def cell(n, name, rel, old, new, want, expect_red=True):
+    path = os.path.join(WC, rel)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    hits = src.count(old)
+    if hits != 1:
+        bad("NC-SR-%d %s → 锚点命中 %d 次, 预期 1(改坏器没打在预期位置)" % (n, name, hits))
+        return
+    before = sha(path)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(src.replace(old, new, 1))
+    if sha(path) == before:
+        bad("NC-SR-%d %s → 摘要没变, mutation 没生效" % (n, name))
+        return
+    try:
+        if rel == LIB:
+            p = subprocess.run("bash -n %s" % path, shell=True, capture_output=True)
+            if p.returncode != 0:
+                bad("NC-SR-%d %s → 改坏后 shell 语法不合法, 这格不算有效负控" % (n, name))
+                return
+        np_, fails, out = run_guard()
+        if "Traceback" in out:
+            bad("NC-SR-%d %s → 出现 Traceback, 不算转红" % (n, name))
+            return
+        if not expect_red:
+            if fails:
+                bad("NC-SR-%d %s → **不该红却红了**(%s)" % (n, name, fails[0][:70]))
+            else:
+                ok("NC-SR-%d %-30s → 仍全绿(通过 %d), 判据认的是语义" % (n, name, np_))
+            return
+        if not fails:
+            bad("NC-SR-%d %s → **没有新增失败**, 这条判据没有守卫" % (n, name))
+            return
+        if want and not any(want in L for L in fails):
+            bad("NC-SR-%d %s → 转红但没点名 %r: %s" % (n, name, want, fails[0][:80]))
+            return
+        ok("NC-SR-%d %-30s → 转红 %d 条: %s" % (n, name, len(fails), fails[0][7:86]))
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+SUB = '-e "s|__RESCUE_PORT__|$_rp|g" '
+GUARD = '''  local _left
+  _left="$(grep -oE '__[A-Z][A-Z0-9_]*__' /etc/nftables.conf | sort -u | tr '\\n' ' ')"
+  if [[ -n "${_left// /}" ]]; then
+    echo "e2e_seed_nft: 模板未完整渲染, 残留占位符: $_left" >&2; return 1
+  fi'''
+
+# 1) 摘掉 __RESCUE_PORT__ 替换 → 闭包判据必须转红
+cell(1, "摘掉 RESCUE_PORT 替换", LIB, SUB, "", "__RESCUE_PORT__")
+
+# 2) 连守卫一起摘掉 → 端口来源判据仍须转红(证明不是只靠守卫兜着)
+def cell2():
+    path = os.path.join(WC, LIB)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    if src.count(SUB) != 1 or src.count(GUARD) != 1:
+        bad("NC-SR-2 锚点命中 sub=%d guard=%d, 预期 1/1" % (src.count(SUB), src.count(GUARD)))
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(src.replace(SUB, "", 1).replace(GUARD, "", 1))
+    try:
+        if subprocess.run("bash -n %s" % path, shell=True, capture_output=True).returncode != 0:
+            bad("NC-SR-2 改坏后语法不合法, 不算有效负控")
+            return
+        np_, fails, out = run_guard()
+        if "Traceback" in out:
+            bad("NC-SR-2 出现 Traceback")
+        elif any("漏渲染" in L or "来源不明" in L or "没有替换" in L for L in fails):
+            ok("NC-SR-2 摘掉替换+守卫              → 仍转红 %d 条: %s" % (len(fails), fails[0][7:82]))
+        else:
+            bad("NC-SR-2 摘掉替换和守卫后**没红** —— 判据全靠守卫兜着, 闭包本身没牙")
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+cell2()
+
+# 3) 模板新增一个合成占位符 → 闭包判据必须发现夹具没跟进
+cell(3, "模板新增合成占位符", TPL,
+     "        ip saddr __INTERNAL_CIDR__ udp dport { 53 } accept",
+     "        ip saddr __INTERNAL_CIDR__ udp dport { 53 } accept\n"
+     "        ip saddr __INTERNAL_CIDR__ tcp dport __SYNTHETIC_PORT__ accept",
+     "漏渲染")
+
+# 4) 救援端口渲染成写死的错误值 → 来源判据必须转红(不能只看 token 消失)
+cell(4, "救援端口写成字面量", LIB, '-e "s|__RESCUE_PORT__|$_rp|g" ',
+     '-e "s|__RESCUE_PORT__|9999|g" ', "字面量")
+
+# 5) 摘掉守卫本身 → 守卫存在性判据必须转红
+cell(5, "摘掉残留占位符守卫", LIB, GUARD, "", "守卫")
+
+# 6) 反向格: 无关注释必须仍绿
+cell(6, "追加无关注释", LIB, "e2e_seed_nft(){\n",
+     "e2e_seed_nft(){\n  # 负控用的无关注释, 不改变任何行为\n", "", expect_red=False)
+
+# 7) 反向格: 模板里加注释也必须仍绿
+cell(7, "模板加无关注释", TPL, "table inet pdg {\n",
+     "table inet pdg {\n    # 负控用的无关注释\n", "", expect_red=False)
+
+print("\n── 收尾: 正式树必须毫发无损 ──")
+for rel in TOUCHED:
+    (ok if sha(os.path.join(ROOT, rel)) == BASE_SHA[rel] else bad)("正式树 %s 逐字节一致" % rel)
+    (ok if os.stat(os.path.join(ROOT, rel)).st_mode & 0o777 == MODE[rel] else bad)(
+        "%s mode 恢复为 %o" % (rel, MODE[rel]))
+g = subprocess.run("git -C %s status --porcelain -- %s" % (ROOT, " ".join(TOUCHED)),
+                   shell=True, capture_output=True, text=True)
+(ok if not g.stdout.strip() else bad)("已跟踪文件无改动: %s" % (g.stdout.strip() or "(干净)"))
+shutil.rmtree(WCROOT, ignore_errors=True)
+
+print("\n" + "─" * 66)
+print("有效 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/negctl/tailscale-isolation-negative-controls.py
+++ b/tests/negctl/tailscale-isolation-negative-controls.py
@@ -18,7 +18,9 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+import tmpguard          # 一次性临时目录: 建了就登记, 退出即清
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
@@ -60,7 +62,7 @@ if os.geteuid() != 0 and subprocess.run(
     print("\n有效 0, 失败 0")
     sys.exit(0)
 
-WCROOT = tempfile.mkdtemp(prefix="pdg-ts-nc-")
+WCROOT = tmpguard.mkdtemp(prefix="pdg-ts-nc-")
 WC = os.path.join(WCROOT, "repo")
 shutil.copytree(ROOT, WC, symlinks=True,
                 ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))

--- a/tests/negctl/tailscale-isolation-negative-controls.py
+++ b/tests/negctl/tailscale-isolation-negative-controls.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Tailscale 入口隔离判据的负控: 把修复逐项改坏, 守卫必须转红。
+
+判断一支测试有没有牙齿的唯一办法, 是把被测的修复撤掉再看它红不红 —— 这个仓库里
+反复出现过"测试全绿但其实什么都没守住"的情况, 所以每条判据都要在这里过一遍。
+
+纪律(与 firewall-render-negative-controls.py 一致):
+  · 改坏器必须**命中且只命中一次**。打空了却"看见红"是假阳性, 那说明红来自别处。
+  · 语法错误造成的红不算数 —— 那证明的是"nft 不认识乱码", 不是"判据在守卫"。
+  · 反向格: 无关改动(注释)必须**仍然全绿**, 否则判据认的是"任何改动"而不是语义。
+  · 收尾必须证明正式树逐字节、mode、git 状态都没被这支测试弄脏。
+
+在工作副本里改, 不碰正式树。
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+TEST = "tests/test-tailscale-ingress-isolation.py"
+NFT = "deploy/firewall/nftables-mihomo.conf"
+DET = "lib/detect-internal-range.sh"
+CHK = "deploy/bot/checks.py"
+TOUCHED = [NFT, DET, CHK]
+
+npass = nfail = 0
+
+
+def ok(m):
+    global npass
+    npass += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail
+    nfail += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        for c in iter(lambda: f.read(65536), b""):
+            h.update(c)
+    return h.hexdigest()
+
+
+BASE_SHA = {r: sha(os.path.join(ROOT, r)) for r in TOUCHED}
+MODE = {r: os.stat(os.path.join(ROOT, r)).st_mode & 0o777 for r in TOUCHED}
+
+if os.geteuid() != 0 and subprocess.run(
+        "sudo -n true", shell=True, capture_output=True).returncode != 0:
+    print("[SKIP] 需要 root 或免密 sudo —— 这支要真加载 nft 才有判据")
+    print("\n有效 0, 失败 0")
+    sys.exit(0)
+
+WCROOT = tempfile.mkdtemp(prefix="pdg-ts-nc-")
+WC = os.path.join(WCROOT, "repo")
+shutil.copytree(ROOT, WC, symlinks=True,
+                ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+
+
+def run_suite():
+    """在工作副本里跑隔离测试, 返回 (通过数, 失败行列表)。"""
+    p = subprocess.run("python3 %s" % os.path.join(WC, TEST), shell=True,
+                       capture_output=True, text=True, cwd=WC)
+    out = (p.stdout or "") + (p.stderr or "")
+    fails = [L for L in out.splitlines() if L.startswith("[FAIL]")]
+    m = re.search(r"通过 (\d+), 失败 (\d+)", out)
+    npass_ = int(m.group(1)) if m else -1
+    return npass_, fails, out
+
+
+print("── 基线: 修复到位时必须全绿, 且动态段真的跑了 ──")
+b_pass, b_fails, b_out = run_suite()
+if b_fails:
+    bad("基线就红了(%d 条), 后面每格都无从判断" % len(b_fails))
+    for L in b_fails[:4]:
+        print("       " + L[:100])
+    sys.exit(1)
+if b_pass <= 0:
+    bad("基线一条断言都没跑出来 —— '0 条失败'不等于绿")
+    sys.exit(1)
+if "真 netns 流量" not in b_out:
+    bad("动态 netns 段被跳过了 —— 这支必须在能建 netns 的环境里跑")
+    sys.exit(1)
+ok("基线绿: 通过 %d, 失败 0, 且真流量段确实执行了" % b_pass)
+
+
+def cell(n, name, rel, old, new, want, expect_red=True):
+    """改坏一处 → 跑 → 判断是否按预期转红 → 恢复。"""
+    path = os.path.join(WC, rel)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    hits = src.count(old)
+    if hits != 1:
+        bad("NC-TS-%d %s → 锚点命中 %d 次, 预期 1(改坏器没打在预期位置)" % (n, name, hits))
+        return
+    before = sha(path)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(src.replace(old, new, 1))
+    if sha(path) == before:
+        bad("NC-TS-%d %s → 摘要没变, mutation 没生效" % (n, name))
+        return
+    try:
+        # 语法门: 改坏后本身就不合法的话, 红灯证明不了判据在守卫
+        if rel == DET:
+            p = subprocess.run("bash -n %s" % path, shell=True, capture_output=True)
+            if p.returncode != 0:
+                bad("NC-TS-%d %s → 改坏后 shell 语法不合法, 这格不算有效负控" % (n, name))
+                return
+        if rel == CHK:
+            p = subprocess.run("python3 -m py_compile %s" % path, shell=True,
+                               capture_output=True)
+            if p.returncode != 0:
+                bad("NC-TS-%d %s → 改坏后 python 语法不合法, 这格不算有效负控" % (n, name))
+                return
+        np_, fails, out = run_suite()
+        if "Traceback" in out:
+            bad("NC-TS-%d %s → 出现 Traceback, 不算转红" % (n, name))
+            return
+        if not expect_red:
+            if fails:
+                bad("NC-TS-%d %s → **不该红却红了**(%s) —— 判据该认语义不认任何改动"
+                    % (n, name, fails[0][:70]))
+            else:
+                ok("NC-TS-%d %-28s → 仍全绿(通过 %d), 判据认的是语义" % (n, name, np_))
+            return
+        if not fails:
+            bad("NC-TS-%d %s → **没有新增失败**, 这条判据没有守卫" % (n, name))
+            return
+        if want and not any(want in L for L in fails):
+            bad("NC-TS-%d %s → 转红但没点名 %r: %s" % (n, name, want, fails[0][:80]))
+            return
+        ok("NC-TS-%d %-28s → 转红 %d 条: %s" % (n, name, len(fails), fails[0][7:88]))
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+TS_PRE = '        iifname "tailscale0" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 } redirect to :7893'
+TS_IN = '        iifname "tailscale0" return\n        # 80/443/5228-5230 已在 prerouting 被改写为 7893'
+
+# 1) 只撤掉 prerouting 的排除。
+#    注意这里**动态流量不会漏** —— input 的排除仍在, 会把改写后的包收口, 两道排除构成
+#    纵深防御。所以这一格的判据只能是静态门。要证明真流量能进 REDIRECT, 见第 2b 格。
+cell(1, "撤掉 prerouting 排除", NFT,
+     TS_PRE,
+     '        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 } redirect to :7893',
+     "prerouting")
+
+# 2) 只撤掉 input 的排除 → tailnet 进 DNS 接管链
+cell(2, "撤掉 input 排除", NFT,
+     TS_IN,
+     '        # 80/443/5228-5230 已在 prerouting 被改写为 7893',
+     "DNS 接管链")
+
+# 2b) 两道排除**一起**撤掉 → 真 netns 流量确实进 REDIRECT 落到 7893 的监听上。
+#     这一格才是"真流量证据", 前两格证的是静态门。
+def cell_both():
+    path = os.path.join(WC, NFT)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    n = src.count('        iifname "tailscale0" return\n')
+    if n != 2:
+        bad("NC-TS-2b 锚点命中 %d 次, 预期 2" % n)
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(src.replace('        iifname "tailscale0" return\n', "", 2))
+    try:
+        np_, fails, out = run_suite()
+        if "Traceback" in out:
+            bad("NC-TS-2b 出现 Traceback, 不算转红")
+        elif any("REDIRECT" in L for L in fails):
+            ok("NC-TS-2b 两道排除全撤            → 真流量进 REDIRECT: %s"
+               % [L for L in fails if "REDIRECT" in L][0][7:88])
+        else:
+            bad("NC-TS-2b 全撤之后真流量**仍没进** REDIRECT —— 动态判据没有牙齿")
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+cell_both()
+
+# 3) 把排除挪到来源匹配之后 → 顺序门必须转红(且真流量也该漏)
+cell(3, "排除挪到来源匹配之后", NFT,
+     TS_PRE,
+     '        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 } redirect to :7893\n'
+     '        iifname "tailscale0" return',
+     "之后")
+
+# 4) 过度排除: 把判据改成"除物理口外全排除" → 合法运营商 CGNAT 那格必须转红。
+#    这一格防的是"用一个大而泛的虚拟网卡排除框架顺手把真实来源也挡了"。
+cell(4, "过度排除(除 lo 外全挡)", NFT,
+     '        iifname "tailscale0" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 }',
+     '        iifname != "lo" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 }',
+     "破坏了既有运营商支持")
+
+# 5) 用 iif 代替 iifname → 接口不存在时整份规则加载失败
+cell(5, "iif 代替 iifname", NFT,
+     '        iifname "tailscale0" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 }',
+     '        iif "tailscale0" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 }',
+     "")
+
+# 6) 反向格: 无关注释必须仍全绿
+cell(6, "追加无关注释", NFT,
+     "table inet pdg {\n",
+     "table inet pdg {\n    # 负控用的无关注释, 不改变任何行为\n",
+     "", expect_red=False)
+
+# ── 检测器一侧(不依赖 netns, 单独判)────────────────────────────────────────
+print("\n── 检测器: 撤掉 tailscale0 排除必须可检出 ──")
+det = os.path.join(WC, DET)
+with open(det, encoding="utf-8") as f:
+    dsrc = f.read()
+# 整行删掉(含行首管道与行尾续行符), 而不是把中段挖空 —— 挖空会留下 `| | grep`,
+# 那是语法错误, 红灯来自 bash 而不是判据, 不算有效负控。
+anchor = '      | awk -v ts="$TS_IF" \'$2 != ts\' \\\n'
+if dsrc.count(anchor) != 1:
+    bad("NC-TS-7 检测器锚点命中 %d 次, 预期 1" % dsrc.count(anchor))
+else:
+    with open(det, "w", encoding="utf-8") as f:
+        f.write(dsrc.replace(anchor, "", 1))
+    p = subprocess.run("bash -n %s" % det, shell=True, capture_output=True)
+    if p.returncode != 0:
+        bad("NC-TS-7 改坏后 shell 语法不合法, 不算有效负控")
+    else:
+        still = 'awk -v ts="$TS_IF"' in open(det, encoding="utf-8").read()
+        if still:
+            bad("NC-TS-7 排除仍在, mutation 没生效")
+        else:
+            ok("NC-TS-7 撤掉检测器排除            → 抓包结果不再按接口过滤(语法仍合法, 是真的改坏了)")
+    with open(det, "w", encoding="utf-8") as f:
+        f.write(dsrc)
+
+# ── 收尾 ──────────────────────────────────────────────────────────────────────
+print("\n── 收尾: 正式树必须毫发无损 ──")
+for rel in TOUCHED:
+    p = os.path.join(ROOT, rel)
+    (ok if sha(p) == BASE_SHA[rel] else bad)("正式树 %s 逐字节一致" % rel)
+    (ok if os.stat(p).st_mode & 0o777 == MODE[rel] else bad)(
+        "%s mode 恢复为 %o" % (rel, MODE[rel]))
+# 只看**已跟踪文件有没有被改动**。未跟踪文件不算脏 —— 这支自己第一次跑时就还没被提交,
+# 把 `??` 也算进去会让它必然自我判红。
+g = subprocess.run("git -C %s status --porcelain" % ROOT, shell=True,
+                   capture_output=True, text=True)
+dirty = [L for L in g.stdout.splitlines() if L and not L.startswith("??")]
+(ok if not dirty else bad)(
+    "已跟踪文件无改动(这支没弄脏仓库)%s" % ("" if not dirty else ": " + "; ".join(dirty[:3])))
+
+shutil.rmtree(WCROOT, ignore_errors=True)
+print("\n" + "─" * 66)
+print("有效 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/negctl/tailscale-isolation-negative-controls.py
+++ b/tests/negctl/tailscale-isolation-negative-controls.py
@@ -148,6 +148,75 @@ def cell(n, name, rel, old, new, want, expect_red=True):
 
 TS_PRE = '        iifname "tailscale0" return\n        ip saddr __INTERNAL_CIDR__ tcp dport { 80, 443, 5228-5230 } redirect to :7893'
 TS_IN = '        iifname "tailscale0" return\n        # 80/443/5228-5230 已在 prerouting 被改写为 7893'
+ICMP_BLOCK = ('        ip protocol icmp accept\n'
+              '        ip6 nexthdr icmpv6 accept\n')
+
+# 0a) 把 tailnet return 挪回 ICMP **之前** —— 这正是上一轮的形态。ICMP 管理可达性必须转红,
+#     而数据面隔离仍然成立(所以这一格证明的是"顺序错了", 不是"隔离没了")。
+def cell_icmp_before():
+    path = os.path.join(WC, NFT)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    old = ICMP_BLOCK + '        # Tailscale 入口隔离'
+    if src.count(old) != 1:
+        bad("NC-TS-0a 锚点命中 %d 次, 预期 1" % src.count(old))
+        return
+    # 先摘掉 ICMP 两行, 再把它们插到 return 之后 → 等价于 return 挪到 ICMP 之前
+    mutated = src.replace(ICMP_BLOCK, "", 1).replace(
+        '        iifname "tailscale0" return\n        # 80/443',
+        '        iifname "tailscale0" return\n' + ICMP_BLOCK + '        # 80/443', 1)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(mutated)
+    try:
+        np_, fails, out = run_suite()
+        if "Traceback" in out:
+            bad("NC-TS-0a 出现 Traceback, 不算转红")
+        elif any("ICMP" in L for L in fails):
+            hit = [L for L in fails if "ICMP" in L]
+            ok("NC-TS-0a return 挪回 ICMP 之前     → ICMP 可达性转红 %d 条: %s"
+               % (len(hit), hit[0][7:80]))
+        else:
+            bad("NC-TS-0a return 挪回 ICMP 之前, ICMP 那几格**没红** —— 可达性判据没有牙齿")
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+cell_icmp_before()
+
+
+# 0b) 把 return 挪到**全部数据面规则之后** → 隔离整个失效: DNS/受保护端口格必须转红。
+def cell_after_dataplane():
+    path = os.path.join(WC, NFT)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    ret = '        iifname "tailscale0" return\n'
+    tail = '        ip saddr __INTERNAL_CIDR__ udp dport 443 reject'
+    if src.count(ret) != 2 or src.count(tail) != 1:
+        bad("NC-TS-0b 锚点命中 return=%d tail=%d, 预期 2/1" % (src.count(ret), src.count(tail)))
+        return
+    # 只动 input 那一条(第二处), prerouting 的保持不动
+    head, sep, rest = src.partition('        # Tailscale 入口隔离')
+    rest = rest.replace(ret, "", 1)
+    rest = rest.replace(tail, ret + tail, 1)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(head + sep + rest)
+    try:
+        np_, fails, out = run_suite()
+        if "Traceback" in out:
+            bad("NC-TS-0b 出现 Traceback, 不算转红")
+        elif any(("DNS 接管链" in L or "受保护端口" in L) for L in fails):
+            hit = [L for L in fails if "DNS 接管链" in L or "受保护端口" in L]
+            ok("NC-TS-0b return 挪到数据面之后    → 隔离失效转红 %d 条: %s"
+               % (len(hit), hit[0][7:80]))
+        else:
+            bad("NC-TS-0b return 挪到数据面之后, 隔离格**没红** —— 顺序判据没有牙齿")
+    finally:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(src)
+
+
+cell_after_dataplane()
 
 # 1) 只撤掉 prerouting 的排除。
 #    注意这里**动态流量不会漏** —— input 的排除仍在, 会把改写后的包收口, 两道排除构成

--- a/tests/nftjson.py
+++ b/tests/nftjson.py
@@ -29,6 +29,11 @@ _SADDR = re.compile(r"\bip\s+saddr\s+(?P<cidr>[0-9.]+/[0-9]+)")
 _DADDR = re.compile(r"\bip\s+daddr\s+(?P<ip>[0-9.]+)")
 _DPORT = re.compile(r"\b(?P<proto>tcp|udp)\s+dport\s+(?:\{(?P<set>[^}]*)\}|(?P<one>\d+))")
 _REDIR = re.compile(r"\bredirect\s+to\s+:?(?P<port>\d+)")
+# iif 与 iifname 是**两个**匹配: 前者按接口索引(加载时解析), 后者按名字(运行时比对)。
+# 只认 iif 会让 `iifname "x" ...` 的接口条件被静默丢掉 —— 规则还在, 匹配没了, 而那是
+# 最会骗人的失真形态: 判据按接口名去找就永远找不到, 内核里其实有。
+# 先匹配 iifname(更长的那个), 否则 \biif 会先命中 iifname 的前三个字符。
+_IIFNAME = re.compile(r'\biifname\s+"(?P<dev>[^"]+)"')
 _IIF = re.compile(r'\biif\s+"(?P<dev>[^"]+)"')
 _CT = re.compile(r"\bct\s+state\s+(?P<states>[\w,]+)")
 _PROTO = re.compile(r"\bip6?\s+(?:protocol|nexthdr)\s+(?P<p>[\w-]+)")
@@ -66,10 +71,15 @@ def _match(proto, field, right):
 def _rule_expr(line):
     """一行规则 → expr 列表。认不出来的返回 None(跳过, 不猜)。"""
     expr = []
-    m = _IIF.search(line)
+    m = _IIFNAME.search(line)
     if m:
-        expr.append({"match": {"op": "==", "left": {"meta": {"key": "iif"}},
+        expr.append({"match": {"op": "==", "left": {"meta": {"key": "iifname"}},
                                "right": m.group("dev")}})
+    else:
+        m = _IIF.search(line)
+        if m:
+            expr.append({"match": {"op": "==", "left": {"meta": {"key": "iif"}},
+                                   "right": m.group("dev")}})
     m = _CT.search(line)
     if m:
         expr.append({"match": {"op": "in", "left": {"ct": {"key": "state"}},

--- a/tests/test-e2e-seed-render.py
+++ b/tests/test-e2e-seed-render.py
@@ -115,10 +115,15 @@ else:
     bad("救援端口的替换值来源不明(既非字面量也非 rescue_const.py)")
 
 print("\n── 五、fail-closed 守卫: 渲染后残留任何 token 都必须让夹具失败 ──")
-if re.search(r"__\[A-Z\]\[A-Z0-9_\]\*__|残留.*占位符|未替换的占位符", seed):
-    ok("夹具带残留占位符守卫")
+# 只看代码行: 注释里写着"残留占位符"不构成守卫 —— 摘掉代码留下注释, 判据必须仍能发现。
+seed_code = "\n".join(L for L in seed.splitlines() if not L.strip().startswith("#"))
+has_scan = re.search(r"grep\s+-oE\s+'__\[A-Z\]", seed_code) is not None
+has_fail = re.search(r"return 1", seed_code) is not None
+if has_scan and has_fail:
+    ok("夹具带残留占位符守卫(真有扫描+非零返回, 不是注释)")
 else:
-    bad("夹具没有残留占位符守卫 —— 将来模板新增 token 又会静默漏渲染")
+    bad("夹具没有残留占位符守卫(扫描=%s 非零返回=%s) —— 模板新增 token 会静默漏渲染"
+        % (has_scan, has_fail))
 
 print("\n" + "─" * 62)
 print("通过 %d, 失败 %d" % (npass, nfail))

--- a/tests/test-e2e-seed-render.py
+++ b/tests/test-e2e-seed-render.py
@@ -91,13 +91,28 @@ if residue:
 else:
     ok("渲染产物无残留占位符")
 
-print("\n── 四、救援端口必须能被反解成数字 ──")
-# 这正是 migrate_firewall_template_sync 用的那条反解, 不另写一套
-rp = re.findall(r"ip saddr \S+ tcp dport (\d+) accept", rendered)
-if rp:
-    ok("救援端口可反解为数字: 共 %d 处" % len(rp))
+print("\n── 四、救援端口的值必须来自正式常量, 且能解析成数字 ──")
+# 上面第三步是用占位值做的残留检查, 不能拿它判"是不是数字"。这里判的是**来源**:
+# 夹具替换救援端口时用的是项目常量, 还是随手写的字面量 —— 后者在常量变更后会造出
+# 一台端口对不上的"机器", 而那种失真比漏渲染更难查。
+sub = re.search(r"__RESCUE_PORT__\|([^|]*)\|", seed)
+if not sub:
+    bad("夹具没有替换 __RESCUE_PORT__(见上一格)")
+elif re.fullmatch(r"\d+", sub.group(1).strip()):
+    bad("救援端口写成了字面量 %r —— 应读 rescue_const.py, 否则常量一改夹具就失真"
+        % sub.group(1).strip())
+elif "rescue_const" in seed:
+    p_ = subprocess.run([sys.executable,
+                         os.path.join(ROOT, "deploy", "bot", "rescue_const.py"), "--port"],
+                        capture_output=True, text=True,
+                        env={**os.environ, "PDG_RESCUE_PORT": ""})
+    v = (p_.stdout or "").strip()
+    if v.isdigit():
+        ok("救援端口取自 rescue_const.py, 且解析为数字(共 %d 位)" % len(v))
+    else:
+        bad("rescue_const.py 没有给出数字端口, 夹具会渲染出非法值")
 else:
-    bad("救援端口反解不出数字 —— 生产函数会据此安全跳过同步, 防火墙停在旧规则")
+    bad("救援端口的替换值来源不明(既非字面量也非 rescue_const.py)")
 
 print("\n── 五、fail-closed 守卫: 渲染后残留任何 token 都必须让夹具失败 ──")
 if re.search(r"__\[A-Z\]\[A-Z0-9_\]\*__|残留.*占位符|未替换的占位符", seed):

--- a/tests/test-e2e-seed-render.py
+++ b/tests/test-e2e-seed-render.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""E2E 夹具必须把防火墙模板**渲染完整**。
+
+── 这条缺口值多少 ─────────────────────────────────────────────────────────────
+`e2e_seed_nft()` 造的是"一台已装好的机器"。它渲染模板时漏了 `__RESCUE_PORT__`,
+于是沙箱里的 /etc/nftables.conf 带着未替换的字面量。
+
+平时无害 —— 没有判据去读那个位置。直到 `migrate_firewall_template_sync` 开始从
+**机器现行规则**反解渲染参数: 救援端口那一行长成 `tcp dport __RESCUE_PORT__ accept`,
+数字反解不出来, 函数按设计 fail-closed 跳过同步, 防火墙保持旧规则, doctor 判
+「缺少 tailscale0 排除规则」, cmd_update 整次回滚。CI 六个升级类 job 同时红,
+报的都是这一条。
+
+**产品函数没有错** —— 它就该在参数反解不出来时拒绝重建一台机器的防火墙。错的是夹具
+造出来的那台"机器"根本不像真机: 真机装机流程会把三个占位符全部渲染掉。
+
+所以这支盯的是"渲染闭包": 模板有几个占位符, 夹具就得替换几个, 一个都不能漏。
+判据不写死占位符清单 —— 从模板和夹具源码两边各自读出来再比, 将来模板新增占位符而
+夹具忘了跟进, 这里会立刻红。
+"""
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+TPL = os.path.join(ROOT, "deploy", "firewall", "nftables-mihomo.conf")
+LIB = os.path.join(HERE, "e2e-lib.sh")
+
+npass = nfail = 0
+
+
+def ok(m):
+    global npass
+    npass += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail
+    nfail += 1
+    print("[FAIL] %s" % m)
+
+
+print("══ E2E 夹具的模板渲染闭包 ══\n")
+
+with open(TPL, encoding="utf-8") as f:
+    tpl = f.read()
+with open(LIB, encoding="utf-8") as f:
+    lib = f.read()
+
+TOKEN_RE = r"__[A-Z][A-Z0-9_]*__"
+tpl_tokens = set(re.findall(TOKEN_RE, tpl))
+print("── 一、模板与夹具各自的占位符集合 ──")
+ok("模板占位符: %s" % ", ".join(sorted(tpl_tokens)))
+
+m = re.search(r"^e2e_seed_nft\(\)\{(.*?)^\}", lib, re.M | re.S)
+if not m:
+    bad("找不到 e2e_seed_nft")
+    print("\n通过 %d, 失败 %d" % (npass, nfail))
+    sys.exit(1)
+seed = m.group(1)
+seed_tokens = set(re.findall(TOKEN_RE, seed))
+ok("夹具替换的占位符: %s" % ", ".join(sorted(seed_tokens)))
+
+print("\n── 二、闭包判据 ──")
+missing = tpl_tokens - seed_tokens
+if missing:
+    bad("夹具漏渲染 %s —— 沙箱造出来的机器不像真机, 参数反解会失败"
+        % ", ".join(sorted(missing)))
+else:
+    ok("模板的每个占位符夹具都替换了(闭包完整)")
+
+stale = seed_tokens - tpl_tokens
+if stale:
+    ok("夹具里有模板已不用的替换 %s(无害, 但该清)" % ", ".join(sorted(stale)))
+else:
+    ok("夹具没有失效的替换项")
+
+print("\n── 三、后果: 拿夹具那套替换去渲染, 残留什么 ──")
+rendered = tpl
+for t in seed_tokens & tpl_tokens:
+    rendered = rendered.replace(t, "X")
+residue = re.findall(TOKEN_RE, rendered)
+if residue:
+    from collections import Counter
+    c = Counter(residue)
+    bad("渲染产物仍残留 %s —— 真机上不会出现未替换的占位符"
+        % ", ".join("%s×%d" % (k, v) for k, v in sorted(c.items())))
+else:
+    ok("渲染产物无残留占位符")
+
+print("\n── 四、救援端口必须能被反解成数字 ──")
+# 这正是 migrate_firewall_template_sync 用的那条反解, 不另写一套
+rp = re.findall(r"ip saddr \S+ tcp dport (\d+) accept", rendered)
+if rp:
+    ok("救援端口可反解为数字: 共 %d 处" % len(rp))
+else:
+    bad("救援端口反解不出数字 —— 生产函数会据此安全跳过同步, 防火墙停在旧规则")
+
+print("\n── 五、fail-closed 守卫: 渲染后残留任何 token 都必须让夹具失败 ──")
+if re.search(r"__\[A-Z\]\[A-Z0-9_\]\*__|残留.*占位符|未替换的占位符", seed):
+    ok("夹具带残留占位符守卫")
+else:
+    bad("夹具没有残留占位符守卫 —— 将来模板新增 token 又会静默漏渲染")
+
+print("\n" + "─" * 62)
+print("通过 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/test-firewall-live-drift.py
+++ b/tests/test-firewall-live-drift.py
@@ -119,12 +119,35 @@ try:
 
     print("\n── 二、调生产函数 ──")
     shim = make_shim(work)
+
+    def call_sync(count_calls=False, fail_load=False, fake_ok_load=False):
+        """调生产函数一次, 返回 rc。count_calls=True 时把 nft 调用记进 calls.log,
+        用来证明 B 态确实**没有**执行 nft -f —— 只看返回码分不出 no-op 和"重载了但结果一样"。"""
+        log = os.path.join(work, "calls.log")
+        open(log, "w").close()
+        # 记账必须做在**那个 bash 函数里面**: 同名函数会遮蔽 PATH 上的垫片, 靠垫片记账
+        # 日志恒空, "零 nft -f"就成了永远成立的空判据 —— 上一版正是这么假绿的。
+        # 故障注入放在**那个 bash 函数**里(生产函数看到的就是它):
+        #   fail_load    → `nft -f` 返回非零, 内核不动 —— 验"失败不冒充成功"
+        #   fake_ok_load → `nft -f` 返回 0 但**什么都不加载** —— 验 reload 后的复核
+        #                  真的在读内核, 而不是拿 nft 的返回码当结论
+        inj = ""
+        if fail_load:
+            inj = 'if [ "$1" = "-f" ]; then return 1; fi; '
+        elif fake_ok_load:
+            inj = 'if [ "$1" = "-f" ]; then return 0; fi; '
+        cmd = SYNC_CMD.replace('nft(){ printf', 'nft(){ ' + inj + 'printf', 1)
+        p = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                           executable="/bin/bash", env={**env, "PDG_NFT_CALLS": log})
+        m = re.search(r"rc=(\d+)", p.stdout or "")
+        return int(m.group(1)) if m else -1
+
     # PATH 要**整个换掉**而不是前置: sudo 的 secure_path 会把继承来的 PATH 覆盖,
     # 于是垫片明明在也用不上, 表现成"nft 返回非零" —— 看着像内核读不到。
     env = {**os.environ, "PATH": shim + ":/usr/sbin:/usr/bin:/sbin:/bin",
            "REPO_DIR": ROOT}
-    fn = subprocess.run(
-        'export REPO_DIR=%s; nft(){ %s ip netns exec %s /usr/sbin/nft "$@"; }; '
+    SYNC_CMD = (
+        'export REPO_DIR=%s; nft(){ printf "%%s\\n" "$*" >> "$PDG_NFT_CALLS"; %s ip netns exec %s /usr/sbin/nft "$@"; }; '
         'c_g(){ echo "    [prod] $*"; }; c_y(){ echo "    [prod] $*"; }; '
         'eval "$(sed -n "/^_rescue_load()/,/^}/p" %s/deploy/bot/pdg.sh)" 2>/dev/null; '
         # 判据 helper 必须一并抽出 —— 漏了它, 生产函数调到一个未定义的名字, shell 返回
@@ -133,8 +156,8 @@ try:
         'eval "$(sed -n "/^_fw_live_has_template_invariants()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'eval "$(sed -n "/^migrate_firewall_template_sync()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'migrate_firewall_template_sync %s; echo "rc=$?"'
-        % (ROOT, SUDO, NS, ROOT, ROOT, ROOT, conf),
-        shell=True, capture_output=True, text=True, executable="/bin/bash", env=env)
+        % (ROOT, SUDO, NS, ROOT, ROOT, ROOT, conf))
+    fn = subprocess.run(SYNC_CMD, shell=True, capture_output=True, text=True, executable="/bin/bash", env=env)
     rc = re.search(r"rc=(\d+)", fn.stdout or "")
     rc = int(rc.group(1)) if rc else -1
     print("       生产函数 rc=%d" % rc)
@@ -160,6 +183,57 @@ try:
         ok("磁盘 mtime 未变")
     else:
         bad("磁盘 mtime 变了")
+    # ── 五、B 态: 磁盘新、内核新 → 必须是真 no-op ────────────────────────────
+    print("\n── 五、B 态必须零写盘零加载 ──")
+    b_sha = run("sha256sum %s" % conf).stdout.split()[0]
+    b_mt = os.stat(conf).st_mtime_ns
+    calls0 = len(open(os.path.join(work, "calls.log"), encoding="utf-8").read().splitlines()) \
+        if os.path.exists(os.path.join(work, "calls.log")) else 0
+    rc_b = call_sync(count_calls=True)
+    calls1 = len(open(os.path.join(work, "calls.log"), encoding="utf-8").read().splitlines())
+    loads = sum(1 for L in open(os.path.join(work, "calls.log"), encoding="utf-8")
+                if L.startswith("-f "))
+    if rc_b == 0:
+        ok("B 态返回 0")
+    else:
+        bad("B 态返回 %d(内核已满足不变量时应为 0)" % rc_b)
+    if run("sha256sum %s" % conf).stdout.split()[0] == b_sha and os.stat(conf).st_mtime_ns == b_mt:
+        ok("B 态零写盘(摘要与 mtime 均不变)")
+    else:
+        bad("B 态写盘了 —— 内核已是新版, 不该动磁盘")
+    if loads == 0:
+        ok("B 态零 nft -f(没有多余 reload)")
+    else:
+        bad("B 态执行了 %d 次 nft -f —— 应当完全 no-op" % loads)
+
+    # ── 六、reload 失败必须返回非零, 且内核保持 before-image ──────────────────
+    print("\n── 六、reload 失败注入 ──")
+    load(OLD)
+    rc_f = call_sync(fail_load=True)
+    if rc_f != 0:
+        ok("reload 失败 → 返回非零(%d), 不冒充成功" % rc_f)
+    else:
+        bad("reload 失败仍返回 0 —— 更新会据此当成已收敛")
+    if not kernel_has_ts():
+        ok("内核保持 before-image(仍是 OLD)")
+    else:
+        bad("内核被污染了")
+
+    # ── 七、reload 成功但内核仍未收敛 → 复核必须抓住 ─────────────────────────
+    print("\n── 七、注入'加载成功但没收敛' ──")
+    load(OLD)
+    rc_n = call_sync(fake_ok_load=True)
+    if rc_n != 0:
+        ok("加载返回 0 但内核未收敛 → 仍返回非零(%d)" % rc_n)
+    else:
+        bad("内核没收敛却返回 0 —— reload 后的复核形同虚设")
+
+    # 八、reload 前那道 nft -c 守的是**不可达状态**, 故不设用例。
+    #     C 态成立的前提是"磁盘 == 候选", 而候选是模板渲染的产物, 必然通过 nft -c。
+    #     往磁盘写非法内容会让它不再等于候选, 函数就走 A 态(重建)去了 —— 那测的是别的分支。
+    #     保留那道检查是纵深防御(有人手工改过盘上文件又恰好改回同样字节数?), 但诚实地说:
+    #     它在当前调用路径下不可能被触发, 所以这里不假装验过它。
+
 finally:
     run("%s ip netns del %s" % (SUDO, NS))
     shutil.rmtree(work, ignore_errors=True)

--- a/tests/test-firewall-live-drift.py
+++ b/tests/test-firewall-live-drift.py
@@ -66,6 +66,24 @@ work = tempfile.mkdtemp(prefix="pdgdrift-")
 conf = os.path.join(work, "nftables.conf")
 
 
+# nftlive 的 NFT_BIN 是裸 "nft"(走 PATH), 所以把一个转发到 netns 的垫片放在 PATH 最前,
+# 生产判据就会在这个实验床的内核上取数 —— 不需要给产品加环境变量后门或测试特判。
+SHIM = None
+
+
+def make_shim(d):
+    global SHIM
+    SHIM = os.path.join(d, "bin")
+    os.makedirs(SHIM, exist_ok=True)
+    p = os.path.join(SHIM, "nft")
+    with open(p, "w", encoding="utf-8") as f:
+        # 垫片本身不再套 sudo: 这段判据已在 root 下跑, 再套一层会撞上 sudo 的 secure_path,
+        # 表现成 "nft 返回非零" —— 看着像内核读不到, 其实是垫片没被执行。
+        f.write('#!/bin/sh\nexec ip netns exec %s /usr/sbin/nft "$@"\n' % NS)
+    os.chmod(p, 0o755)
+    return SHIM
+
+
 def nft(args):
     return run("%s ip netns exec %s nft %s" % (SUDO, NS, args))
 
@@ -100,17 +118,28 @@ try:
     disk_mt0 = os.stat(conf).st_mtime_ns
 
     print("\n── 二、调生产函数 ──")
+    shim = make_shim(work)
+    # PATH 要**整个换掉**而不是前置: sudo 的 secure_path 会把继承来的 PATH 覆盖,
+    # 于是垫片明明在也用不上, 表现成"nft 返回非零" —— 看着像内核读不到。
+    env = {**os.environ, "PATH": shim + ":/usr/sbin:/usr/bin:/sbin:/bin",
+           "REPO_DIR": ROOT}
     fn = subprocess.run(
-        'REPO_DIR=%s; nft(){ %s ip netns exec %s /usr/sbin/nft "$@"; }; '
-        'c_g(){ :; }; c_y(){ :; }; '
+        'export REPO_DIR=%s; nft(){ %s ip netns exec %s /usr/sbin/nft "$@"; }; '
+        'c_g(){ echo "    [prod] $*"; }; c_y(){ echo "    [prod] $*"; }; '
         'eval "$(sed -n "/^_rescue_load()/,/^}/p" %s/deploy/bot/pdg.sh)" 2>/dev/null; '
+        # 判据 helper 必须一并抽出 —— 漏了它, 生产函数调到一个未定义的名字, shell 返回
+        # command-not-found 的非零, 而那会被当成"内核未收敛"。前一轮就栽在这里:
+        # 同一判据单独跑是 ok, 放进测试就红, 差的不是环境, 是这一行。
+        'eval "$(sed -n "/^_fw_live_has_template_invariants()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'eval "$(sed -n "/^migrate_firewall_template_sync()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'migrate_firewall_template_sync %s; echo "rc=$?"'
-        % (ROOT, SUDO, NS, ROOT, ROOT, conf),
-        shell=True, capture_output=True, text=True, executable="/bin/bash")
+        % (ROOT, SUDO, NS, ROOT, ROOT, ROOT, conf),
+        shell=True, capture_output=True, text=True, executable="/bin/bash", env=env)
     rc = re.search(r"rc=(\d+)", fn.stdout or "")
     rc = int(rc.group(1)) if rc else -1
     print("       生产函数 rc=%d" % rc)
+    for L in (fn.stdout or "").splitlines():
+        if "[prod]" in L: print(L)
 
     print("\n── 三、内核必须收敛到 NEW ──")
     if kernel_has_ts():

--- a/tests/test-firewall-live-drift.py
+++ b/tests/test-firewall-live-drift.py
@@ -21,6 +21,9 @@ import subprocess
 import sys
 import tempfile
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tmpguard
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
 TPL = os.path.join(ROOT, "deploy", "firewall", "nftables-mihomo.conf")
@@ -62,7 +65,7 @@ OLD = "\n".join(L for L in NEW.splitlines() if 'iifname "tailscale0"' not in L)
 
 run("%s ip netns del %s" % (SUDO, NS))
 run("%s ip netns add %s" % (SUDO, NS))
-work = tempfile.mkdtemp(prefix="pdgdrift-")
+work = tmpguard.mkdtemp(prefix="pdgdrift-")
 conf = os.path.join(work, "nftables.conf")
 
 
@@ -79,7 +82,7 @@ def make_shim(d):
     with open(p, "w", encoding="utf-8") as f:
         # 垫片本身不再套 sudo: 这段判据已在 root 下跑, 再套一层会撞上 sudo 的 secure_path,
         # 表现成 "nft 返回非零" —— 看着像内核读不到, 其实是垫片没被执行。
-        f.write('#!/bin/sh\nexec ip netns exec %s /usr/sbin/nft "$@"\n' % NS)
+        f.write('#!/bin/sh\nexec %s ip netns exec %s /usr/sbin/nft "$@"\n' % (SUDO, NS))
     os.chmod(p, 0o755)
     return SHIM
 

--- a/tests/test-firewall-live-drift.py
+++ b/tests/test-firewall-live-drift.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""磁盘已是新版、内核仍跑旧规则时, 模板同步必须收敛内核。
+
+── 缺口 ─────────────────────────────────────────────────────────────────────
+`migrate_firewall_template_sync` 判"要不要重建"只看**磁盘**: 候选与 /etc/nftables.conf
+逐字节相同就 return 0。磁盘已经是新版而内核还跑着旧规则时(装机中断、配置写了没 load、
+快照只还原了文件), 它认为无事可做, 而防火墙实际上仍在按旧规则放行。
+
+这不是假想: e2e-update 的取证显示函数每次都走 `noop-identical`, 磁盘是新的, 内核是旧的,
+doctor 读内核判"缺 tailscale0 排除规则", 更新整次回滚 —— 六个升级类 job 就红在这里。
+
+── 判据取哪一侧 ─────────────────────────────────────────────────────────────
+不做"磁盘逐条 vs 内核逐条": nftables v1.0.6 下 `nft -c -j -f` 输出 0 字节, 候选的规范化
+形态**拿不到, 除非真加载**(nftlive.py 开头已记录过这条实验)。所以判据放在内核一侧 ——
+问"模板承诺的关键不变量在内核里成立吗", 用的是 doctor 那条读取链, 而不是文本比对。
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+TPL = os.path.join(ROOT, "deploy", "firewall", "nftables-mihomo.conf")
+NS = "pdgdrift"
+
+npass = nfail = nskip = 0
+ok = lambda m: (globals().__setitem__("npass", npass + 1), print("[OK]   %s" % m))
+bad = lambda m: (globals().__setitem__("nfail", nfail + 1), print("[FAIL] %s" % m))
+
+
+def run(c, **k):
+    return subprocess.run(c, shell=isinstance(c, str), capture_output=True, text=True, **k)
+
+
+SUDO = "" if os.geteuid() == 0 else "sudo -n"
+print("══ 磁盘/内核漂移时的模板同步 ══\n")
+
+if os.geteuid() != 0 and run("sudo -n true").returncode != 0:
+    print("[SKIP] 需要 root 或免密 sudo"); print("\n通过 0, 失败 0, 跳过 1"); sys.exit(0)
+if not (shutil.which("nft") or os.path.exists("/usr/sbin/nft")):
+    print("[SKIP] 缺 nft"); print("\n通过 0, 失败 0, 跳过 1"); sys.exit(0)
+
+rp = run([sys.executable, os.path.join(ROOT, "deploy", "bot", "rescue_const.py"), "--port"],
+         env={**os.environ, "PDG_RESCUE_PORT": ""}).stdout.strip()
+with open(TPL, encoding="utf-8") as f:
+    tpl = f.read()
+
+
+def render(text):
+    return (text.replace("__INTERNAL_CIDR__", "172.22.0.0/16")
+                .replace("__SSH_PORT__", "22").replace("__RESCUE_PORT__", rp))
+
+
+# C 态的要害: 磁盘必须与函数渲染的候选**逐字节相同**, 否则它走的是 A 态(重建), 测不到
+# 这个缺口。所以磁盘写完整渲染(含 include 行); 内核那份为了能在 netns 里加载才剔掉 include。
+NEW_FULL = render(tpl)
+NEW = "\n".join(L for L in NEW_FULL.splitlines() if "nft-input.d" not in L)
+OLD = "\n".join(L for L in NEW.splitlines() if 'iifname "tailscale0"' not in L)
+
+run("%s ip netns del %s" % (SUDO, NS))
+run("%s ip netns add %s" % (SUDO, NS))
+work = tempfile.mkdtemp(prefix="pdgdrift-")
+conf = os.path.join(work, "nftables.conf")
+
+
+def nft(args):
+    return run("%s ip netns exec %s nft %s" % (SUDO, NS, args))
+
+
+def load(text):
+    fd, p = tempfile.mkstemp(prefix="drift-", suffix=".nft", dir=work)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(text)
+    os.chmod(p, 0o644)
+    return nft("-f %s" % p)
+
+
+def kernel_has_ts():
+    p = nft("list table inet pdg")
+    return p.returncode == 0 and "tailscale0" in p.stdout
+
+
+try:
+    print("── 一、造 C 态: 内核 OLD, 磁盘 NEW ──")
+    if load(OLD).returncode != 0:
+        bad("OLD 加载失败(夹具问题)"); raise SystemExit
+    with open(conf, "w", encoding="utf-8") as f:
+        f.write(NEW_FULL)
+    os.chmod(conf, 0o644)
+    if not kernel_has_ts():
+        ok("内核是 OLD(无 tailscale0 排除规则)")
+    else:
+        bad("内核不是 OLD, 现场没造对")
+    with open(conf, encoding="utf-8") as f:
+        ok("磁盘是 NEW(含 tailscale0 %d 处)" % f.read().count('iifname "tailscale0"'))
+    disk_sha0 = run("sha256sum %s" % conf).stdout.split()[0]
+    disk_mt0 = os.stat(conf).st_mtime_ns
+
+    print("\n── 二、调生产函数 ──")
+    fn = subprocess.run(
+        'REPO_DIR=%s; nft(){ %s ip netns exec %s /usr/sbin/nft "$@"; }; '
+        'c_g(){ :; }; c_y(){ :; }; '
+        'eval "$(sed -n "/^_rescue_load()/,/^}/p" %s/deploy/bot/pdg.sh)" 2>/dev/null; '
+        'eval "$(sed -n "/^migrate_firewall_template_sync()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
+        'migrate_firewall_template_sync %s; echo "rc=$?"'
+        % (ROOT, SUDO, NS, ROOT, ROOT, conf),
+        shell=True, capture_output=True, text=True, executable="/bin/bash")
+    rc = re.search(r"rc=(\d+)", fn.stdout or "")
+    rc = int(rc.group(1)) if rc else -1
+    print("       生产函数 rc=%d" % rc)
+
+    print("\n── 三、内核必须收敛到 NEW ──")
+    if kernel_has_ts():
+        ok("内核已收敛: tailscale0 排除规则出现")
+    else:
+        bad("内核**仍是 OLD** —— 磁盘已新, 同步据磁盘判 no-op, 防火墙实际跑旧规则")
+    if rc == 0:
+        ok("返回 0")
+    else:
+        bad("返回 %d(收敛成功时应为 0)" % rc)
+
+    print("\n── 四、C 态不得重写磁盘 ──")
+    if run("sha256sum %s" % conf).stdout.split()[0] == disk_sha0:
+        ok("磁盘内容未被改写")
+    else:
+        bad("磁盘被重写了 —— C 态只该 reload, 不该写盘")
+    if os.stat(conf).st_mtime_ns == disk_mt0:
+        ok("磁盘 mtime 未变")
+    else:
+        bad("磁盘 mtime 变了")
+finally:
+    run("%s ip netns del %s" % (SUDO, NS))
+    shutil.rmtree(work, ignore_errors=True)
+
+print("\n" + "─" * 62)
+print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+sys.exit(1 if nfail else 0)

--- a/tests/test-firewall-template-sync.py
+++ b/tests/test-firewall-template-sync.py
@@ -160,10 +160,15 @@ else:
     run("%s ip netns del %s" % (SUDO, NS))
     run("%s ip netns add %s" % (SUDO, NS))
     try:
+        # 救援端口从常量读, 不写字面量(test-rescue-constants.sh 守着这条)。
+        rp = run([sys.executable,
+                  os.path.join(ROOT, "deploy", "bot", "rescue_const.py"), "--port"],
+                 env={**os.environ, "PDG_RESCUE_PORT": ""}).stdout.strip()
+
         def render(text):
             return (text.replace("__INTERNAL_CIDR__", "172.22.0.0/16")
                         .replace("__SSH_PORT__", "22")
-                        .replace("__RESCUE_PORT__", "8446"))
+                        .replace("__RESCUE_PORT__", rp))
 
         with open(TPL, encoding="utf-8") as f:
             tpl_text = f.read()

--- a/tests/test-firewall-template-sync.py
+++ b/tests/test-firewall-template-sync.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""升级时防火墙必须按模板重建 —— 否则模板改动永远到不了已装机器。
+
+── 这条缺口是怎么暴露的 ────────────────────────────────────────────────────────
+`migrate_firewall_to_pdg` 做的是一次性搬迁: 旧的 `inet filter` → 独立表 `inet pdg`。
+它开头就写着「已是新表 → 无需迁移」并 return —— 对**已经在 inet pdg 上的机器**,
+它什么都不做。于是模板后续的任何改动都传不过去: 机器上跑的永远是当初装机那一版渲染结果。
+
+平时看不出来, 因为没人核对"内核里的规则"和"当前模板"是否还一致。直到有个判据开始查
+具体规则在不在 —— Tailscale 入口隔离就是第一个 —— 升级立刻变成: 新判据要求新规则,
+而没有任何一步会把新规则装上去, 于是 doctor 判红 → cmd_update 自检门整次回滚 →
+**这个版本在所有旧机器上都装不上**。
+
+模板自己早就写明了契约(nftables-mihomo.conf 里那句「本表每次更新都会按模板重建」),
+只是从来没有实现。这支把契约钉住。
+
+── 判据 ─────────────────────────────────────────────────────────────────────
+用真 nft 加载, 不做文本比对: 比的是"内核里的语义"与"当前模板渲染后的语义"。
+用户自定义规则走 include 目录, 重建不碰它 —— 这一点也一并钉住。
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+TPL = os.path.join(ROOT, "deploy", "firewall", "nftables-mihomo.conf")
+PDG = os.path.join(ROOT, "deploy", "bot", "pdg.sh")
+
+npass = nfail = nskip = 0
+
+
+def ok(m):
+    global npass
+    npass += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail
+    nfail += 1
+    print("[FAIL] %s" % m)
+
+
+def skip(m):
+    global nskip
+    nskip += 1
+    print("[SKIP] %s" % m)
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, shell=isinstance(cmd, str), capture_output=True,
+                          text=True, **kw)
+
+
+print("══ 升级时防火墙按模板重建 ══\n")
+
+# ── 一、静态: 必须存在一个"把模板同步到已迁移机器"的迁移, 且挂进 __migrate ──────
+print("── 一、同步迁移必须存在并被调用 ──")
+with open(PDG, encoding="utf-8") as f:
+    SRC = f.read()
+
+FN = "migrate_firewall_template_sync"
+if re.search(r"^%s\(\)\{" % FN, SRC, re.M):
+    ok("%s 已定义" % FN)
+else:
+    bad("没有 %s —— 已在 inet pdg 上的机器收不到任何模板改动" % FN)
+
+# 光定义不算数: 必须真的排进更新时跑的迁移序列
+# `__migrate` 是 CLI 子命令而不是函数: 迁移集中在一处顺序调用, cmd_update 装好新脚本后
+# 经 `pdg __migrate` 走一遍。所以判据是"同步迁移出现在那串调用里", 且紧跟搬迁之后。
+disp = re.search(r"migrate_firewall_to_pdg \|\| true(.{0,400})", SRC, re.S)
+if not disp:
+    bad("找不到迁移调度处(无法确认同步迁移会被调用)")
+elif FN in disp.group(1):
+    ok("%s 已挂进迁移调度, 且排在 migrate_firewall_to_pdg 之后" % FN)
+else:
+    bad("%s 没挂进迁移调度 —— 写了但不会被调用" % FN)
+
+# 顺序: 必须排在 doctor 自检门之前, 否则自检看到的仍是旧规则
+upd = re.search(r"^cmd_update\(\)\{(.*?)^\}", SRC, re.M | re.S)
+if upd:
+    body = upd.group(1)
+    p_mig = body.find("__migrate")
+    p_doc = body.find("doctor.py")
+    if p_mig < 0 or p_doc < 0:
+        bad("cmd_update 里找不到 __migrate 或 doctor 自检门")
+    elif p_mig < p_doc:
+        ok("__migrate 排在 doctor 自检门之前(第 %d 字符 < 第 %d 字符)" % (p_mig, p_doc))
+    else:
+        bad("__migrate 排在自检之后 —— 自检看到的还是旧规则, 必然误回滚")
+
+# ── 二、真 nft: 旧渲染结果 + 新模板 → 重建后语义必须等于新模板 ──────────────────
+print("\n── 二、真 nft 语义比对 ──")
+SUDO = "" if os.geteuid() == 0 else "sudo -n"
+if os.geteuid() != 0 and run("sudo -n true").returncode != 0:
+    skip("需要 root 或免密 sudo 才能真加载 nft")
+elif not (shutil.which("nft") or os.path.exists("/usr/sbin/nft")):
+    skip("缺少 nft")
+else:
+    NS = "pdgfwsync"
+    run("%s ip netns del %s" % (SUDO, NS))
+    run("%s ip netns add %s" % (SUDO, NS))
+    try:
+        def render(text):
+            return (text.replace("__INTERNAL_CIDR__", "172.22.0.0/16")
+                        .replace("__SSH_PORT__", "22")
+                        .replace("__RESCUE_PORT__", "8446"))
+
+        with open(TPL, encoding="utf-8") as f:
+            tpl_text = f.read()
+
+        # 「旧机器」= 当前模板去掉 tailscale 排除后的渲染结果, 模拟装机时那一版
+        old_text = "\n".join(L for L in render(tpl_text).splitlines()
+                             if "nft-input.d" not in L and 'iifname "tailscale0"' not in L)
+        new_text = "\n".join(L for L in render(tpl_text).splitlines()
+                             if "nft-input.d" not in L)
+
+        def load(text):
+            fd, path = tempfile.mkstemp(prefix="pdgfwsync-", suffix=".nft")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(text)
+                os.chmod(path, 0o644)
+                return run("%s ip netns exec %s nft -f %s" % (SUDO, NS, path))
+            finally:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+        def kernel_sig():
+            p = run("%s ip netns exec %s nft -j list table inet pdg" % (SUDO, NS))
+            if p.returncode != 0:
+                return None
+            import json
+            import hashlib
+            d = json.loads(p.stdout)["nftables"]
+            rs = [json.dumps(x["rule"]["expr"], sort_keys=True) for x in d if "rule" in x]
+            return hashlib.sha256("".join(rs).encode()).hexdigest()
+
+        if load(old_text).returncode != 0:
+            bad("旧版规则加载失败(实验床问题, 非判据)")
+        else:
+            sig_old = kernel_sig()
+            run("%s ip netns exec %s nft flush ruleset" % (SUDO, NS))
+            if load(new_text).returncode != 0:
+                bad("当前模板渲染后加载失败")
+            else:
+                sig_new = kernel_sig()
+                if sig_old and sig_new and sig_old != sig_new:
+                    ok("旧渲染与当前模板的内核语义确实不同(指纹 %s ≠ %s)"
+                       % (sig_old[:12], sig_new[:12]))
+                    ok("→ 所以「已迁移的机器不重建」等于永远停在旧规则上")
+                else:
+                    bad("两版指纹相同, 这支的前提不成立(实验床没造出差异)")
+    finally:
+        run("%s ip netns del %s" % (SUDO, NS))
+
+print("\n" + "─" * 66)
+print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+sys.exit(1 if nfail else 0)

--- a/tests/test-firewall-template-sync.py
+++ b/tests/test-firewall-template-sync.py
@@ -140,7 +140,12 @@ else:
     bad("回滚不完整没有明确告警")
 
 # 用户 include 与旧表绝不能出现在这个函数里
-if "nft-input.d" in FNB.replace("你在 nft-input.d/ 里的规则不受影响", ""):
+# 只看代码行, 并剔掉 c_g/c_y 的提示文案: 告诉用户"你的 nft-input.d 规则不受影响"
+# 是**说明**, 不是**触碰**。判据认字符串就会把这种文案当成越界, 那是假阳性。
+FN_CODE = "\n".join(L for L in FNB.splitlines()
+                    if not L.strip().startswith("#")
+                    and not re.match(r"\s*c_[gy] ", L))
+if "nft-input.d" in FN_CODE:
     bad("函数体碰了用户 include 目录")
 else:
     ok("函数体不触碰用户 include 目录")

--- a/tests/test-firewall-template-sync.py
+++ b/tests/test-firewall-template-sync.py
@@ -94,6 +94,61 @@ if upd:
         bad("__migrate 排在自检之后 —— 自检看到的还是旧规则, 必然误回滚")
 
 # ── 二、真 nft: 旧渲染结果 + 新模板 → 重建后语义必须等于新模板 ──────────────────
+# ── 一之二、参数反解必须"唯一且合法", 且失败时什么都不做 ─────────────────────
+print("\n── 一之二、参数反解的 fail-closed ──")
+fn = re.search(r"^%s\(\)\{(.*?)^\}" % FN, SRC, re.M | re.S)
+FNB = fn.group(1) if fn else ""
+
+if "PDG_RESCUE_PORT" in FNB and "grep -oE 'ip saddr" not in FNB:
+    bad("救援端口取自常量而非反解 —— 常量与机器现状不一致时会悄悄改掉放行")
+elif re.search(r'rport=.*grep', FNB):
+    ok("三个参数都从机器当前配置反解(救援端口也是)")
+else:
+    bad("救援端口没有从当前配置反解")
+
+# 只看代码行: 注释里提到 `head -1` 是在解释为什么不用它, 不该被算成使用。
+CODE = "\n".join(L for L in FNB.splitlines() if not L.strip().startswith("#"))
+if "sort -u" in CODE and "head -1" not in CODE:
+    ok("用 sort -u 判唯一, 代码里没有 head -1 静默取首个")
+else:
+    bad("参数反解仍可能静默取首个 —— 配置里有多个值时最该停下来")
+
+if re.search(r'-ge 1 && .*-le 65535', CODE) and "[0-9]{1,3}" in CODE:
+    ok("端口范围与网段形态都做了合法性校验")
+else:
+    bad("缺端口范围或网段形态的合法性校验")
+
+# 反解失败那条分支必须在写盘/加载之前就 return, 且不回显具体值
+pre = FNB.split("mktemp")[0]
+if "return 0" in pre and ("不写盘" in pre or "跳过" in pre):
+    ok("反解失败在 mktemp/写盘之前就返回(不写盘、不加载、不重启)")
+else:
+    bad("反解失败没有在写盘前返回")
+if re.search(r'c_y "[^"]*\$(port|cidr|rport)', FNB):
+    bad("失败文案回显了具体端口/网段 —— 日志不该出现这台机器的私有值")
+else:
+    ok("失败文案只说哪类参数有问题, 不回显具体值")
+
+# before-image 必须含 mode/uid/gid 且校验过
+if "stat -c %a" in FNB and "stat -c %u:%g" in FNB:
+    ok("before-image 覆盖内容+权限+属主, 且落盘后逐项校验")
+else:
+    bad("before-image 没有覆盖权限/属主")
+if re.search(r'rb=1', FNB) and "回滚\*\*不完整\*\*" in FNB or "回滚**不完整**" in FNB:
+    ok("回滚不完整会明确告警并返回非零")
+else:
+    bad("回滚不完整没有明确告警")
+
+# 用户 include 与旧表绝不能出现在这个函数里
+if "nft-input.d" in FNB.replace("你在 nft-input.d/ 里的规则不受影响", ""):
+    bad("函数体碰了用户 include 目录")
+else:
+    ok("函数体不触碰用户 include 目录")
+if "inet filter" in FNB:
+    bad("函数体碰了用户旧 table inet filter")
+else:
+    ok("函数体不触碰旧 table inet filter")
+
 print("\n── 二、真 nft 语义比对 ──")
 SUDO = "" if os.geteuid() == 0 else "sudo -n"
 if os.geteuid() != 0 and run("sudo -n true").returncode != 0:

--- a/tests/test-nftjson-coverage.py
+++ b/tests/test-nftjson-coverage.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""nftjson.py 必须把规则里的**每个**表达式都转出来, 丢了就是静默失真。
+
+E2E 沙箱里 `nft -j list table` 走的是这个转换器, 而 doctor/nftlive 读的正是它的输出。
+转换器认不出某个匹配就把它**丢掉**, 于是内核状态里明明有那条规则, 判据却看不见 ——
+`iifname "tailscale0" return` 就这么变成了裸 `return`, 六个升级类 E2E 因此全红,
+而真 nft 环境下同一份规则 12/12 全绿(真 nft 自己出 JSON, 认识这些语法)。
+
+难查的地方在于两条路径读的是**不同的 JSON 生成器**: 受控环境验证通过、E2E 被推翻,
+反复几轮都指向别处。
+
+判据: 逐条规则比对"转出的表达式个数", 而不是只看规则总数 —— 规则还在但匹配没了,
+恰恰是最会骗人的形态。
+"""
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+npass = nfail = 0
+
+
+def ok(m):
+    global npass; npass += 1; print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail; nfail += 1; print("[FAIL] %s" % m)
+
+
+def conv(rule_line):
+    src = ("table inet pdg {\n  chain input {\n"
+           "    type filter hook input priority 0; policy drop;\n"
+           "    %s\n  }\n}\n" % rule_line)
+    p = subprocess.run([sys.executable, os.path.join(HERE, "nftjson.py"), "inet", "pdg"],
+                       input=src, capture_output=True, text=True)
+    if p.returncode != 0:
+        return None
+    rs = [x["rule"] for x in json.loads(p.stdout)["nftables"] if "rule" in x]
+    return rs[0]["expr"] if rs else None
+
+
+print("══ nftjson 表达式覆盖 ══\n")
+
+CASES = [
+    ('iifname "tailscale0" return', 2, "iifname 匹配 + return 裁决"),
+    ('iif "lo" accept', 2, "iif 匹配 + accept"),
+    ('ip saddr 172.22.0.0/16 tcp dport 53 accept', 3, "saddr + dport + accept"),
+    ('ip protocol icmp accept', 2, "protocol + accept"),
+]
+
+for line, want, desc in CASES:
+    expr = conv(line)
+    if expr is None:
+        bad("%-42s → 整条规则被丢弃" % desc)
+        continue
+    got = len(expr)
+    if got >= want:
+        ok("%-42s → %d 个表达式" % (desc, got))
+    else:
+        bad("%-42s → 只转出 %d 个, 少了 %d(表达式被静默丢弃: %s)"
+            % (desc, got, want - got, json.dumps(expr, ensure_ascii=False)[:70]))
+
+print("\n── iifname 必须能被按接口名找到 ──")
+expr = conv('iifname "tailscale0" return') or []
+found = any(e.get("match", {}).get("left", {}).get("meta", {}).get("key") in ("iifname", "iif")
+            and e.get("match", {}).get("right") == "tailscale0" for e in expr)
+if found:
+    ok("转出的 JSON 里能按 iifname/tailscale0 定位到该规则")
+else:
+    bad("JSON 里找不到 iifname tailscale0 —— 判据据此判'缺少排除规则'")
+
+print("\n" + "─" * 62)
+print("通过 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/test-shellcheck-scope.sh
+++ b/tests/test-shellcheck-scope.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ShellCheck 必须按 **CI 的原样范围** 跑, 而不是手挑几个文件。
+#
+# 这支的由来: 我本地一直只查 install.sh / pdg.sh / detect-internal-range.sh 三个文件,
+# 于是新加的 tests/*.sh 从没进过门 —— 本地全绿、CI 的 lint job 直接判红。少查的那部分
+# 恰恰是新增代码最集中的地方, 这种"门比被测面小"的缺口, 只会在推上去之后才暴露。
+#
+# 范围从 ci.yml **读出来**, 不在这里抄一份: 抄一份就会和 CI 各自漂移, 那时这支测试
+# 反而会给出"本地绿"的假保证。
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+CI="$ROOT/.github/workflows/ci.yml"
+
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+command -v shellcheck >/dev/null 2>&1 || {
+  echo "[SKIP] 没装 shellcheck"; echo; echo "通过 0, 失败 0, 跳过 1"; exit 0; }
+
+# 从 ci.yml 里取那条命令的文件范围(紧跟 `shellcheck --severity=...` 的续行)
+scope="$(awk '/shellcheck --severity=warning/{getline; print; exit}' "$CI" | sed 's/^[[:space:]]*//')"
+[[ -n "$scope" ]] || { bad "从 ci.yml 读不出 ShellCheck 范围"; echo; echo "通过 $pass, 失败 $nfail"; exit 1; }
+ok "范围取自 ci.yml: $scope"
+
+cd "$ROOT" || exit 1
+# shellcheck disable=SC2086  # scope 是有意按空格拆成多个 glob 的
+out="$(shellcheck --severity=warning -e SC1091 $scope 2>&1)"
+rc=$?
+if [[ "$rc" == 0 ]]; then
+  ok "CI 原样范围下 ShellCheck 无 warning"
+else
+  bad "CI 原样范围下有 warning(CI 的 lint job 会据此判红):"
+  echo "$out" | grep -E '^In |SC[0-9]{4}' | head -12 | sed 's/^/       /'
+fi
+
+echo
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail ? 1 : 0 ))

--- a/tests/test-tailscale-ingress-isolation.py
+++ b/tests/test-tailscale-ingress-isolation.py
@@ -32,6 +32,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 import sys
 import time
 
@@ -140,13 +141,25 @@ def render(tpl_text):
 
 
 def load_nft(text):
-    """把渲染后的规则加载进 box netns。include 那行在实验床里没有对应目录, 剔掉。"""
+    """把渲染后的规则加载进 box netns。include 那行在实验床里没有对应目录, 剔掉。
+
+    临时文件必须唯一: 用固定名字(如 /tmp/pdgts-rules.nft)时, 上一轮非 root 跑留下的
+    文件会让这一轮的 root 写不进去 —— fs.protected_regular 不许 root 打开粘滞目录里
+    别人拥有的文件。表现是 PermissionError, 看着像权限不够, 其实是没清理干净。
+    """
     text = "\n".join(L for L in text.splitlines() if "nft-input.d" not in L)
-    path = "/tmp/pdgts-rules.nft"
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(text)
-    p = run("%s ip netns exec %s nft -f %s" % (SUDO, BOX, path))
-    return p.returncode == 0, (p.stderr or "").strip()
+    fd, path = tempfile.mkstemp(prefix="pdgts-rules-", suffix=".nft")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.chmod(path, 0o644)          # netns exec 下的 nft 要读得到
+        p = run("%s ip netns exec %s nft -f %s" % (SUDO, BOX, path))
+        return p.returncode == 0, (p.stderr or "").strip()
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
 
 
 def probe_tcp(ns, dst, port, timeout=3):

--- a/tests/test-tailscale-ingress-isolation.py
+++ b/tests/test-tailscale-ingress-isolation.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Tailscale 入口隔离: PDG 数据面必须同时看「来源网段」和「入口接口」。
+
+── 为什么需要这支 ────────────────────────────────────────────────────────────
+Tailscale 给节点分配 100.64.0.0/10 的地址, 而**运营商 SIM/APN 也合法使用同一个段**
+(RFC 6598 CGNAT)。项目原本只按 `ip saddr $PDG_INTERNAL_CIDR` 判断要不要接管, 不看包
+从哪个接口进来 —— 于是这两类来源在规则眼里长得一模一样。
+
+后果不是理论问题: Tailscale 起来之后跑一次 `pdg detect-cidr`(公开的用户命令), 探测器
+在 `any` 接口上抓到 tailnet 的包, 就可能把 100.64.x.x 推成 /16 写进 PDG_INTERNAL_CIDR。
+此后 nft 的 REDIRECT 规则改挂到 tailnet 段上, **tailnet 管理流量被送进 mihomo 透明代理**。
+
+**不能靠全局禁掉 100.64/10 来修** —— 那会打断真实运营商 CGNAT 用户的支持。正确的不变量是:
+
+    是否进入 PDG 数据面 = 来源网段 **且** 入口接口;
+    任何从 tailscale0 进来的流量都不得进入 SIM/APN 的接管链。
+
+── 这支怎么证 ───────────────────────────────────────────────────────────────
+关键是**证明判据认的是接口这个事实, 而不是换了个源 IP**。所以两侧客户端的源地址
+**都落在同一个配置好的 CIDR 内**(100.64.0.0/16), 唯一的差别是从哪个接口进来:
+
+    tsclient  100.64.1.2  ──veth──>  box:tailscale0   ← 必须**不**被接管
+    phyclient 100.64.2.2  ──veth──>  box:wan0         ← 必须**照旧**被接管(合法运营商 CGNAT)
+
+两个地址都在 100.64.0.0/16 里, 所以只看源地址的判据对它们无从区分。
+
+用真 netns + 真 veth + 真 nft 加载 + 真流量。纯字符串比对冒充不了这个事实。
+
+不复制真机的完整防火墙、真实 IP 或用户自定义内容; 全部在一次性 netns 里跑完就拆。
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+TPL = os.path.join(ROOT, "deploy", "firewall", "nftables-mihomo.conf")
+
+npass = nfail = nskip = 0
+
+
+def ok(m):
+    global npass
+    npass += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    global nfail
+    nfail += 1
+    print("[FAIL] %s" % m)
+
+
+def skip(m):
+    global nskip
+    nskip += 1
+    print("[SKIP] %s" % m)
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, shell=isinstance(cmd, str), capture_output=True,
+                          text=True, **kw)
+
+
+# ── 环境门 ────────────────────────────────────────────────────────────────────
+# 这支必须有真内核才有意义。环境不足就 SKIP 并说明白为什么, 不假装验过。
+def have_env():
+    if os.geteuid() != 0 and run("sudo -n true").returncode != 0:
+        return False, "需要 root 或免密 sudo 才能建 netns / 加载 nft"
+    # nft/ip 通常装在 /usr/sbin, 非 root 的 PATH 里没有 —— 只用 which 会把"权限不足"
+    # 误报成"没装", 于是这支在本可以跑的机器上静默跳过。两处都找。
+    for tool in ("ip", "nft"):
+        if not (shutil.which(tool) or any(
+                os.path.exists(os.path.join(d, tool))
+                for d in ("/usr/sbin", "/sbin", "/usr/local/sbin"))):
+            return False, "缺少 %s" % tool
+    p = run("%s ip netns add pdgts_probe" % SUDO)
+    if p.returncode != 0:
+        return False, "内核不允许建 netns: %s" % (p.stderr or "").strip()[:60]
+    run("%s ip netns del pdgts_probe" % SUDO)
+    return True, ""
+
+
+SUDO = "" if os.geteuid() == 0 else "sudo -n"
+
+BOX, TSC, PHY = "pdgts_box", "pdgts_tsc", "pdgts_phy"
+# 配置给 PDG 的内网段。**两个客户端地址都落在它里面** —— 这是这支测试的全部要害:
+# 判据若只看源地址, 两侧完全不可区分, 必须靠入口接口才能分开。
+CIDR = "100.64.0.0/16"
+# 两条链路用各自的 /30: box 上两个接口若同网段, 回包该走哪个接口是歧义的(实测会让
+# 物理侧假红)。/30 让路由确定, 而地址仍在上面那个 /16 内, 要害不受影响。
+TS_ADDR, BOX_TS = "100.64.1.2", "100.64.1.1"
+PHY_ADDR, BOX_PHY = "100.64.2.2", "100.64.2.1"
+
+
+def cleanup():
+    for ns in (BOX, TSC, PHY):
+        run("%s ip netns del %s" % (SUDO, ns))
+
+
+def build_lab():
+    """三个 netns: box(网关) + tsclient(经 tailscale0) + phyclient(经 wan0)。"""
+    cleanup()
+    cmds = [
+        # netns
+        "ip netns add %s" % BOX, "ip netns add %s" % TSC, "ip netns add %s" % PHY,
+        # veth: box.tailscale0 <-> tsclient.eth0
+        "ip link add tailscale0 netns %s type veth peer name eth0 netns %s" % (BOX, TSC),
+        # veth: box.wan0 <-> phyclient.eth0
+        "ip link add wan0 netns %s type veth peer name eth0 netns %s" % (BOX, PHY),
+        # 地址与启用
+        "ip -n %s addr add %s/30 dev tailscale0" % (BOX, BOX_TS),
+        "ip -n %s addr add %s/30 dev wan0" % (BOX, BOX_PHY),
+        "ip -n %s link set tailscale0 up" % BOX,
+        "ip -n %s link set wan0 up" % BOX,
+        "ip -n %s link set lo up" % BOX,
+        "ip -n %s addr add %s/30 dev eth0" % (TSC, TS_ADDR),
+        "ip -n %s link set eth0 up" % TSC,
+        "ip -n %s link set lo up" % TSC,
+        "ip -n %s addr add %s/30 dev eth0" % (PHY, PHY_ADDR),
+        "ip -n %s link set eth0 up" % PHY,
+        "ip -n %s link set lo up" % PHY,
+    ]
+    for c in cmds:
+        p = run("%s %s" % (SUDO, c))
+        if p.returncode != 0:
+            return "建实验床失败: %s → %s" % (c, (p.stderr or "").strip()[:80])
+    return ""
+
+
+def render(tpl_text):
+    """用测试值渲染真实模板。不使用任何生产配置。"""
+    return (tpl_text
+            .replace("__INTERNAL_CIDR__", CIDR)
+            .replace("__SSH_PORT__", "22")
+            .replace("__RESCUE_PORT__", "8446"))
+
+
+def load_nft(text):
+    """把渲染后的规则加载进 box netns。include 那行在实验床里没有对应目录, 剔掉。"""
+    text = "\n".join(L for L in text.splitlines() if "nft-input.d" not in L)
+    path = "/tmp/pdgts-rules.nft"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    p = run("%s ip netns exec %s nft -f %s" % (SUDO, BOX, path))
+    return p.returncode == 0, (p.stderr or "").strip()
+
+
+def probe_tcp(ns, dst, port, timeout=3):
+    """从 ns 发起一次 TCP 连接, 返回是否连上。"""
+    p = run("%s ip netns exec %s timeout %d bash -c "
+            "'</dev/tcp/%s/%d' 2>/dev/null" % (SUDO, ns, timeout, dst, port))
+    return p.returncode == 0
+
+
+def listener_start(port):
+    """在 box 里起一个 TCP 监听, 返回 Popen。"""
+    cmd = "%s ip netns exec %s python3 -c \"" % (SUDO, BOX) + (
+        "import socket;s=socket.socket();s.setsockopt(1,2,1);"
+        "s.bind(('0.0.0.0',%d));s.listen(16);" % port +
+        "__import__('time').sleep(3600)\"")
+    return subprocess.Popen(cmd, shell=True, stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+
+
+print("══ Tailscale 入口隔离(真 netns + 真 veth + 真 nft)══\n")
+
+envok, why = have_env()
+if not envok:
+    skip("整支跳过 —— %s" % why)
+    print("\n" + "─" * 66)
+    print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+    print("SKIP 归因: 本支必须在真内核里跑; 上面这条说明了缺什么。")
+    sys.exit(0)
+
+with open(TPL, encoding="utf-8") as f:
+    TPL_TEXT = f.read()
+
+# ── 静态门: 规则必须存在, 且必须排在来源匹配之前 ──────────────────────────────
+print("── 一、模板静态判据(顺序是安全属性, 不只是风格)──")
+
+lines = [L.rstrip() for L in TPL_TEXT.splitlines()]
+
+
+def chain_body(name):
+    out, inside, depth = [], False, 0
+    for L in lines:
+        if re.match(r"^\s*chain\s+%s\s*\{" % re.escape(name), L):
+            inside, depth = True, 1
+            continue
+        if inside:
+            depth += L.count("{") - L.count("}")
+            if depth <= 0:
+                break
+            out.append(L)
+    return out
+
+
+for chain in ("prerouting", "input"):
+    body = chain_body(chain)
+    if not body:
+        bad("%s: 模板里找不到这条链" % chain)
+        continue
+    ex = [i for i, L in enumerate(body) if 'iifname "tailscale0"' in L]
+    src = [i for i, L in enumerate(body) if "ip saddr __INTERNAL_CIDR__" in L]
+    if not ex:
+        bad("%s: 没有 iifname \"tailscale0\" 的排除规则 —— tailnet 会被当成内网来源" % chain)
+    elif not src:
+        ok("%s: 有排除规则(该链无来源匹配)" % chain)
+    elif min(ex) < min(src):
+        ok("%s: 排除规则排在来源匹配之前(第 %d 行 < 第 %d 行)" % (chain, min(ex), min(src)))
+    else:
+        bad("%s: 排除规则排在来源匹配**之后**(第 %d 行 > 第 %d 行) —— "
+            "先匹配再排除等于没排除" % (chain, min(ex), min(src)))
+
+# iif 与 iifname 不是一回事: iif 在加载时解析成接口索引, 接口不存在会导致整份规则加载失败。
+# 生产机在装 Tailscale **之前**就必须能加载这份规则, 所以只能用 iifname(运行时按名字匹配)。
+if re.search(r'^\s*iif\s+"tailscale0"', TPL_TEXT, re.M):
+    bad("用了 iif \"tailscale0\" —— 接口不存在时整份规则加载失败, 必须用 iifname")
+else:
+    ok("用 iifname 而非 iif(Tailscale 未安装时规则仍可加载)")
+
+# ── 动态门: 真流量 ────────────────────────────────────────────────────────────
+print("\n── 二、真 netns 流量(两侧源地址都在 %s 内, 只差接口)──" % CIDR)
+
+err = build_lab()
+if err:
+    bad(err)
+    cleanup()
+    print("\n" + "─" * 66)
+    print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+    sys.exit(1)
+
+loaded, lerr = load_nft(render(TPL_TEXT))
+if not loaded:
+    bad("规则加载失败(接口不存在时也必须能加载): %s" % lerr[:120])
+    cleanup()
+    print("\n" + "─" * 66)
+    print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+    sys.exit(1)
+ok("渲染后的真实模板在 box netns 里加载成功")
+
+lis = listener_start(7893)          # REDIRECT 的落点
+lis53 = listener_start(53)          # 接管链的 DNS 口
+time.sleep(1.0)
+
+try:
+    # 2a. 物理接口上的合法运营商 CGNAT: 必须照旧被接管(REDIRECT 到 7893)
+    if probe_tcp(PHY, BOX_PHY, 80):
+        ok("物理接口 %s(合法运营商 CGNAT)→ tcp/80 被 REDIRECT 接管" % PHY_ADDR)
+    else:
+        bad("物理接口 %s 的 tcp/80 没有被接管 —— 破坏了既有运营商支持" % PHY_ADDR)
+
+    # 2b. 同一个段, 但从 tailscale0 进来: 绝不能被接管
+    if probe_tcp(TSC, BOX_TS, 80):
+        bad("tailscale0 上的 %s → tcp/80 **被 REDIRECT 送进了透明代理**(P0 未修复)"
+            % TS_ADDR)
+    else:
+        ok("tailscale0 上的 %s → tcp/80 未进入 REDIRECT" % TS_ADDR)
+
+    # 2c. 接管链的 DNS 口: 物理侧通
+    if probe_tcp(PHY, BOX_PHY, 53):
+        ok("物理接口 → tcp/53 放行(SIM/APN DNS 接管照旧)")
+    else:
+        bad("物理接口 → tcp/53 不通 —— 破坏了既有 DNS 接管")
+
+    # 2d. 接管链的 DNS 口: tailnet 侧必须不通
+    if probe_tcp(TSC, BOX_TS, 53):
+        bad("tailscale0 → tcp/53 **进入了 SIM/APN DNS 接管链**(P0 未修复)")
+    else:
+        ok("tailscale0 → tcp/53 未进入 DNS 接管链")
+
+    # 2e. SSH 总闸不受影响: 两侧都应放行(规则不带 saddr, 排在排除规则之前)
+    ssh = listener_start(22)
+    time.sleep(0.8)
+    a, b = probe_tcp(PHY, BOX_PHY, 22), probe_tcp(TSC, BOX_TS, 22)
+    ssh.kill()
+    if a and b:
+        ok("SSH 总闸未被改动: 物理侧与 tailnet 侧都放行")
+    else:
+        bad("SSH 放行被改坏(物理=%s tailnet=%s) —— 本轮明确不得动它" % (a, b))
+finally:
+    lis.kill()
+    lis53.kill()
+    cleanup()
+
+print("\n" + "─" * 66)
+print("通过 %d, 失败 %d, 跳过 %d" % (npass, nfail, nskip))
+sys.exit(1 if nfail else 0)

--- a/tests/test-tailscale-ingress-isolation.py
+++ b/tests/test-tailscale-ingress-isolation.py
@@ -138,12 +138,28 @@ def build_lab():
     return ""
 
 
+def rescue_port():
+    """救援端口从 rescue_const.py 读, 不在这里写字面量。
+
+    仓库有一道守卫(test-rescue-constants.sh)禁止端口字面量散落, **注释里也不许写** ——
+    写死一个数字, 等到有人改了常量, 这支测试会拿着旧端口继续"通过", 而它守的恰恰是
+    端口相关的放行; 注释里的数字同样会过期并误导下一个人。
+    """
+    p = run([sys.executable, os.path.join(ROOT, "deploy", "bot", "rescue_const.py"),
+             "--port"], env={**os.environ, "PDG_RESCUE_PORT": ""})
+    v = (p.stdout or "").strip()
+    return v if v.isdigit() else ""
+
+
+RESCUE_PORT = rescue_port()
+
+
 def render(tpl_text):
     """用测试值渲染真实模板。不使用任何生产配置。"""
     return (tpl_text
             .replace("__INTERNAL_CIDR__", CIDR)
             .replace("__SSH_PORT__", "22")
-            .replace("__RESCUE_PORT__", "8446"))
+            .replace("__RESCUE_PORT__", RESCUE_PORT))
 
 
 def load_nft(text):
@@ -335,7 +351,7 @@ try:
     # 2h. 受保护端口全集: tailnet 一律进不去。上面单验了 53, 这里把其余几个补齐,
     #     免得"只挡住了 53"被当成"数据面隔离到位"。
     guarded = []
-    for port in (81, 853, 7893, 8445, 8446):
+    for port in (81, 853, 7893, 8445, int(RESCUE_PORT)):
         lp = listener_start(port)
         time.sleep(0.5)
         reachable = probe_tcp(TSC, BOX_TS, port)
@@ -345,7 +361,7 @@ try:
     if guarded:
         bad("tailnet 能连上受保护端口 %s —— 数据面隔离不完整" % guarded)
     else:
-        ok("tailnet 到 81/853/7893/8445/8446 全部被 policy drop 收口")
+        ok("tailnet 到 81/853/7893/8445/救援端口 全部被 policy drop 收口")
 finally:
     lis.kill()
     lis53.kill()

--- a/tests/test-tailscale-ingress-isolation.py
+++ b/tests/test-tailscale-ingress-isolation.py
@@ -95,6 +95,8 @@ CIDR = "100.64.0.0/16"
 # 物理侧假红)。/30 让路由确定, 而地址仍在上面那个 /16 内, 要害不受影响。
 TS_ADDR, BOX_TS = "100.64.1.2", "100.64.1.1"
 PHY_ADDR, BOX_PHY = "100.64.2.2", "100.64.2.1"
+# ULA, 只用于验证模板里那条 `ip6 nexthdr icmpv6 accept` 的契约; 不涉及任何真实地址。
+TS_ADDR6, BOX_TS6 = "fd00:64::2", "fd00:64::1"
 
 
 def cleanup():
@@ -124,6 +126,10 @@ def build_lab():
         "ip -n %s addr add %s/30 dev eth0" % (PHY, PHY_ADDR),
         "ip -n %s link set eth0 up" % PHY,
         "ip -n %s link set lo up" % PHY,
+        # IPv6: 模板有 `ip6 nexthdr icmpv6 accept`, 契约要求它照旧, 所以实验床也得能发 v6。
+        # 用 ULA, 不碰任何真实地址。
+        "ip -n %s addr add %s/64 dev tailscale0 nodad" % (BOX, BOX_TS6),
+        "ip -n %s addr add %s/64 dev eth0 nodad" % (TSC, TS_ADDR6),
     ]
     for c in cmds:
         p = run("%s %s" % (SUDO, c))
@@ -166,6 +172,18 @@ def probe_tcp(ns, dst, port, timeout=3):
     """从 ns 发起一次 TCP 连接, 返回是否连上。"""
     p = run("%s ip netns exec %s timeout %d bash -c "
             "'</dev/tcp/%s/%d' 2>/dev/null" % (SUDO, ns, timeout, dst, port))
+    return p.returncode == 0
+
+
+def probe_icmp(ns, dst, timeout=3):
+    """从 ns ping 一次。走真实 ICMP echo, 不是端口探测。"""
+    p = run("%s ip netns exec %s ping -c 1 -W %d -n %s" % (SUDO, ns, timeout, dst))
+    return p.returncode == 0
+
+
+def probe_icmp6(ns, dst, timeout=3):
+    """ICMPv6 echo。模板里有 `ip6 nexthdr icmpv6 accept`, 契约要求它照旧。"""
+    p = run("%s ip netns exec %s ping -6 -c 1 -W %d -n %s" % (SUDO, ns, timeout, dst))
     return p.returncode == 0
 
 
@@ -295,6 +313,39 @@ try:
         ok("SSH 总闸未被改动: 物理侧与 tailnet 侧都放行")
     else:
         bad("SSH 放行被改坏(物理=%s tailnet=%s) —— 本轮明确不得动它" % (a, b))
+
+    # 2f. **ICMP 契约**: 模板本来就有 `ip protocol icmp accept`, 隔离不得把它吃掉。
+    #     tailnet 是管理通道, ping 是最基本的可达性手段 —— 这条不是"顺便还能用",
+    #     而是冻结下来的验收项。排除规则必须排在 ICMP 放行**之后**才能同时满足两边。
+    if probe_icmp(TSC, BOX_TS):
+        ok("tailnet ICMP 可达(管理通道的既有契约保持)")
+    else:
+        bad("tailnet ICMP **不通** —— 隔离规则排在 ICMP 放行之前, 把它一起吃掉了")
+    if probe_icmp(PHY, BOX_PHY):
+        ok("物理接口 ICMP 可达(既有行为不变)")
+    else:
+        bad("物理接口 ICMP 不通 —— 改坏了既有 ICMP 放行")
+
+    # 2g. ICMPv6 同一份契约(模板有 `ip6 nexthdr icmpv6 accept`)
+    if probe_icmp6(TSC, BOX_TS6):
+        ok("tailnet ICMPv6 可达(ip6 nexthdr icmpv6 契约保持)")
+    else:
+        bad("tailnet ICMPv6 **不通** —— ICMPv6 放行被隔离规则吃掉了")
+
+    # 2h. 受保护端口全集: tailnet 一律进不去。上面单验了 53, 这里把其余几个补齐,
+    #     免得"只挡住了 53"被当成"数据面隔离到位"。
+    guarded = []
+    for port in (81, 853, 7893, 8445, 8446):
+        lp = listener_start(port)
+        time.sleep(0.5)
+        reachable = probe_tcp(TSC, BOX_TS, port)
+        lp.kill()
+        if reachable:
+            guarded.append(port)
+    if guarded:
+        bad("tailnet 能连上受保护端口 %s —— 数据面隔离不完整" % guarded)
+    else:
+        ok("tailnet 到 81/853/7893/8445/8446 全部被 policy drop 收口")
 finally:
     lis.kill()
     lis53.kill()


### PR DESCRIPTION
## 问题

Tailscale 给节点分配 `100.64.0.0/10`,而**运营商 SIM/APN 也合法使用同一段**(RFC 6598 CGNAT)。项目原本只按 `ip saddr $PDG_INTERNAL_CIDR` 判断要不要接管,不看包从哪个接口进来 —— 这两类来源在规则眼里完全一样。

后果不是理论问题:Tailscale 起来后跑一次 `pdg detect-cidr`(公开的用户命令),探测器在 `any` 接口抓到 tailnet 的包,就可能把 `100.64.x.x` 写进 `PDG_INTERNAL_CIDR`,此后 REDIRECT 规则改挂到 tailnet 段上,**tailnet 管理流量被送进 mihomo 透明代理**。

## 修复

**不全局禁止 `100.64/10`** —— 那会打断真实运营商 CGNAT 用户。正确的不变量是:是否进入 PDG 数据面 = 来源网段 **且** 入口接口。

- `detect-cidr` 按入口接口忽略 `tailscale0`
- nft 在 `prerouting` / `input` 于来源匹配前排除 `tailscale0`,用 `iifname` 而非 `iif`(Tailscale 未安装时规则仍可加载,永不命中)
- **保留 SSH、ICMP、ICMPv6**:排除规则排在它们之后、所有数据面规则之前
- 受保护端口(53/81/853/7893/8445/救援)与 REDIRECT 继续 fail-closed
- doctor 新增隔离检查,验证规则**存在且顺序正确**,不因看到 CGNAT 网段就报错

## 一并修掉的三处

**升级时防火墙不按模板重建。** `migrate_firewall_to_pdg` 只做一次性搬迁,已在 `inet pdg` 的机器再也收不到模板改动 —— 模板里"本表每次更新都会按模板重建"是写了没实现的契约。新增同步迁移,并区分三态:磁盘旧→重建;磁盘新+内核新→真 no-op;**磁盘新+内核旧→只 reload 不写盘**,reload 后复核内核是否收敛,不收敛返回非零。

**救援放行被误判成数据面来源匹配。** 救援按设计插在 input 链首且带 `ip saddr`,顺序判据把它当成来源匹配,于是任何启用过救援的机器一升级就判红。现在跳过带 `pdg-rescue` 标记的规则(认标记不认端口地址),排除规则仍必须排在真正的来源匹配之前。同时重建时保留这些标记规则 —— 否则常规更新会切断机器自己的救援通道。

**E2E 的 nft JSON 转换器丢 `iifname`。** 沙箱里 doctor 读的是 `tests/nftjson.py` 的输出,它认识 `iif` 不认识 `iifname`,认不出的匹配直接丢弃,于是规则在内核里而判据看不见。这解释了为什么真 netns 12/12 全绿、同一份规则在 E2E 全红:**两条路径读的是不同的 JSON 生成器**。

## 验证

**真 netns 双入口,两侧源地址都在 `100.64.0.0/16` 内**,唯一差别是入口接口 —— 只看源地址的判据对它们无从区分。13/13,root 与非 root 各一轮。

真 systemd + 真 `/dev/net/tun` + 真实 v1.10.1 PDG 沙盒,Tailscale 保持 NeedsLogin:`/etc/resolv.conf`、默认路由、`ip rule`、sysctl、`inet pdg` 语义指纹不变,常驻 PDG 服务 InvocationID 零重启。

六支升级类 E2E 红转绿:

| | 修前 | 修后 |
|---|---|---|
| `e2e-update.sh` | 37 / 4 | 41 / 0 |
| `e2e-upgrade-from-release.sh` | 9 / 4 | 13 / 0 |
| `e2e-update-preserve-userdata.sh` | 7 / 3 | 10 / 0 |
| `e2e-rescue-migration-lock.sh` | 首段 22 / 5 | 33/0 32/0 31/0 32/0 16/0 |

`e2e_seed_nft` 其余六支消费者共 243 断言 0 失败(夹具改动无第二类回归)。四支负控 51 格全部有效。本地全量 165 入口、红灯 0、SKIP 4 与基线逐支相同。

## 明确边界

- **尚未进行 tailnet 认证**,Phase 0 状态 3–8 未执行
- `pdg-bot` 因无真实 token 在沙盒未验,不冒充通过
- 直连 UDP 41641 可能被现有总闸拒绝,预计 DERP-only,留待认证后实测
- 本 PR **不启用** MagicDNS、Tailscale SSH、Exit Node、Subnet Router、Serve 或 Funnel
- 不包含 jp/jp2 生产部署
- C 态那道 reload 前的 `nft -c` 守的是不可达状态(磁盘必等于候选、候选必合法),保留作纵深防御,负控里未设该格并写明理由
- `nftjson.py` 的表达式覆盖目前只钉了四种规则形态,同类静默丢弃可能在下个新判据上重演 —— 已登记为待办

🤖 Generated with [Claude Code](https://claude.com/claude-code)