### PR TITLE
fix(cert): standalone 续期钩子的三个缺陷

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,10 @@ jobs:
       - name: "救援端口反解 (注入形态与模板独立行都要认; 真多端口才算多值)"
         run: bash tests/test-rescue-port-derivation.sh
 
+      # jp 上 certbot 每失败一次就多积一条 80 放行, 积到两条时 doctor 判红、升级整次回滚。
+      - name: "证书续期钩子 (加在哪就能从哪撤; 有 nft 却解析不到时不许落 iptables)"
+        run: bash tests/test-cert-hook-cleanup.sh
+
       # 本地只查几个手挑的文件, 新增的 tests/*.sh 就永远进不了门 —— 本地全绿, CI 判红。
       - name: "ShellCheck 范围守卫 (本地门必须与 CI 同范围, 范围从 ci.yml 读出)"
         run: bash tests/test-shellcheck-scope.sh

--- a/deploy/cert/proxy-gateway-open-cert-http.sh
+++ b/deploy/cert/proxy-gateway-open-cert-http.sh
@@ -29,8 +29,27 @@ _purge_cert_http() {
                      | grep "comment \"$MARK\"" | grep -oE 'handle [0-9]+$' | awk '{print $2}')
         done
     fi
+    # iptables 侧**只在这台机器根本没有 nft 时**才清 —— 与下面插入分支的门控对称:
+    # 只在写得进去的地方清。有 nft 却来调 iptables 是有害的: iptables-nft 会顺手
+    # **建出** `table ip filter`, 而那张表和 inet pdg 挂同一个 input hook, 它的存在
+    # 本身就是 doctor 判红「防火墙链冲突」的来源 —— 清理动作反而制造出要清理的东西。
+    # 门看的是 **$NFT 解析结果**, 不是 `command -v nft` —— 这正是本文件反复强调的那条:
+    # 本脚本由 certbot 的 timer/cron 拉起, PATH 里未必有 /usr/sbin, 只看 PATH 会把一台
+    # 有 nft 的机器误判成没有。$NFT 非空 = nft 侧已处理完, 直接收工。
+    [[ -n "$NFT" ]] && return 0
+    # $NFT 为空但 PATH 上有 nft: 说明 lib/nftbin.sh 缺失或坏了。插入分支在这种情况下
+    # 是响亮失败, 清理这边同样不许碰 iptables。
+    command -v nft >/dev/null 2>&1 && return 0
     if command -v iptables >/dev/null 2>&1; then
-        while iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do :; done
+        # 次数封顶: 退出条件是"iptables -D 终于返回非零", 而这个前提由外部命令决定。
+        # 碰上恒返回 0 的实现(测试桩、某些包装器)就是死循环 —— 这段跑在 certbot 的
+        # systemd timer 里, 挂住的是续期本身, 比它要修的缺陷更糟。上限取 32:
+        # 真实残骸是"每次认证失败积一条", 到不了这个量级。
+        local i=0
+        while [ "$i" -lt 32 ] \
+              && iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do
+            i=$((i + 1))
+        done
     fi
 }
 _purge_cert_http

--- a/deploy/cert/proxy-gateway-open-cert-http.sh
+++ b/deploy/cert/proxy-gateway-open-cert-http.sh
@@ -4,22 +4,55 @@
 # mihomo 模式: 80 口本就无人监听(nft 把内网来源 80 REDIRECT 到 7893, 外部 80 default-drop),
 #   certbot 可直接绑, 无需停代理 —— 续期期间保持在线。
 set -e
-CORE=$(cat /etc/privdns-gateway/backend 2>/dev/null || echo singbox)
-[[ "$CORE" == singbox ]] && { systemctl stop sing-box 2>/dev/null || true; }
+
 # nft 的位置走共用判据(lib/nftbin.sh): 本脚本由 certbot(systemd timer / cron)拉起, 那套
-# PATH 里未必有 /usr/sbin —— 只看 PATH 会当成"没装 nft"落到 iptables 分支, 80 口实际没放行,
-# ACME HTTP-01 验证失败, 证书悄悄续不上。
+# PATH 里未必有 /usr/sbin —— 只看 PATH 会当成"没装 nft"。
 NFT=""
 if [[ -f /opt/privdns-gateway/lib/nftbin.sh ]]; then
     # shellcheck source=../../lib/nftbin.sh
     . /opt/privdns-gateway/lib/nftbin.sh && NFT="$(pdg_nft_bin || true)"
 fi
 [[ -n "$NFT" ]] || NFT="$(command -v nft 2>/dev/null || true)"
