### PR TITLE
test(cert): 让钩子清理判据长出牙齿(真执行, 不再只 grep)

### DIFF
--- a/tests/test-cert-hook-cleanup.sh
+++ b/tests/test-cert-hook-cleanup.sh
@@ -34,8 +34,6 @@ done
 # 加一句说明就够, 不必长成某个特定形状。
 if grep -qE 'command -v nft .*&&|拒绝改用 iptables' "$PRE" && grep -q 'exit 1' "$PRE"; then
   ok "pre-hook 在有 nft 却解析不到路径时拒绝落 iptables(响亮失败而非留无效规则)"
-elif false; then
-  bad "pre-hook 仍会在有 inet pdg 时落到 iptables 分支 —— 那条规则被 policy drop 架空, 证书必然续不上"
 else
   bad "pre-hook 仍会在有 inet pdg 时落到 iptables —— 那条规则被 policy drop 架空"
 fi
@@ -63,6 +61,98 @@ if grep -qE '(清理|cleanup|_purge)' "$PRE"; then
   ok "pre-hook 进场先清残骸(post 没跑到时的兜底)"
 else
   bad "pre-hook 不清残骸 —— certbot 失败时 post 未必执行, 残骸会一次次累积"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 以下三格**真的执行钩子**。
+#
+# 上面四格全是对源码 grep —— 那种判据看不见行为。实际发生过: 一版修复同时带着死循环、
+# 无条件调 iptables、删掉了配置重载三处缺陷, 这支照样 6/0 全绿(`grep -q iptables "$POST"`
+# 反而因为那行存在而通过), 最后是 tests/test-nft-input-scan.py 抓到的。
+# 静态判据留着仍有用(它们钉的是意图), 但必须有真跑的一档在下面兜着。
+# ═══════════════════════════════════════════════════════════════════════════════
+
+command -v timeout >/dev/null 2>&1 || { echo "[SKIP] 无 timeout, 跳过执行档"; }
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pdg-certhook.XXXXXX")"
+[[ -n "${PDG_KEEP_TMP:-}" ]] || trap 'rm -rf "$TMP"' EXIT
+[[ -n "${PDG_KEEP_TMP:-}" ]] && echo "[dbg] TMP=$TMP"
+STUB="$TMP/stub"; mkdir -p "$STUB"
+NFT_LOG="$TMP/nft.log"; IPT_LOG="$TMP/ipt.log"; CONF="$TMP/nftables.conf"
+printf 'table inet pdg {}\n' > "$CONF"
+
+# 桩一律 `exit 0` —— 这正是死循环那次的触发条件, 刻意保留。
+_stub(){ printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> %s\nexit 0\n' "$2" > "$1"; chmod 755 "$1"; }
+_stub "$STUB/iptables" "$IPT_LOG"
+_stub "$STUB/nft"      "$NFT_LOG"
+printf '#!/bin/sh\nexit 0\n' > "$STUB/systemctl"; chmod 755 "$STUB/systemctl"
+# 第五格要走 iptables 分支, 那要求"这台机器根本没有 nft" —— 所以另备一个**不含 nft**
+# 的桩目录。第一版写这格时共用了上面那个: `command -v nft` 命中 nft 桩 → 走 nft 分支 →
+# iptables 一次都没调, 断言却因为"没挂死"而绿。日志里那句"调用 0 次"是它露的马脚。
+NONFT="$TMP/stub-nonft"; mkdir -p "$NONFT"
+_stub "$NONFT/iptables" "$IPT_LOG"
+printf '#!/bin/sh\nexit 0\n' > "$NONFT/systemctl"; chmod 755 "$NONFT/systemctl"
+
+# 把钩子拷进沙箱, 绝对路径改指沙箱(不给生产代码加接缝)
+_sandbox_hook(){        # $1=源 $2=目标 $3=lib 目录(可以是不存在的路径)
+  sed -e "s#/opt/privdns-gateway/lib#$3#g" -e "s#/etc/nftables.conf#$CONF#g" "$1" > "$2"
+  chmod 755 "$2"
+}
+
+# ── 五、桩恒返回 0 时不许挂死 ────────────────────────────────────────────────
+# 清理循环的退出条件是"iptables -D 终于返回非零", 而那由外部命令决定。恒返回 0 的实现
+# (测试桩、某些包装器)会让它转到天荒地老。这段跑在 certbot 的 systemd timer 里,
+# 挂住的是**续期本身** —— 比它要修的缺陷更糟, 所以必须有次数上限。
+: > "$IPT_LOG"
+_sandbox_hook "$PRE" "$TMP/pre-noNft.sh" "$TMP/nolib"     # lib 指向不存在 → $NFT 为空
+if PATH="$NONFT:/usr/bin:/bin" timeout 20 bash "$TMP/pre-noNft.sh" >/dev/null 2>&1; then rc=0; else rc=$?; fi
+_n=$(wc -l < "$IPT_LOG")
+if [[ "$_n" -eq 0 ]]; then
+  bad "这一格空转了: iptables 一次都没被调到, 说明根本没走进要测的那条分支"
+elif [[ "$rc" == 124 ]]; then
+  bad "pre-hook 在恒返回 0 的 iptables 下挂死(20s 未退出) —— 清理循环没有次数上限"
+elif [[ "$_n" -gt 64 ]]; then
+  bad "pre-hook 调了 iptables $_n 次 —— 上限失效"
+else
+  ok "pre-hook 面对恒返回 0 的 iptables 仍能退出(rc=$rc, 调用 $_n 次), 清理循环有上限"
+fi
+
+# ── 六、解析得到 nft 时, 一次都不许碰 iptables ───────────────────────────────
+# iptables-nft 会顺手**建出** `table ip filter`, 而那张表和 inet pdg 挂同一个 input hook
+# —— 它的存在本身就是 doctor 判红「防火墙链冲突」的来源。清理动作反而制造出要清理的东西。
+#
+# 场景必须是**真实的那一个**: $NFT 经 lib/nftbin.sh 解析得到, 而 `nft` **不在 PATH 上**。
+# 这正是 certbot 的 timer/cron 环境(PATH 无 /usr/sbin)。第一版判据把 nft 桩放进 PATH,
+# 于是无论门写成 `[[ -n "$NFT" ]]` 还是 `command -v nft`, 两条都成立 —— 判据看不出区别,
+# 拆掉正确的那道门它照样绿。把 nft 藏到 PATH 之外, 两者才分得开。
+FAKE="$TMP/fakerepo"; mkdir -p "$FAKE/lib" "$FAKE/deploy/bot" "$TMP/hidden"
+cp "$ROOT/lib/nftbin.sh" "$FAKE/lib/nftbin.sh"
+_stub "$TMP/hidden/nft" "$NFT_LOG"                 # 藏在 PATH 之外
+cat > "$FAKE/deploy/bot/nftscan.py" <<PY
+import sys
+if "--nft-path" in sys.argv: print("$TMP/hidden/nft")
+PY
+for _h in "$PRE" "$POST"; do
+  _nm="$(basename "$_h")"
+  : > "$IPT_LOG"; : > "$NFT_LOG"
+  _sandbox_hook "$_h" "$TMP/x.sh" "$FAKE/lib"
+  PATH="$NONFT:/usr/bin:/bin" REPO_DIR="$FAKE" timeout 20 bash "$TMP/x.sh" >/dev/null 2>&1
+  if [[ ! -s "$NFT_LOG" ]]; then
+    bad "$_nm 这一格空转了: nft 一次都没被调到, 说明 \$NFT 压根没解析出来"
+  elif [[ -s "$IPT_LOG" ]]; then
+    bad "$_nm 在 nft 可用时仍调了 iptables($(wc -l < "$IPT_LOG") 次) —— iptables-nft 会建出 ip filter, 那正是要清理的东西"
+  else
+    ok "$_nm 在 nft 解析得到(但不在 PATH 上)时一次都没碰 iptables"
+  fi
+  [[ "$_h" == "$POST" ]] && cp "$NFT_LOG" "$TMP/post-nft.log"
+done
+
+# ── 七、post-hook 必须重载磁盘配置 ───────────────────────────────────────────
+# 按标记逐处删是**补**重载够不着的地方(那份配置只定义 inet pdg, 碰不到 inet filter),
+# 不是**替代**它。post-hook 的本职是把防火墙恢复到规范状态, 不只是"删掉我加的那条"。
+if grep -qF -- "-f $CONF" "$TMP/post-nft.log" 2>/dev/null; then
+  ok "post-hook 重载了磁盘配置(把防火墙恢复到规范状态, 不只是删掉自己加的那条)"
+else
+  bad "post-hook 没有重载磁盘配置 —— 只删自己加的那条不等于恢复规范状态"
 fi
 
 echo


### PR DESCRIPTION
## 为什么

`tests/test-cert-hook-cleanup.sh` 原来六格全是对源码 `grep`。实证它没有牙齿：上一版修复
（PR #15 的 `401c23c`）同时带着**三处**缺陷 —— 死循环、无条件调 iptables、删掉了配置重载
—— 它照样 6/0 全绿。其中 `grep -q iptables "$POST"` 反而因为那行存在而**通过**。

真正抓到的是 `tests/test-nft-input-scan.py`（我根本没碰的既有判据，它会**执行**这两个钩子）。

## 补了三格真执行的

| 格 | 咬什么 |
|---|---|
| 五 | 桩恒返回 0 时不许挂死 —— 这段跑在 certbot 的 systemd timer 里，挂住的是续期本身 |
| 六 | `$NFT` 解析得到时一次都不许碰 iptables —— `iptables-nft` 会**建出** `ip filter`，而那正是要清理的东西 |
| 七 | post-hook 必须重载磁盘配置 —— 按标记删是**补**重载够不着的地方，不是替代它 |

第六格的场景必须是**真实的那一个**：nft 经 `lib/nftbin.sh` 解析得到、而**不在 PATH 上**
（certbot 的 timer/cron 没有 `/usr/sbin`）。第一版把 nft 桩放进了 PATH，于是门写成
`[[ -n "$NFT" ]]` 还是 `command -v nft` 两条都成立，判据看不出区别。

## 两处空转守卫

都是实际踩到的：第五格第一版共用了含 nft 桩的目录 → 走了 nft 分支 → iptables 调用 **0 次**
却因为"没挂死"而绿。现在一次都没调到就直接判死。第六格同理（nft 未被调到即判死）。

## 负控

改坏落在工作副本、逐格 `git checkout` 还原：

```
拆循环上限     → 红(挂死)
拆 pre 的门    → 红(nft 可用时调了 iptables)
拆 post 的门   → 红(同上)
拆重载         → 红(没重载磁盘配置)
追加无关注释   → 仍绿
```

本地 10/0。仅测试文件改动，无生产代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)