### PR TITLE
fix(tests): nftjson 认不出就报错, 不再丢半条规则

### DIFF
--- a/tests/nftjson.py
+++ b/tests/nftjson.py
@@ -15,11 +15,31 @@
      统一调这里。
 
 覆盖的语法就是 deploy/firewall/nftables-mihomo.conf 那套形态(它是渲染出来的, 不是手写的,
-所以形态有限)。遇到不认识的行**跳过而不是猜** —— 猜出来的规则会让判据对着不存在的东西打转。
+所以形态有限), 外加真机上会出现的两种注入形态(救援放行带 `ip daddr` + 标记, 证书钩子带标记)。
+
+**认不出来时怎么办, 分两种**:
+
+  · 整行压根不是规则(`include ...`、空行、括号) → 跳过, 这是对的。
+  · 是规则、但里面有**没被任何匹配器吃掉的残渣** → **报错退非零, 绝不输出**。
+    以前的行为是"能认多少认多少, 剩下的丢掉", 于是 `iifname "tailscale0" return`
+    变成裸 `return` —— 规则还在, 接口条件没了。判据按接口名找就永远找不到, 而内核里
+    其实有。六个升级类 E2E 因此全红, 真 nft 环境下同一份规则 12/12 全绿(真 nft 自己
+    出 JSON), 排查方向被带偏好几轮。
+    丢一整条规则至少会让 audit_kernel 说"缺规则"; 丢半条给出的是一个**看着正常的错
+    答案**, 那是本项目最危险的一类缺陷(见交接文档 9.1)。宁可让桩自己喊"我不认识"。
 """
 import json
 import re
 import sys
+
+
+class UnknownSyntax(Exception):
+    """规则里有没被吃掉的残渣 —— 与其丢半条, 不如让调用方知道转换器落后于配置。"""
+
+    def __init__(self, line, residue):
+        self.line = line
+        self.residue = residue
+        super().__init__("nftjson 不认识这段语法: %r (整行: %r)" % (residue, line))
 
 _TABLE = re.compile(r"^\s*table\s+(?P<family>\w+)\s+(?P<name>\S+)\s*\{")
 _CHAIN = re.compile(r"^\s*chain\s+(?P<name>\S+)\s*\{")
@@ -62,6 +82,26 @@ def _ports(spec):
     return out
 
 
+def _eat(eaten, m):
+    """记下这个匹配吃掉的区间。残渣判定全靠它 —— 少记一处就会误报"不认识"。"""
+    if m:
+        eaten.append(m.span())
+    return m
+
+
+def _residue(line, eaten):
+    """挖掉所有被吃掉的区间, 剩下的还有实义字符吗。
+
+    只把**空白与分隔符**当无害(`;` `,` 是 nft 的语法噪声)。任何字母数字残留都算
+    "有一段我没看懂" —— 那正是 iifname 那次的形态, 它当时就是被整段忽略掉的。
+    """
+    chars = list(line)
+    for a, b in eaten:
+        for i in range(a, b):
+            chars[i] = " "
+    return re.sub(r"[\s;,]+", "", "".join(chars))
+
+
 def _match(proto, field, right):
     return {"match": {"op": "==",
                       "left": {"payload": {"protocol": proto, "field": field}},
@@ -69,33 +109,37 @@ def _match(proto, field, right):
 
 
 def _rule_expr(line):
-    """一行规则 → expr 列表。认不出来的返回 None(跳过, 不猜)。"""
+    """一行规则 → expr 列表。
+
+    整行不是规则 → None(跳过)。是规则但有残渣 → 抛 UnknownSyntax(绝不丢半条)。
+    """
     expr = []
-    m = _IIFNAME.search(line)
+    eaten = []                      # 已被某个匹配器吃掉的区间, 用来算残渣
+    m = _eat(eaten, _IIFNAME.search(line))
     if m:
         expr.append({"match": {"op": "==", "left": {"meta": {"key": "iifname"}},
                                "right": m.group("dev")}})
     else:
-        m = _IIF.search(line)
+        m = _eat(eaten, _IIF.search(line))
         if m:
             expr.append({"match": {"op": "==", "left": {"meta": {"key": "iif"}},
                                    "right": m.group("dev")}})
-    m = _CT.search(line)
+    m = _eat(eaten, _CT.search(line))
     if m:
         expr.append({"match": {"op": "in", "left": {"ct": {"key": "state"}},
                                "right": m.group("states").split(",")}})
-    m = _SADDR.search(line)
+    m = _eat(eaten, _SADDR.search(line))
     if m:
         net, ln = m.group("cidr").split("/")
         expr.append({"match": {"op": "==",
                                "left": {"payload": {"protocol": "ip", "field": "saddr"}},
                                "right": {"prefix": {"addr": net, "len": int(ln)}}}})
-    m = _DADDR.search(line)
+    m = _eat(eaten, _DADDR.search(line))
     if m:
         expr.append({"match": {"op": "==",
                                "left": {"payload": {"protocol": "ip", "field": "daddr"}},
                                "right": m.group("ip")}})
-    m = _PROTO.search(line)
+    m = _eat(eaten, _PROTO.search(line))
     if m:
         # nft 会把 icmpv6 归一成 ipv6-icmp —— 桩也照做, 好让"协议别名不算漂移"这条判据
         # 在沙箱里同样成立(它正是 .153 那四条假漂移之一)。
@@ -105,31 +149,36 @@ def _rule_expr(line):
                                                     else "ip", "field": "nexthdr"
                                                     if "nexthdr" in line else "protocol"}},
                                "right": "ipv6-icmp" if p == "icmpv6" else p}})
-    m = _DPORT.search(line)
+    m = _eat(eaten, _DPORT.search(line))
     if m:
         right = ({"set": _ports(m.group("set"))} if m.group("set") is not None
                  else int(m.group("one")))
         expr.append(_match(m.group("proto"), "dport", right))
-    m = _REDIR.search(line)
+    m = _eat(eaten, _REDIR.search(line))
     if m:
         expr.append({"redirect": {"port": int(m.group("port"))}})
     else:
         for v in _VERDICTS:
-            if re.search(r"\b%s\b" % v, line):
+            mv = _eat(eaten, re.search(r"\b%s\b" % v, line))
+            if mv:
                 if v == "reject":
                     # nft 打印 reject 时会补上默认类型 —— 同样是那四条"假漂移"之一
                     expr.append({"reject": {"type": "icmp", "expr": "port-unreachable"}})
                 else:
                     expr.append({v: None})
                 break
-    m = _COMMENT.search(line)
+    m = _eat(eaten, _COMMENT.search(line))
     if m:
         expr.append({"comment": m.group("c")})
-    # 只有 match 没有 verdict, 或者两者都没有 → 认不出来
+    # 只有 match 没有 verdict, 或两者都没有 → 这行压根不是规则(include/括号/空行), 跳过
     if not expr or not any(k in e for e in expr
                            for k in ("accept", "drop", "reject", "redirect", "return",
                                      "masquerade", "continue")):
         return None
+    # 是规则了。还有没被吃掉的实义字符 = 我只认得一半 —— 那是最会骗人的形态, 拒绝输出。
+    left = _residue(line, eaten)
+    if left:
+        raise UnknownSyntax(line.strip(), left)
     return expr
 
 
@@ -191,7 +240,15 @@ def to_json(text, family="inet", table="pdg"):
 def main(argv):
     fam = argv[1] if len(argv) > 1 else "inet"
     tab = argv[2] if len(argv) > 2 else "pdg"
-    obj = to_json(sys.stdin.read(), fam, tab)
+    try:
+        obj = to_json(sys.stdin.read(), fam, tab)
+    except UnknownSyntax as e:
+        # 退 2 而不是 1: 1 是"表不在"(真 nft 也这么退), 2 专指"桩看不懂这条规则"。
+        # 调用方据此能分清"防火墙没配对"与"转换器落后于配置" —— 后者查错方向完全不同。
+        sys.stderr.write("Error: %s\n" % e)
+        sys.stderr.write("Error: 这是**桩**的覆盖不足, 不是防火墙的问题。"
+                         "请给 tests/nftjson.py 补上这个匹配器, 不要放宽判据。\n")
+        return 2
     if not obj["nftables"]:
         # 表不在: 真 nft 会报错退非零, 桩照做 —— 绝不返回一个"看着健康"的空壳
         sys.stderr.write("Error: No such file or directory\n")

--- a/tests/test-nftjson-coverage.py
+++ b/tests/test-nftjson-coverage.py
@@ -43,11 +43,28 @@ def conv(rule_line):
 
 print("══ nftjson 表达式覆盖 ══\n")
 
+# 清单来自**真实来源**, 不是想象出来的:
+#   · deploy/firewall/nftables-mihomo.conf 的每一种规则行(模板是渲染出来的, 形态有限);
+#   · 真机上两种注入形态 —— 救援放行(带 ip daddr + pdg-rescue 标记, 见交接文档第 15 节)、
+#     证书 standalone 钩子(带 pdg-cert-http 标记, 第 16 节);
+#   · tests/e2e-custom-nft.sh 喂进来的用户自定义规则。
+# 新增一种在机形态时, 这里要跟着加一行 —— 否则它会被 UnknownSyntax 挡下(那是有意的)。
 CASES = [
     ('iifname "tailscale0" return', 2, "iifname 匹配 + return 裁决"),
     ('iif "lo" accept', 2, "iif 匹配 + accept"),
     ('ip saddr 172.22.0.0/16 tcp dport 53 accept', 3, "saddr + dport + accept"),
     ('ip protocol icmp accept', 2, "protocol + accept"),
+    ('ip6 nexthdr icmpv6 accept', 2, "ip6 nexthdr(icmpv6 归一为 ipv6-icmp)"),
+    ('ct state established,related accept', 2, "ct state 集合 + accept"),
+    ('ip saddr 172.22.0.0/16 tcp dport { 53, 81, 853 } accept', 3, "dport 集合"),
+    ('ip saddr 172.22.0.0/16 tcp dport { 80, 443, 5228-5230 } redirect to :7893',
+     3, "dport 含区间 + redirect"),
+    ('ip saddr 172.22.0.0/16 udp dport 443 reject', 3, "reject(补默认 icmp 类型)"),
+    ('tcp dport { 22 } accept', 2, "单元素集合(不折叠成标量)"),
+    ('udp dport 51820 accept', 2, "裸 udp dport"),
+    ('ip saddr 172.22.0.0/16 ip daddr 10.0.0.5 tcp dport 8446 accept comment "pdg-rescue"',
+     5, "救援注入形态: saddr + daddr + dport + accept + 标记"),
+    ('tcp dport 80 accept comment "pdg-cert-http"', 3, "证书钩子形态: dport + accept + 标记"),
 ]
 
 for line, want, desc in CASES:
@@ -70,6 +87,42 @@ if found:
     ok("转出的 JSON 里能按 iifname/tailscale0 定位到该规则")
 else:
     bad("JSON 里找不到 iifname tailscale0 —— 判据据此判'缺少排除规则'")
+
+print("\n── 认不出来时必须出声, 不许丢半条 ──")
+# 这是这支判据真正要守的东西。以前的行为是"能认多少认多少, 剩下的丢掉":
+# `iifname "tailscale0" return` 变成裸 `return`, 规则还在、接口条件没了, 判据按接口名
+# 永远找不到。丢一整条至少会让 audit_kernel 说"缺规则"; 丢半条给出的是一个看着正常的
+# 错答案 —— 排查方向会被带偏好几轮(真 nft 环境同一份规则 12/12 全绿, 因为它自己出 JSON)。
+
+
+def raw(rule_line):
+    src = ("table inet pdg {\n  chain input {\n"
+           "    type filter hook input priority 0; policy drop;\n"
+           "    %s\n  }\n}\n" % rule_line)
+    return subprocess.run([sys.executable, os.path.join(HERE, "nftjson.py"), "inet", "pdg"],
+                          input=src, capture_output=True, text=True)
+
+
+for line, why in (("meta mark 0x1 accept", "meta 匹配"),
+                  ("ip saddr @allowlist accept", "命名集合"),
+                  ("tcp flags syn counter accept", "flags/counter")):
+    r = raw(line)
+    if r.returncode == 0:
+        bad("%-16s 未被察觉 —— 转换器丢掉了它却照常输出(这正是 iifname 那次的形态)" % why)
+    elif r.returncode != 2 or "不认识这段语法" not in r.stderr:
+        bad("%-16s 退了 %d 但没说清是桩看不懂: %s" % (why, r.returncode, r.stderr.strip()[:60]))
+    else:
+        ok("%-16s → 退 2 并点名是桩的覆盖不足(不是防火墙的问题)" % why)
+
+# 反向: 不是规则的行(include / 括号)照旧安静跳过, 不许因为"有残渣"就误报
+r = raw('include "/etc/privdns-gateway/nft-input.d/*.conf"')
+if r.returncode != 0:
+    bad("include 行触发了 rc=%d —— 它不是规则, 不该被当成看不懂的规则: %s"
+        % (r.returncode, r.stderr.strip()[:60]))
+elif [x for x in json.loads(r.stdout)["nftables"] if "rule" in x]:
+    bad("include 行被造成了一条规则 —— 那是凭空捏造, 内核里没有这条")
+else:
+    ok("include 行安静跳过: rc=0、表与链照常输出、不造规则、不触发 UnknownSyntax")
 
 print("\n" + "─" * 62)
 print("通过 %d, 失败 %d" % (npass, nfail))

--- a/tests/test-nftjson-coverage.py
+++ b/tests/test-nftjson-coverage.py
@@ -18,6 +18,14 @@ import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+# 救援端口的唯一事实源是 deploy/bot/rescue_const.py —— 连测试夹具也不许敲数字,
+# 注释里也不许写(test-rescue-constants.sh 在守这条全仓不变量)。
+# 这个坑在本仓库已经重复过五次, 每次都是"新写一支测试时顺手写了端口" ——
+# 而守卫只在全量回归里才跑到, 写的当下不会提醒。
+RPORT = subprocess.run([sys.executable, os.path.join(ROOT, "deploy/bot/rescue_const.py"),
+                        "--port"], capture_output=True, text=True, check=True).stdout.strip()
 npass = nfail = 0
 
 
@@ -62,8 +70,8 @@ CASES = [
     ('ip saddr 172.22.0.0/16 udp dport 443 reject', 3, "reject(补默认 icmp 类型)"),
     ('tcp dport { 22 } accept', 2, "单元素集合(不折叠成标量)"),
     ('udp dport 51820 accept', 2, "裸 udp dport"),
-    ('ip saddr 172.22.0.0/16 ip daddr 10.0.0.5 tcp dport 8446 accept comment "pdg-rescue"',
-     5, "救援注入形态: saddr + daddr + dport + accept + 标记"),
+    ('ip saddr 172.22.0.0/16 ip daddr 10.0.0.5 tcp dport %s accept comment "pdg-rescue"'
+     % RPORT, 5, "救援注入形态: saddr + daddr + dport + accept + 标记"),
     ('tcp dport 80 accept comment "pdg-cert-http"', 3, "证书钩子形态: dport + accept + 标记"),
 ]
 


### PR DESCRIPTION
关掉交接文档第 10 节那条 P2。

## 要害不是「只支持四种形态」

是**认不出就静默丢弃**。`iifname "tailscale0" return` 转出来成了裸 `return` —— 规则还在、
接口条件没了。判据按接口名找永远找不到，而内核里其实有。六个升级类 E2E 因此全红，
真 nft 环境下同一份规则 12/12 全绿（真 nft 自己出 JSON），排查方向被带偏好几轮。

丢一整条至少会让 `audit_kernel` 说「缺规则」；**丢半条给出的是一个看着正常的错答案** ——
本项目最危险的那一类（交接文档 9.1）。

## 改法

每个匹配器记下自己吃掉的区间（`_eat`），收口时看还剩什么（`_residue`）：

| 情况 | 行为 |
|---|---|
| 整行不是规则（`include` / 括号 / 空行） | 照旧安静跳过 |
| 是规则、但有实义残渣 | 抛 `UnknownSyntax`，CLI 退 **2** 并点名「这是桩的覆盖不足，不是防火墙的问题」 |

退 2 而非 1 是有意的：1 是「表不在」（真 nft 也这么退），2 专指「桩看不懂」—— 两者查错方向完全不同。
`e2e-lib` 的 nft 桩用 `exec` 调它，rc=2 直接成为桩的退出码，nftlive 按设计 fail-closed。

## 判据 4 → 13 种形态

清单来自**真实来源**：模板里的每一种规则行、真机上两种注入形态（救援放行带 `ip daddr` +
`pdg-rescue` 标记；证书钩子带 `pdg-cert-http` 标记）、`e2e-custom-nft` 喂进来的用户自定义规则。
**15 种在机形态零误报。** 另加三格「未知语法必须退 2 并点名」和一格反向对照。

## 负控

```
恢复静默丢弃  → 红(3)      摘 daddr      → 红(1)
摘 iifname    → 红(2)      摘 ct state   → 红(1)
摘 comment    → 红(2)      追加无关注释  → 仍绿
```

本地：coverage 18/0、nftjson-stub 25/0、ci-coverage 22/22、invariants 25/25、false-green 16/0。
仅测试基础设施改动，无生产代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)