-# 兼容两种表名: 新版独立表 inet pdg; 旧装(尚未迁移)仍是 inet filter。
+
+MARK='pdg-cert-http'
+
+# 进场先清一遍残骸: certbot 认证失败时以非零退出, post-hook **未必执行** —— jp 上就是这样,
+# 每失败一次就多积一条 80 放行, 积到两条时 doctor 判红、升级整次回滚。
+# 所以清理不能只挂在 post-hook 上, 这里也要兜一次; 两边都必须幂等。
+_purge_cert_http() {
+    if [[ -n "$NFT" ]]; then
+        for tbl in "inet pdg" "inet filter"; do
+            # shellcheck disable=SC2086  # tbl 有意按空格拆成 family + name
+            while read -r h; do
+                [[ -n "$h" ]] && "$NFT" delete rule $tbl input handle "$h" 2>/dev/null || true
+            done < <("$NFT" -a list table $tbl 2>/dev/null \
+                     | grep "comment \"$MARK\"" | grep -oE 'handle [0-9]+$' | awk '{print $2}')
+        done
+    fi
+    if command -v iptables >/dev/null 2>&1; then
+        while iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do :; done
+    fi
+}
+_purge_cert_http
+
+CORE=$(cat /etc/privdns-gateway/backend 2>/dev/null || echo singbox)
+[[ "$CORE" == singbox ]] && { systemctl stop sing-box 2>/dev/null || true; }
+
+# 放行加在哪里, 取决于这台机器用的是哪张表。带标记插入, 撤销才能精确定位 ——
+# 绝不按端口删: 用户完全可能自己写过一条同端口放行。
 if [[ -n "$NFT" ]] && "$NFT" list table inet pdg >/dev/null 2>&1; then
-    "$NFT" insert rule inet pdg input tcp dport 80 accept 2>/dev/null || true
+    "$NFT" insert rule inet pdg input tcp dport 80 accept comment "$MARK" 2>/dev/null || true
 elif [[ -n "$NFT" ]] && "$NFT" list table inet filter >/dev/null 2>&1; then
-    "$NFT" insert rule inet filter input tcp dport 80 accept 2>/dev/null || true
+    "$NFT" insert rule inet filter input tcp dport 80 accept comment "$MARK" 2>/dev/null || true
+elif [[ -z "$NFT" ]] && command -v nft >/dev/null 2>&1; then
+    # 有 nft 却解析不到路径, 说明 lib/nftbin.sh 缺失或坏了。这时**绝不能**落到 iptables:
+    # iptables-nft 会建出 `table ip filter`, 而它和 inet pdg 挂同一个 input hook,
+    # PDG 那条是 policy drop —— 加进去的放行从一开始就被架空(实测 packets 0),
+    # 认证必然失败, 还留下越积越多的残骸。响亮地失败比悄悄留个没用的规则强。
+    echo "pre-hook: 找不到可用的 nft(lib/nftbin.sh 缺失?), 拒绝改用 iptables —— " \
+         "那会在 inet pdg 同 hook 上建一张被架空的表。请修好 nft 路径后重试。" >&2
+    exit 1
 elif command -v iptables >/dev/null 2>&1; then
+    # 这台机器根本没有 nft(纯 iptables 环境), 此时 iptables 分支是唯一且正确的选择。
     iptables -I INPUT 1 -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null || true
 fi

--- a/deploy/cert/proxy-gateway-restore-firewall.sh
+++ b/deploy/cert/proxy-gateway-restore-firewall.sh
@@ -1,19 +1,34 @@
 #!/bin/bash
 # certbot --standalone post-hook: 还原防火墙 + (sing-box 模式)把 80 口还给 sing-box。
 set -e
-# nft 位置同 pre-hook, 走共用判据(lib/nftbin.sh): PATH 里没有 sbin 时若落到 iptables 分支,
-# pre-hook 插进 nft 的那条 80 口放行就永远撤不掉了。
+
+# nft 位置同 pre-hook, 走共用判据(lib/nftbin.sh)。
 NFT=""
 if [[ -f /opt/privdns-gateway/lib/nftbin.sh ]]; then
     # shellcheck source=../../lib/nftbin.sh
     . /opt/privdns-gateway/lib/nftbin.sh && NFT="$(pdg_nft_bin || true)"
 fi
 [[ -n "$NFT" ]] || NFT="$(command -v nft 2>/dev/null || true)"
-if [[ -n "$NFT" ]] && [[ -f /etc/nftables.conf ]]; then
-    "$NFT" -f /etc/nftables.conf 2>/dev/null || true
-elif command -v iptables >/dev/null 2>&1; then
+
+MARK='pdg-cert-http'
+
+# 清理必须**覆盖全部三处且幂等**, 不依赖"当初加在哪"这个记忆。
+# 原因: 两个钩子各算各的 —— 以前 post 的 nft 分支只做 `nft -f /etc/nftables.conf`,
+# 而那份配置只定义 inet pdg, 重载它根本不碰 ip filter。于是 pre 落 iptables、post 走 nft 时,
+# 残骸永远撤不掉。按标记逐处删就没有这个缝。
+if [[ -n "$NFT" ]]; then
+    for tbl in "inet pdg" "inet filter"; do
+        # shellcheck disable=SC2086  # tbl 有意按空格拆成 family + name
+        while read -r h; do
+            [[ -n "$h" ]] && "$NFT" delete rule $tbl input handle "$h" 2>/dev/null || true
+        done < <("$NFT" -a list table $tbl 2>/dev/null \
+                 | grep "comment \"$MARK\"" | grep -oE 'handle [0-9]+$' | awk '{print $2}')
+    done
+fi
+if command -v iptables >/dev/null 2>&1; then
     while iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do :; done
 fi
+
 CORE=$(cat /etc/privdns-gateway/backend 2>/dev/null || echo singbox)
 [[ "$CORE" == singbox ]] && { systemctl start sing-box 2>/dev/null || true; }
 # mihomo 模式: 全程没停 mihomo, 无需启动

--- a/deploy/cert/proxy-gateway-restore-firewall.sh
+++ b/deploy/cert/proxy-gateway-restore-firewall.sh
@@ -12,10 +12,11 @@ fi
 
 MARK='pdg-cert-http'
 
-# 清理必须**覆盖全部三处且幂等**, 不依赖"当初加在哪"这个记忆。
-# 原因: 两个钩子各算各的 —— 以前 post 的 nft 分支只做 `nft -f /etc/nftables.conf`,
-# 而那份配置只定义 inet pdg, 重载它根本不碰 ip filter。于是 pre 落 iptables、post 走 nft 时,
-# 残骸永远撤不掉。按标记逐处删就没有这个缝。
+# 两件事, 互补不是替代:
+#   ① 按标记逐处删 —— 补重载够不着的地方。`nft -f` 那份配置只定义 inet pdg, 重载它
+#      根本不碰 `inet filter`; 于是 pre 落一处、post 重载另一处时, 残骸永远撤不掉。
+#   ② 重载磁盘配置 —— post-hook 的本职: 把防火墙恢复到规范状态, 而不只是"删掉我加的那条"。
+# 顺序是先删后重载: 重载在最后, 最终状态就是磁盘上的规范状态。
 if [[ -n "$NFT" ]]; then
     for tbl in "inet pdg" "inet filter"; do
         # shellcheck disable=SC2086  # tbl 有意按空格拆成 family + name
@@ -25,8 +26,24 @@ if [[ -n "$NFT" ]]; then
                  | grep "comment \"$MARK\"" | grep -oE 'handle [0-9]+$' | awk '{print $2}')
     done
 fi
-if command -v iptables >/dev/null 2>&1; then
-    while iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do :; done
+# iptables 侧**只在这台机器根本没有 nft 时**才清 —— 与 pre-hook 插入分支的门控对称:
+# 只在写得进去的地方清。有 nft 却来调 iptables 是有害的: iptables-nft 会顺手**建出**
+# `table ip filter`, 而那张表和 inet pdg 挂同一个 input hook, 它的存在本身就是 doctor
+# 判红「防火墙链冲突」的来源 —— 清理动作反而制造出要清理的东西。
+if [[ -z "$NFT" ]] && ! command -v nft >/dev/null 2>&1 && command -v iptables >/dev/null 2>&1; then
+    # 次数封顶, 理由同 pre-hook: 退出条件由外部命令决定, 恒返回 0 的实现会让它死循环。
+    i=0
+    while [ "$i" -lt 32 ] \
+          && iptables -D INPUT -p tcp --dport 80 -m comment --comment proxy-gateway-cert-http -j ACCEPT 2>/dev/null; do
+        i=$((i + 1))
+    done
+fi
+
+# ② 重载: 把 inet pdg 恢复成磁盘上的样子。失败不致命(标记规则上面已经删干净了),
+# 但要出声 —— 静默跳过等于防火墙停在一个没人声明过的状态。
+if [[ -n "$NFT" ]]; then
+    "$NFT" -f /etc/nftables.conf 2>/dev/null \
+        || echo "post-hook: 重载 /etc/nftables.conf 失败, 防火墙可能未回到规范状态" >&2
 fi
 
 CORE=$(cat /etc/privdns-gateway/backend 2>/dev/null || echo singbox)

--- a/tests/test-cert-hook-cleanup.sh
+++ b/tests/test-cert-hook-cleanup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# 证书 standalone 续期钩子: 加在哪里就必须能从哪里撤掉, 且不许加一条注定无效的规则。
+#
+# ── 这支的由来 ────────────────────────────────────────────────────────────────
+# jp 上 certbot 反复失败, 每失败一次 `table ip filter` 就多积一条 `tcp dport 80 accept`,
+# 积到两条时 doctor 判红两项, 升级整次回滚。查下来是钩子的两个结构性问题:
+#
+#   1) pre-hook 解析不到 nft 时会落到 iptables 分支, 而 iptables-nft 会建出
+#      `table ip filter`。那张表和 `inet pdg` 挂**同一个 input hook**, 而 PDG 那条是
+#      `policy drop` —— 加进去的放行**从一开始就被架空**(实测 packets 0, 一个包都没匹配过)。
+#      认证必然失败, 于是"证书悄悄续不上"+"残骸越积越多"同时发生。
+#      有 `inet pdg` 却解析不到 nft, 正确的反应是**响亮地失败**, 不是加一条没用的规则。
+#
+#   2) 两个钩子对"规则加在哪"的判断**各算各的**: post-hook 的 nft 分支只做
+#      `nft -f /etc/nftables.conf`, 而那份配置只定义 `inet pdg` —— 重载它根本不碰
+#      `ip filter`。pre 落 iptables、post 走 nft 时, 残骸就永远撤不掉。
+#      清理必须**幂等且覆盖全部三处**, 不能依赖"当初加在哪"这个记忆。
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+PRE="$ROOT/deploy/cert/proxy-gateway-open-cert-http.sh"
+POST="$ROOT/deploy/cert/proxy-gateway-restore-firewall.sh"
+
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+for f in "$PRE" "$POST"; do
+  [[ -f "$f" ]] || { bad "找不到 $f"; echo; echo "通过 $pass, 失败 $nfail"; exit 1; }
+done
+
+# ── 一、有 inet pdg 却解析不到 nft: 不许落 iptables, 必须失败 ─────────────────
+# 判据看的是"有 nft 却解析不到路径时是否拒绝 iptables", 不是字面量 —— 守卫写成 exit 1
+# 加一句说明就够, 不必长成某个特定形状。
+if grep -qE 'command -v nft .*&&|拒绝改用 iptables' "$PRE" && grep -q 'exit 1' "$PRE"; then
+  ok "pre-hook 在有 nft 却解析不到路径时拒绝落 iptables(响亮失败而非留无效规则)"
+elif false; then
+  bad "pre-hook 仍会在有 inet pdg 时落到 iptables 分支 —— 那条规则被 policy drop 架空, 证书必然续不上"
+else
+  bad "pre-hook 仍会在有 inet pdg 时落到 iptables —— 那条规则被 policy drop 架空"
+fi
+
+# ── 二、插入的规则必须带标记, 才能精确撤销 ───────────────────────────────────
+# 标记可以走变量(MARK=...), 判据认"有标记常量且插入时带上了", 不钉死字面量写法。
+if grep -qE "^MARK=.*pdg-cert-http" "$PRE" && grep -qE 'insert rule .* comment "\$MARK"' "$PRE"; then
+  ok "pre-hook 插入的放行带 pdg-cert-http 标记(可精确撤销)"
+else
+  bad "pre-hook 的放行没有标记 —— 只能靠端口猜, 而用户可能自己写过同端口放行"
+fi
+
+# ── 三、清理必须覆盖全部三处, 且不依赖"当初加在哪" ───────────────────────────
+for place in 'inet pdg' 'inet filter' 'iptables'; do
+  if grep -q "$place" "$POST"; then
+    ok "post-hook 覆盖 $place"
+  else
+    bad "post-hook 不清理 $place —— pre 落在那里时残骸永远撤不掉"
+  fi
+done
+
+# ── 四、pre-hook 自己进场也要先清一遍(post 没跑到时的兜底)──────────────────
+# certbot 失败退出时 post-hook 未必执行, 所以残骸只能靠下一次 pre-hook 进场清。
+if grep -qE '(清理|cleanup|_purge)' "$PRE"; then
+  ok "pre-hook 进场先清残骸(post 没跑到时的兜底)"
+else
+  bad "pre-hook 不清残骸 —— certbot 失败时 post 未必执行, 残骸会一次次累积"
+fi
+
+echo
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail ? 1 : 0 ))


### PR DESCRIPTION
## 背景

jp 上 `certbot.service` 反复 failed，每失败一次内核里的 `table ip filter` 就多积一条
`tcp dport 80 accept`。积到两条时 doctor 判红两项（「80 对全网放行」+「防火墙链冲突」），
**升级因此整次回滚** —— 这是 v1.10.3 装不上去的第二道坎。

现场处置（删掉那个第三方域名 `gkgj.abrdns.com` 与残骸表）已在 2026-08-18 做完，
但**钩子脚本本身的缺陷当时原样保留**。它们是本项目的文件、`install.sh` 会装，
将来谁在这类机器上配一个 standalone 续期的域名，会踩同一个坑。

## 三个独立缺陷

1. **落错表** —— `pre_hook` 解析不到 nft 时会落 iptables 分支，而 `iptables-nft` 建出的
   `table ip filter` 与 `inet pdg` 挂**同一个 input hook**，PDG 那条是 `policy drop`，
   加进去的放行从一开始就被架空。`packets 0` 是铁证：那两条规则一个包都没匹配过。
   **这套机制对任何 standalone 域名都从没成功过**，不只是那一个域名的问题。

   → 现在：有 nft 却解析不到路径时**响亮失败**，而不是留一条注定无效的规则。

2. **撤不掉** —— 两个钩子对「规则加在哪」各算各的：`post_hook` 的 nft 分支只做
   `nft -f /etc/nftables.conf`，而那份配置只定义 `inet pdg`，重载它根本碰不到 `ip filter`。
   于是 pre 落 iptables、post 走 nft 时，残骸永远撤不掉。

   → 现在：插入时带 `comment "pdg-cert-http"` 标记，撤销按标记**逐处精确删**，覆盖
   `inet pdg` / `inet filter` / iptables **全部三处**，幂等，不依赖「当初加在哪」的记忆。
   刻意**不按端口删** —— 用户完全可能自己写过一条同端口放行。

3. **失败时不清理** —— certbot 认证失败以非零退出，`post_hook` **未必执行**（取决于版本
   与写法，不能假定）。jp 上第二条残骸就是这么来的。

   → 现在：`pre_hook` **进场先清一遍**，清理不再只挂在 post 上；两边都幂等。

## 判据

新增 `tests/test-cert-hook-cleanup.sh`（6 项，已登记进 `ci.yml`）。

## 尚未覆盖的

- 这套机制**此前从没成功过**，所以修复**没有历史成功样本可对照**。
- jp/jp2 目前都没有 standalone 续期的域名（`gkgj` 已删），**修复尚未在真机上被真实触发过**。
- 更彻底的做法仍是让这类域名改走 webroot 或 DNS-01，根本不需要临时开 80。
  本次只修了 standalone 这条路径本身，没有改变认证方式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)