### PR TITLE
内网面板访问(方案 B): 手机零 App 访问家里的 Web 面板

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - name: "内网面板门二: 面板表校验 + 反代生成(改写指令的空测)"
         run: python3 tests/test-lanpanel.py
 
+      - name: "内网面板接线: 面板规则必须排在反自环 REJECT 之前(含空测)"
+        run: python3 tests/test-lan-wire.py
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
       - name: "内网面板门一: 子网路由重叠拒绝(含每条判据的空测)"
         run: python3 tests/test-lanroute.py
 
+      - name: "内网面板门二: 面板表校验 + 反代生成(改写指令的空测)"
+        run: python3 tests/test-lanpanel.py
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: "doctor: 冲突制造者定位 + Tailscale 卸载残留"
         run: python3 tests/test-doctor-conflict-creator.py
 
+      - name: "内网面板门一: 子网路由重叠拒绝(含每条判据的空测)"
+        run: python3 tests/test-lanroute.py
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,9 @@ jobs:
       - name: "内网面板接线: 面板规则必须排在反自环 REJECT 之前(含空测)"
         run: python3 tests/test-lan-wire.py
 
+      - name: "内网面板自检: 四项判据的每条分支(含 ACL 探测的三种读法)"
+        run: python3 tests/test-lan-doctor.py
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/deploy/bot/cfgrestore.py
+++ b/deploy/bot/cfgrestore.py
@@ -573,7 +573,8 @@ def restore_managed(snap_id, *, expect_digest="", trigger_source="legacy"):
                 t.derive("mihomo_cfg", mihomorender.deriver_from_paths(
                     rs_meta_path=pdgtx.FSROOT + "/opt/pdg-bot/rulesets.json",
                     mitm_hijack_file=pdgtx.FSROOT + "/etc/mosdns/rules/mitm_hijack.txt",
-                    platform_file=pdgtx.FSROOT + "/etc/privdns-gateway/platform"))
+                    platform_file=pdgtx.FSROOT + "/etc/privdns-gateway/platform",
+                    lan_table_file=pdgtx.FSROOT + "/etc/privdns-gateway/lan-panels.json"))
                 out["derived"] = ["mihomo_cfg"]
             # 动作由**实际落盘的目标**推导(read_for_update 失败被跳过的不算数)
             for a in pdgtx.actions_for_targets(out["restored"] + out.get("derived", [])):

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1931,6 +1931,95 @@ def check_lan_cert():
     return ("ok", name, "%d 张证书都还有 14 天以上" % len(panels))
 
 
+
+def _lan_probe_target(cfg):
+    """挑一个**不在面板表里**、但与某个面板同网段的地址, 用来探 tailnet ACL 的边界。
+
+    取同 /24 里的另一个主机位: 家里那侧如果按设计把 ACL 收成"只允许网关访问那几个
+    IP:端口", 这个地址就该到不了。返回 (ip, port, 参照的面板 IP) 或 None。
+    """
+    import ipaddress
+    tgts = []
+    lp = _lanpanel()
+    if lp is None:
+        return None
+    try:
+        tgts = lp.targets(cfg)
+    except Exception:  # noqa: BLE001
+        return None
+    for ip_s, port in tgts:
+        try:
+            ip = ipaddress.ip_address(ip_s)
+        except ValueError:
+            continue
+        if ip.version != 4:
+            continue
+        net = ipaddress.ip_network("%s/24" % ip_s, strict=False)
+        used = {t[0] for t in tgts}
+        # 从网段末尾往回找一个没被用到的主机位 —— 靠后的地址通常没有设备,
+        # 探它比探 .1(往往是路由器)更不容易打扰到真在跑的东西。
+        for host in list(net.hosts())[::-1][:8]:
+            if str(host) not in used:
+                return (str(host), port, ip_s)
+    return None
+
+
+def check_deep_lan_acl():
+    """tailnet ACL 越界探测(慢速, 只在 --deep 跑)。
+
+    设计文档第 4 节把这条列为"能测出来的, 不是只能靠嘱咐": **真正的硬边界在家里那台
+    子网路由器上** —— Tailscale 的包过滤在目标节点执行, 所以网关就算被 root 了, 往
+    ACL 之外的地址发包也会被家里那台丢掉。项目管不了用户的 tailnet 后台, 但可以探。
+
+    判据的读法要小心, 三种结果不是"成功/失败"两分:
+      · 连上了        → ACL 放行了本不该放行的地址 → fail
+      · 连接被拒(RST) → 包**到达了对端**才会有 RST → ACL 同样放行了 → fail
+      · 不可达/超时   → 被丢在半路 → 这正是期望的结果 → ok
+
+    探测**以 root 身份发起**, 因此不受门三(出站白名单)约束 —— 那是有意的: 门三管的是
+    反代进程, 而这一项要量的是**家里那侧**的过滤器。用受限身份去探, 量到的会是自己的
+    防火墙, 那等于什么都没验。
+    """
+    name = "内网面板: tailnet ACL 边界(deep)"
+    cfg = _lan_cfg()
+    if cfg is None:
+        return None
+    on, _active = _lan_on()
+    if not on:
+        return None
+    pick = _lan_probe_target(cfg)
+    if pick is None:
+        return ("warn", name, "挑不出可用的探测地址(面板表里没有 IPv4 上游?), 本项没跑")
+    ip_, port, ref = pick
+    import socket
+    s = socket.socket()
+    s.settimeout(4)
+    try:
+        s.connect((ip_, port))
+        s.close()
+        return ("fail", name,
+                "从网关能连上 %s:%d —— 它**不在**面板表里, 说明 tailnet ACL 没有收窄到"
+                "只允许那几个 IP:端口。一台被拿下的网关因此能摸到你家整个网段。"
+                "去 tailnet 后台按 docs/design-lan-panels.md 第 4 节的模板配 ACL。" % (ip_, port))
+    except socket.timeout:
+        return ("ok", name, "%s:%d(面板表之外)连不上 —— ACL 边界看起来是收紧的" % (ip_, port))
+    except ConnectionRefusedError:
+        return ("fail", name,
+                "%s:%d 回了 RST —— 包**到达了对端**才会有这个回应, 说明 tailnet ACL 放行了"
+                "面板表之外的地址(参照面板 %s)。ACL 该做的是把它丢掉, 而不是让对端拒绝。"
+                % (ip_, port, ref))
+    except OSError as e:
+        # EHOSTUNREACH(113)/ENETUNREACH(101) = 被丢在半路, 正是期望的
+        if getattr(e, "errno", None) in (101, 113):
+            return ("ok", name, "%s:%d(面板表之外)被丢弃 —— ACL 边界成立" % (ip_, port))
+        return ("warn", name, "探测没跑成(%s), 本项无结论" % e)
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+
 ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue,
@@ -1940,7 +2029,8 @@ ALL = [check_platform, check_services, check_bot_credentials, check_health_timer
        check_cert, check_cert_dir_sync, check_dns, check_core_config, check_rulesets, check_rule_precedence,
        check_mitm_structure, check_mitm, check_transactions]
 ALERT = [check_services, check_dns, check_cert]  # healthcheck 用的轻量子集(运行期故障)
-DEEP = [check_deep_dot_handshake, check_deep_probe81, check_deep_dot_witness, check_deep_dns_cn,
+DEEP = [check_deep_lan_acl,
+        check_deep_dot_handshake, check_deep_probe81, check_deep_dot_witness, check_deep_dns_cn,
         check_deep_clash, check_deep_upstreams, check_deep_hijack_note]  # pdg doctor --deep 追加
 
 def run(funcs=None):

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1704,9 +1704,237 @@ def check_transactions():
             "<code>sudo pdg tx recover &lt;id&gt;</code> 恢复。" % (len(pend), items))
 
 
+
+# ── 内网面板(方案 B) ─────────────────────────────────────────────────────────
+LAN_TABLE = "/etc/privdns-gateway/lan-panels.json"
+LAN_CERT_DIR = "/etc/pdg-lan/certs"
+LAN_NFT_TABLE = "pdglan"
+LAN_USER = "pdg-lan"
+
+
+def _lan_cfg():
+    try:
+        with open(LAN_TABLE, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def _lan_on():
+    """这台机器**此刻是否真的在用**内网面板。
+
+    判据不能只看面板表在不在: 停用之后表是刻意留下的(disable 的语义就是先停一停),
+    对着一个没在跑的功能报红只会让人下次不看 doctor。反过来, 服务在跑就必须查 ——
+    哪怕 profile 里的意图写着 0。
+
+    返回 (在用吗, 服务是否 active)。
+    """
+    _rc, out, _e = _run(["systemctl", "is-active", "pdg-lan"], 8)
+    active = (out or "").strip() == "active"
+    intent = (_profile("PDG_LAN_ENABLED") or "").strip() == "1"
+    return (active or intent), active
+
+
+def _lanpanel():
+    """按需 import lanpanel —— 它与 doctor 装在同一个目录(lib/modules.sh 的清单里)。
+    取不到就让调用方报"判据跑不了", 而不是让整个 doctor 崩掉。"""
+    try:
+        import lanpanel
+        return lanpanel
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def check_lan_routes():
+    """门一常驻: 本机接受的子网路由有没有与自己正在用的网段相交。
+
+    **与内网面板功能开没开无关**。危险来自"接受了一个重叠的路由"这件事本身: 只要接受了,
+    本机发往那个段的包就会走进 tailnet, 而分流数据面从配置上完全看不出问题。所以判据
+    挂在"有没有接受路由"上, 不挂在 PDG_LAN_ENABLED 上。
+    """
+    name = "内网面板: 子网路由重叠"
+    if not os.path.exists("/proc/net/dev"):
+        return None
+    try:
+        with open("/proc/net/dev", encoding="utf-8") as f:
+            if not any(l.strip().startswith("tailscale0:") for l in f):
+                return None          # 没有 tailnet, 这条不适用
+    except OSError:
+        return None
+    rc, out, _ = _run(["tailscale", "status", "--json"], 10)
+    if rc != 0 or not out.strip():
+        return ("warn", name, "读不到 tailscale status —— 无法确认接受了哪些子网路由")
+    try:
+        st = json.loads(out)
+    except ValueError:
+        return ("warn", name, "tailscale status 输出不是合法 JSON, 判据本次没跑")
+    # 本机**接受**的路由: 其它节点通告、且本机装进了路由表的那些。
+    routes = []
+    for peer in (st.get("Peer") or {}).values():
+        for r in (peer.get("PrimaryRoutes") or []):
+            if r not in routes:
+                routes.append(r)
+    if not routes:
+        return ("ok", name, "没有从别的节点接受任何子网路由, 不存在重叠")
+    try:
+        import lanroute
+    except Exception:  # noqa: BLE001
+        return ("warn", name, "取不到 lanroute 模块, 重叠判据本次没跑(装机清单里少了它?)")
+    internal = _profile("PDG_INTERNAL_CIDR")
+    locals_ = []
+    for fam in ("-4", "-6"):
+        rc, o, _ = _run(["ip", "-o", fam, "addr", "show", "scope", "global"], 8)
+        if rc == 0:
+            for line in o.splitlines():
+                parts = line.split()
+                if len(parts) > 3:
+                    try:
+                        locals_.append(lanroute.parse_net(parts[3]))
+                    except ValueError:
+                        pass
+    inet = None
+    if internal:
+        try:
+            inet = lanroute.parse_net(internal)
+        except ValueError:
+            inet = None
+    bad = lanroute.judge(routes, inet, locals_)
+    if not bad:
+        note = "" if inet else "(注意: 读不到 PDG_INTERNAL_CIDR, 最要紧的那条判据没跑)"
+        return ("ok" if inet else "warn", name,
+                "接受的 %d 条路由都不与本机网段相交%s" % (len(routes), note))
+    why = "; ".join("%s: %s" % (c, r[0][1]) for c, r in bad[:3])
+    return ("fail", name,
+            "接受的子网路由里有 %d 条会打乱本机数据面 —— %s。"
+            "这类故障从配置上完全看不出来, 要在家里那侧改小通告范围。" % (len(bad), why))
+
+
+def check_lan_whitelist():
+    """门三: 内核里的出站白名单必须与面板表**逐条一致**。
+
+    漂移的两个方向都危险, 但不是同一种危险:
+      · 白名单多出面板表没有的地址 = 反代能连到不该连的地方(通常是删了面板没重新生成);
+      · 白名单少了面板表里的地址 = 那个面板打不开, 而症状是 502, 看着像设备坏了。
+    """
+    name = "内网面板: 出站白名单"
+    cfg = _lan_cfg()
+    if cfg is None:
+        return None                   # 从来没配过这个功能
+    on, active = _lan_on()
+    if not on:
+        return ("ok", name, "内网面板已停用(面板表留着, pdg lan enable 可以随时回来) —— 不适用")
+    lp = _lanpanel()
+    if lp is None:
+        return ("warn", name, "取不到 lanpanel 模块, 白名单判据本次没跑")
+    try:
+        want = set(lp.targets(cfg))
+    except Exception as e:  # noqa: BLE001
+        return ("warn", name, "面板表读不出目标(%s)" % e)
+    # **不能用 nftlive.read_kernel()**: 它只取 `inet pdg` 那一张表, 看不见 pdglan ——
+    # 用它的话这一项会永远报"表不存在", 而一个永远报红的检查等于没有。这里直接问那张表。
+    rc, raw, err = _run(["nft", "-j", "list", "table", "inet", LAN_NFT_TABLE], 15)
+    if rc != 0:
+        # nft 明确说"没有这张表"与"nft 用不了"要分开: 前者是判据成立的一种结果,
+        # 后者是判据没跑成 —— 混成一句会让缺权限的机器看起来像防火墙丢了。
+        low = (err or "").lower()
+        if "no such file" in low or "does not exist" in low:
+            seen_table, have, obj = False, set(), None
+        else:
+            return ("warn", name, "读不到 inet %s 表(%s)" % (LAN_NFT_TABLE, (err or "").strip()[:120]))
+    else:
+        try:
+            obj = json.loads(raw)
+        except ValueError:
+            return ("warn", name, "nft -j 输出不是合法 JSON, 白名单判据本次没跑")
+        seen_table = True
+        have = set()
+    for item in ((obj or {}).get("nftables", []) if obj else []):
+        rule = item.get("rule")
+        if not rule or rule.get("table") != LAN_NFT_TABLE:
+            continue
+        ip_, port = None, None
+        for ex in rule.get("expr", []):
+            m = ex.get("match")
+            if not m:
+                continue
+            left, right = m.get("left", {}), m.get("right")
+            pl = left.get("payload") or {}
+            if pl.get("field") == "daddr" and isinstance(right, str):
+                ip_ = right
+            elif pl.get("field") == "dport" and isinstance(right, int):
+                port = right
+        if ip_ and port:
+            have.add((ip_, port))
+    if not seen_table:
+        if not want:
+            return ("ok", name, "面板表是空的, 也没有白名单表 —— 一致")
+        if active:
+            # 反代**正在跑**而白名单不在 = 这个进程此刻能连到内网任意地址。门三本来靠
+            # ExecStartPre 挡住这种状态, 走到这里说明有人在服务起来之后把表删了。
+            return ("fail", name,
+                    "反代正在运行, 但内核里没有 inet %s 表 —— 它此刻**能连到内网任意地址**。"
+                    "立刻 sudo pdg lan render 再 sudo systemctl restart pdg-lan。" % LAN_NFT_TABLE)
+        return ("warn", name,
+                "启用意图开着, 但反代没在跑、白名单也不在 —— 功能实际上是停的。"
+                "要用就 sudo pdg lan enable, 不用就 sudo pdg lan disable 把意图也改掉。")
+    extra, miss = have - want, want - have
+    if not extra and not miss:
+        return ("ok", name, "白名单与面板表逐条一致(%d 个上游)" % len(want))
+    parts = []
+    if extra:
+        parts.append("白名单多出 %s —— 反代能连到面板表之外的地址"
+                     % ", ".join("%s:%d" % t for t in sorted(extra)[:3]))
+    if miss:
+        parts.append("白名单缺少 %s —— 那些面板会以 502 打不开, 看着像设备坏了"
+                     % ", ".join("%s:%d" % t for t in sorted(miss)[:3]))
+    return ("fail", name, "; ".join(parts) + "。跑 sudo pdg lan render 后重启 pdg-lan。")
+
+
+def check_lan_cert():
+    """面板证书的剩余天数。
+
+    反代读的是**落盘的**证书, 它自己不去续 —— 续期靠 acme.sh 装的 cron。那条链断掉时
+    不会有任何报错, 直到某天所有面板一起打不开。所以这一项存在的意义就是提前那两周。
+
+    判据用 `openssl x509 -checkend`(与 check_cert 同一个惯用法), 不自己解析日期字符串:
+    notAfter 的格式带时区缩写, strptime 在不同 locale 下解出来的东西不一样。
+    """
+    name = "内网面板: 证书"
+    cfg = _lan_cfg()
+    if cfg is None:
+        return None
+    on, _active = _lan_on()
+    if not on:
+        return None                   # 停用中: 证书过不过期都不影响任何东西
+    panels = [p for p in cfg.get("panels", []) if isinstance(p, dict) and p.get("name")]
+    if not panels:
+        return None
+    missing, expired, soon = [], [], []
+    for p in panels:
+        crt = os.path.join(LAN_CERT_DIR, "%s.crt" % p["name"])
+        if not os.path.exists(crt):
+            missing.append(p["name"]); continue
+        rc, _, _ = _run(["openssl", "x509", "-checkend", "0", "-noout", "-in", crt], 8)
+        if rc != 0:
+            expired.append(p["name"]); continue
+        rc, _, _ = _run(["openssl", "x509", "-checkend", str(14 * 86400), "-noout", "-in", crt], 8)
+        if rc != 0:
+            soon.append(p["name"])
+    if missing:
+        return ("fail", name, "这些面板没有可读的证书: %s —— 跑 sudo pdg lan cert <dns插件名>"
+                % ", ".join(missing[:5]))
+    if expired:
+        return ("fail", name, "这些面板的证书已过期: %s —— 面板打不开" % ", ".join(expired[:5]))
+    if soon:
+        return ("warn", name, "这些面板的证书 14 天内到期: %s —— 续期链(acme.sh 的 cron)"
+                              "可能已经断了, 它断掉时不会有任何报错" % ", ".join(soon[:5]))
+    return ("ok", name, "%d 张证书都还有 14 天以上" % len(panels))
+
+
 ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue,
+       check_lan_routes, check_lan_whitelist, check_lan_cert,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_rescue_firewall, check_geosite_db, check_mem,
        check_cert, check_cert_dir_sync, check_dns, check_core_config, check_rulesets, check_rule_precedence,

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -211,6 +211,66 @@ def render_caddy(cfg, certs_dir, bind="127.0.0.1"):
     return "\n".join(L)
 
 
+NFT_TABLE = "pdglan"
+
+
+def render_nft(cfg, uid):
+    """门三: 反代进程的**出站白名单**。除了面板表里出现过的 IP:端口, 它什么都连不到。
+
+    按 uid 过滤而不是按端口 —— 端口挡不住"别的进程发起同样的连接"。uid 才是"这些包是反代
+    发的"这件事的判据。
+
+    比设计文档更严: 文档说的是"只允许经 tailscale0 访问白名单", 这里做成**不分接口**的
+    白名单。反代的合法出站本来就只有那几个上游 —— 上游必须是字面 IP(见 parse_target),
+    所以它连 DNS 都不需要。多留一个"经别的接口可以随便连"的口子没有任何用途, 只是攻击面。
+
+    为什么可以用独立的表(与救援平面当年的教训相反):
+      · 救援平面那次栽在 **input** 方向 —— 同一 hook 上多条 base chain 都会执行, 别的链里的
+        `accept` 终止不了本链, `inet pdg` 的 policy drop 照样把包丢掉, 于是独立表里的放行
+        形同虚设。
+      · 这里是 **output** 方向而且判决是 `reject` —— drop/reject 是跨链终局的, 任一条链拒了
+        包就没了。所以独立表在这个方向上成立。
+      · 而且 doctor/nftscan 的冲突判据只认 `hook input`(见 nftscan.py 的 _HOOK_IN),
+        挂 output 不会被自己的自检判成冲突 —— 那正是救援平面独立表当年踩的第二个坑。
+
+    **这份规则是 fail-open 的**: 文件加载失败时白名单就不存在, 而反代照跑。所以调用方必须
+    把它挂成反代 unit 的 ExecStartPre —— 加载不上就别启动。这一条不是建议, 是这道门能不能
+    成立的前提。
+    """
+    errs = validate(cfg)
+    if errs:
+        raise PanelError("面板表没通过校验, 拒绝生成防火墙规则:\n" + "\n".join("  " + e for e in errs))
+    if not (isinstance(uid, str) and re.match(r"^[a-z_][a-z0-9_-]{0,31}$", uid)):
+        raise PanelError("uid 要是用户名(收到 %r)" % (uid,))
+
+    L = []
+    L.append("#!/usr/sbin/nft -f")
+    L.append("# 由 lanpanel.py 生成 —— 不要手改。")
+    L.append("# 反代进程(%s)的出站白名单: 只有面板表里出现过的 IP:端口。" % uid)
+    L.append("# 必须挂成反代 unit 的 ExecStartPre —— 这份加载不上就不该让反代跑起来。")
+    L.append("table inet %s" % NFT_TABLE)
+    L.append("delete table inet %s" % NFT_TABLE)
+    L.append("table inet %s {" % NFT_TABLE)
+    L.append("\tchain output {")
+    L.append("\t\ttype filter hook output priority filter; policy accept;")
+    L.append("\t\t# 不是反代发的包, 本链一概不管")
+    L.append('\t\tmeta skuid != "%s" accept' % uid)
+    L.append("\t\t# 回给本机的响应(反代监听在环回上, 由 mihomo 拨进来)")
+    L.append("\t\toif lo accept")
+    tgts = targets(cfg)
+    if tgts:
+        L.append("\t\t# ── 白名单: 与反代读同一份面板表派生 ──")
+    for ip, port in tgts:
+        fam = "ip6" if ":" in ip else "ip"
+        L.append("\t\t%s daddr %s tcp dport %d accept" % (fam, ip, port))
+    L.append("\t\t# 其余一律拒。用 reject 而不是 drop: 反代会立刻拿到错误并回 502,")
+    L.append("\t\t# 而 drop 要等到超时 —— 那时故障看起来像\"设备很慢\", 不像\"被挡了\"。")
+    L.append("\t\treject with icmpx admin-prohibited")
+    L.append("\t}")
+    L.append("}")
+    return "\n".join(L) + "\n"
+
+
 def legacy_tls_panels(cfg):
     """需要放宽 TLS 套件的面板名。
 

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -14,6 +14,9 @@
 
 用法:
   lanpanel.py check   <表.json>              校验(门二), 0=通过 2=有问题
+  lanpanel.py list    <表.json>              人看的面板清单
+  lanpanel.py add     <表.json> --name .. --host .. --target ..   生成加了一条的**候选表**
+  lanpanel.py rm      <表.json> <name>       生成删了一条的候选表
   lanpanel.py render  <表.json> --certs <目录> [--bind <地址>]   生成 Caddyfile
   lanpanel.py targets <表.json>              列出 IP<TAB>端口, 供防火墙白名单使用
 """
@@ -281,6 +284,45 @@ def legacy_tls_panels(cfg):
     return [p["name"] for p in cfg.get("panels", []) if isinstance(p, dict) and p.get("legacy_tls")]
 
 
+def add_panel(cfg, panel):
+    """返回**新的**面板表(不改原对象, 不写盘)。
+
+    与 cidrgen.py 同一个规矩: 这里只从现有内容生成候选内容, 落盘、校验、观察、回滚全交给
+    pdgtx。于是"改到一半失败"这种状态不存在 —— 要么整张新表生效, 要么原样不动。
+
+    候选**整体**过一次校验, 不只校验新增那条: 新面板可能与既有面板撞 name 或 host, 那种
+    冲突只有把整张表放在一起看才发现得了。
+    """
+    panels = list(cfg.get("panels", []))
+    panels.append(panel)
+    cand = dict(cfg)
+    cand["panels"] = panels
+    errs = validate(cand)
+    if errs:
+        raise PanelError("加进去之后这张表就不合法了, 拒绝改动:\n" + "\n".join("  " + e for e in errs))
+    return cand
+
+
+def rm_panel(cfg, name):
+    """按 name 删一条。删不到就报错而不是静默成功 —— "删了个不存在的东西"和"删掉了"
+    在事后看起来一模一样, 而用户以为面板已经没了。"""
+    panels = list(cfg.get("panels", []))
+    left = [p for p in panels if not (isinstance(p, dict) and p.get("name") == name)]
+    if len(left) == len(panels):
+        have = [p.get("name") for p in panels if isinstance(p, dict)]
+        raise PanelError("没有名叫 %r 的面板。现有: %s"
+                         % (name, ", ".join(have) if have else "(一个都没有)"))
+    cand = dict(cfg)
+    cand["panels"] = left
+    return cand
+
+
+def dumps(cfg):
+    """落盘用的文本。固定 indent 与 key 顺序 —— 事务要比对 before/after, 格式抖动会让
+    "没改内容"的一次操作看起来像改过。"""
+    return json.dumps(cfg, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
 def load(path):
     with open(path, encoding="utf-8") as f:
         return json.load(f)
@@ -302,6 +344,61 @@ def main(argv):
         for e in errs:
             print(e)
         return 2 if errs else 0
+
+    if mode == "add":
+        # lanpanel.py add <表> --name x --host y --target z [--insecure|--no-insecure]
+        #                     [--rewrite-location] [--fix-referer] [--legacy-tls] [--entry-query q]
+        panel, rest = {}, argv[3:]
+        flags = {"--rewrite-location": "rewrite_location", "--fix-referer": "fix_referer",
+                 "--legacy-tls": "legacy_tls"}
+        while rest:
+            a = rest[0]
+            if a in ("--name", "--host", "--target", "--entry-query") and len(rest) > 1:
+                panel[a[2:].replace("-", "_")] = rest[1]; rest = rest[2:]
+            elif a == "--insecure":
+                panel["insecure_upstream"] = True; rest = rest[1:]
+            elif a == "--no-insecure":
+                panel["insecure_upstream"] = False; rest = rest[1:]
+            elif a in flags:
+                panel[flags[a]] = True; rest = rest[1:]
+            else:
+                print("认不出的参数: %s" % a)
+                return 3
+        try:
+            sys.stdout.write(dumps(add_panel(cfg, panel)))
+        except PanelError as e:
+            print(str(e))
+            return 2
+        return 0
+
+    if mode == "rm":
+        if len(argv) < 4:
+            print("rm 要给面板名")
+            return 3
+        try:
+            sys.stdout.write(dumps(rm_panel(cfg, argv[3])))
+        except PanelError as e:
+            print(str(e))
+            return 2
+        return 0
+
+    if mode == "list":
+        panels = cfg.get("panels", [])
+        if not panels:
+            print("(还没有面板)")
+            return 0
+        for p in panels:
+            if not isinstance(p, dict):
+                continue
+            marks = [k for k in ("rewrite_location", "fix_referer", "legacy_tls") if p.get(k)]
+            if p.get("insecure_upstream"):
+                marks.append("不校验上游证书")
+            if p.get("entry_query"):
+                marks.append("入口参数")
+            print("%-12s %-34s → %s%s"
+                  % (p.get("name"), p.get("host"), p.get("target"),
+                     ("   [" + ", ".join(marks) + "]") if marks else ""))
+        return 0
 
     if mode == "targets":
         for ip, port in targets(cfg):

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -20,6 +20,7 @@
   lanpanel.py zone-risk <表.json> <DoT域名>  风险②: 面板域名与 DoT 是否同 zone
   lanpanel.py render  <表.json> --certs <目录> [--bind <地址>]   生成 Caddyfile
   lanpanel.py targets <表.json>              列出 IP<TAB>端口, 供防火墙白名单使用
+  lanpanel.py nft     <表.json> --uid <用户>  门三: 出站白名单的 nft 规则
 """
 import ipaddress
 import json
@@ -441,6 +442,23 @@ def main(argv):
             print("%-12s %-34s → %s%s"
                   % (p.get("name"), p.get("host"), p.get("target"),
                      ("   [" + ", ".join(marks) + "]") if marks else ""))
+        return 0
+
+    if mode == "nft":
+        # lanpanel.py nft <表> --uid <用户名>
+        uid = None
+        rest = argv[3:]
+        while rest:
+            if rest[0] == "--uid" and len(rest) > 1:
+                uid, rest = rest[1], rest[2:]
+            else:
+                print("认不出的参数: %s" % rest[0]); return 3
+        if not uid:
+            print("nft 要 --uid <运行反代的用户名>"); return 3
+        try:
+            sys.stdout.write(render_nft(cfg, uid))
+        except PanelError as e:
+            print(str(e)); return 2
         return 0
 
     if mode == "zone-risk":

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -17,6 +17,7 @@
   lanpanel.py list    <表.json>              人看的面板清单
   lanpanel.py add     <表.json> --name .. --host .. --target ..   生成加了一条的**候选表**
   lanpanel.py rm      <表.json> <name>       生成删了一条的候选表
+  lanpanel.py zone-risk <表.json> <DoT域名>  风险②: 面板域名与 DoT 是否同 zone
   lanpanel.py render  <表.json> --certs <目录> [--bind <地址>]   生成 Caddyfile
   lanpanel.py targets <表.json>              列出 IP<TAB>端口, 供防火墙白名单使用
 """
@@ -214,6 +215,48 @@ def render_caddy(cfg, certs_dir, bind="127.0.0.1"):
     return "\n".join(L)
 
 
+def shared_zone(a, b):
+    """两个域名共同的父域(按标签从右往左比)。只有一个标签(纯 TLD)时返回 None ——
+    example.com 与 example.net 共有 "com" 不说明任何事。"""
+    la = [x for x in (a or "").lower().strip(".").split(".") if x]
+    lb = [x for x in (b or "").lower().strip(".").split(".") if x]
+    common = []
+    for x, y in zip(reversed(la), reversed(lb)):
+        if x != y:
+            break
+        common.append(x)
+    if len(common) < 2:
+        return None
+    return ".".join(reversed(common))
+
+
+def zone_risk(cfg, dot_domain):
+    """风险②: 签发面板证书用的 DNS token 会不会顺带能签发本项目自己的 DoT 域名。
+
+    为什么这是**权限升级**而不只是"多一个凭据": Cloudflare 这类服务商的 token 按 zone 授权,
+    而面板域名与 DoT 域名通常在同一个 zone 里。那么一台被拿下的网关可以用这个 token 签发
+    `dot.example.com` 的证书, 进而 MITM 用户自己的 DNS —— 而 DoT 正是这个项目存在的理由。
+    面板被看到是一回事, DNS 被劫持是另一回事。
+
+    判据是"共同父域至少两个标签"。这是对 eTLD+1 的近似 —— 不引 public suffix list:
+    多带一份要跟着上游更新的数据, 而这里**宁可多报**: 报错了用户看一眼就知道不相干,
+    漏报了他会在不知情的情况下把 DoT 的签发权交出去。
+
+    返回 [(面板 host, 共同父域), ...], 空 = 没有这个风险。
+    """
+    if not dot_domain:
+        return []
+    out = []
+    for p in cfg.get("panels", []):
+        if not isinstance(p, dict):
+            continue
+        h = p.get("host")
+        z = shared_zone(h, dot_domain)
+        if z:
+            out.append((h, z))
+    return out
+
+
 NFT_TABLE = "pdglan"
 
 
@@ -399,6 +442,14 @@ def main(argv):
                   % (p.get("name"), p.get("host"), p.get("target"),
                      ("   [" + ", ".join(marks) + "]") if marks else ""))
         return 0
+
+    if mode == "zone-risk":
+        # lanpanel.py zone-risk <表> <DoT域名>
+        dot = argv[3] if len(argv) > 3 else ""
+        risks = zone_risk(cfg, dot)
+        for host, z in risks:
+            print("%s\t%s" % (host, z))
+        return 2 if risks else 0
 
     if mode == "targets":
         for ip, port in targets(cfg):

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""内网面板(方案 B)的面板表: 校验(门二)、反代配置生成、出站白名单派生(门三的输入)。
+
+**门二 = 反代只做白名单映射。**域名到 `IP:端口` 一对一, 不接受通配、不按 Host 动态解析
+目标。否则任何能触发 SNI 的人都能让网关去连家里的任意地址 —— 反代会老老实实照做, 因为
+"按 Host 找上游"正是反代的本职。
+
+这里有一条比设计文档更严的要求: **上游必须写字面 IP, 不接受域名。**写域名的话, 决定
+网关去连哪台机器的是 DNS 而不是这份表 —— 而这台网关自己就是做 DNS 劫持的, 上游解析结果
+被换掉时白名单一个字都不用改。门三按这份表派生放行规则, 表里是域名就没法派生。
+
+生成而不是让用户手写反代配置, 与 mihomo 配置由 sb2mihomo.py 渲染同一个理由: 手写的那份
+迟早与面板表不一致, 而不一致的方向恰恰是"防火墙按表放行、反代按手写的连别处"。
+
+用法:
+  lanpanel.py check   <表.json>              校验(门二), 0=通过 2=有问题
+  lanpanel.py render  <表.json> --certs <目录> [--bind <地址>]   生成 Caddyfile
+  lanpanel.py targets <表.json>              列出 IP<TAB>端口, 供防火墙白名单使用
+"""
+import ipaddress
+import json
+import re
+import sys
+
+# 面板名: 用来做文件名和日志标识, 限死字符集免得后面到处转义。
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,30}$")
+# 主机名: 普通域名。**明确不接受通配**(`*.` 开头) —— 那正是门二要挡的东西。
+HOST_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(\.(?!-)[a-z0-9-]{1,63})+$")
+
+KNOWN_KEYS = {
+    "name", "host", "target", "insecure_upstream",
+    "rewrite_location", "fix_referer", "legacy_tls", "entry_query",
+}
+
+
+class PanelError(Exception):
+    pass
+
+
+def _err(lst, panel_ix, msg):
+    lst.append("第 %d 条面板: %s" % (panel_ix + 1, msg))
+
+
+def parse_target(t):
+    """拆 `scheme://IP[:port]`, 返回 (scheme, ip, port)。
+
+    只认 http / https, 只认字面 IP。端口省略时按 scheme 取默认值 —— 派生防火墙规则要用到
+    具体端口, "默认端口"这件事不能留给两个地方各猜一次。
+    """
+    # 先只拆形状, **不在正则里限定必须是 IP**: 那样写域名的人只会看到一句"格式不对",
+    # 而真正该告诉他的是"这里不能写域名, 因为决定连哪台机器的会变成 DNS"。
+    m = re.match(r"^(https?)://(\[[0-9a-fA-F:]+\]|[^/:\s]+)(?::([0-9]{1,5}))?/?$", t or "")
+    if not m:
+        raise PanelError("上游要写成 http(s)://<字面 IP>[:端口], 收到的是 %r" % (t,))
+    scheme, host, port = m.group(1), m.group(2), m.group(3)
+    host = host.strip("[]")
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        raise PanelError("上游 %r 不是字面 IP —— 写域名的话决定连哪台机器的是 DNS 而不是这份表, "
+                         "而这台网关自己就在做 DNS 劫持" % host)
+    if ip.is_loopback:
+        raise PanelError("上游 %s 是环回地址 —— 那指向网关自己, 不是家里的设备" % ip)
+    p = int(port) if port else (443 if scheme == "https" else 80)
+    if not (1 <= p <= 65535):
+        raise PanelError("端口 %s 不在 1-65535" % port)
+    return scheme, str(ip), p
+
+
+def validate(cfg):
+    """返回问题列表(空 = 通过)。一次把所有问题列全, 不在第一条就返回 ——
+    用户改一条跑一次、再撞下一条, 那种来回是能一次说完的。"""
+    errs = []
+    if not isinstance(cfg, dict):
+        return ["面板表最外层要是一个 JSON 对象"]
+    panels = cfg.get("panels")
+    if not isinstance(panels, list):
+        return ['面板表缺 "panels" 数组']
+    seen_name, seen_host, seen_target = {}, {}, {}
+    for i, p in enumerate(panels):
+        if not isinstance(p, dict):
+            _err(errs, i, "要是一个对象")
+            continue
+        unknown = set(p) - KNOWN_KEYS
+        if unknown:
+            # 不静默忽略: 拼错的键(比如 insecure_upstrem)会让一个本该显式的决定变成默认值,
+            # 而默认值恰好是更宽松的那个。
+            _err(errs, i, "有认不出的字段 %s —— 拼错的话本该显式的决定会静默变成默认值"
+                 % ", ".join(sorted(unknown)))
+
+        name = p.get("name")
+        if not isinstance(name, str) or not NAME_RE.match(name):
+            _err(errs, i, "name 要是 [a-z0-9-] 的短名(收到 %r)" % (name,))
+        elif name in seen_name:
+            _err(errs, i, "name %r 与第 %d 条重复" % (name, seen_name[name] + 1))
+        else:
+            seen_name[name] = i
+
+        host = p.get("host")
+        if not isinstance(host, str) or not HOST_RE.match(host or ""):
+            if isinstance(host, str) and host.startswith("*"):
+                _err(errs, i, "host %r 是通配 —— 门二不接受通配: 那等于让任何能触发 SNI 的人"
+                              "决定网关去连谁" % host)
+            else:
+                _err(errs, i, "host 要是普通域名(收到 %r)" % (host,))
+        elif host in seen_host:
+            _err(errs, i, "host %r 与第 %d 条重复 —— 同一个域名指两个上游, "
+                          "实际生效的是哪个取决于反代的实现细节" % (host, seen_host[host] + 1))
+        else:
+            seen_host[host] = i
+
+        try:
+            scheme, ip, port = parse_target(p.get("target"))
+        except PanelError as e:
+            _err(errs, i, str(e))
+        else:
+            key = (ip, port)
+            if key in seen_target:
+                # 不是错误, 但值得说: 两个域名指同一台设备的同一个端口通常是笔误
+                pass
+            seen_target[key] = i
+            if scheme == "https" and p.get("insecure_upstream") is None:
+                _err(errs, i, "上游是 https, 必须显式写 insecure_upstream —— 家用设备几乎都是"
+                              "自签证书, 但\"默认跳过校验\"是错的: 那该由你按设备逐个确认")
+
+        for k in ("insecure_upstream", "rewrite_location", "fix_referer", "legacy_tls"):
+            v = p.get(k)
+            if v is not None and not isinstance(v, bool):
+                _err(errs, i, "%s 要是 true/false(收到 %r)" % (k, v))
+
+        q = p.get("entry_query")
+        if q is not None and (not isinstance(q, str) or not re.match(r"^[A-Za-z0-9_.=&%-]{1,200}$", q)):
+            _err(errs, i, "entry_query 要是查询串片段, 如 magicpath=xxxx(收到 %r)" % (q,))
+
+    return errs
+
+
+def targets(cfg):
+    """派生出站白名单需要的 (IP, 端口) 集合 —— 门三按它放行, 与反代读同一份表。"""
+    out = []
+    for p in cfg.get("panels", []):
+        if not isinstance(p, dict):
+            continue
+        try:
+            _, ip, port = parse_target(p.get("target"))
+        except PanelError:
+            continue
+        if (ip, port) not in out:
+            out.append((ip, port))
+    return out
+
+
+def render_caddy(cfg, certs_dir, bind="127.0.0.1"):
+    """由面板表生成 Caddyfile。
+
+    这些改写能力**从第一版就带上**, 不等踩到再补: 方案 A 在七台真机上逐个踩过一遍(见
+    docs/design-lan-panels.md 第 6 节), 它们是设备的毛病, 与反代跑在哪台机器上无关。
+    """
+    errs = validate(cfg)
+    if errs:
+        raise PanelError("面板表没通过校验, 拒绝生成:\n" + "\n".join("  " + e for e in errs))
+
+    L = []
+    L.append("# 由 lanpanel.py 生成 —— 不要手改。改面板用 `pdg lan add/rm`。")
+    L.append("# 手改的那份迟早与面板表不一致, 而不一致的方向恰恰是"
+             "\"防火墙按表放行、反代按手改的连别处\"。")
+    L.append("{")
+    L.append("\tadmin off")
+    # 证书由 acme.sh 签发落盘, Caddy 不自己去要 —— 那样才不必为每个 DNS 服务商单独构建。
+    L.append("\tauto_https off")
+    L.append("}")
+    L.append("")
+
+    for p in cfg["panels"]:
+        scheme, ip, port = parse_target(p["target"])
+        host = p["host"]
+        name = p["name"]
+        up = "%s://%s:%d" % (scheme, ip, port)
+
+        L.append("# 面板 %s" % name)
+        L.append("%s:443 {" % host)
+        L.append("\tbind %s" % bind)
+        L.append("\ttls %s/%s.crt %s/%s.key" % (certs_dir, name, certs_dir, name))
+
+        if p.get("entry_query"):
+            # 前后端分离的应用(sub-store 之类)要在入口带参数, 否则每台设备都得手输后端地址。
+            L.append("\t@bare path /")
+            L.append("\tredir @bare /?%s 302" % p["entry_query"])
+
+        L.append("\treverse_proxy %s {" % up)
+        if scheme == "https":
+            L.append("\t\ttransport http {")
+            L.append("\t\t\ttls")
+            if p.get("insecure_upstream"):
+                L.append("\t\t\ttls_insecure_skip_verify")
+            L.append("\t\t}")
+        if p.get("rewrite_location"):
+            # 设备会把自己的局域网 IP 写进 Location 跳转头(Zyxel 交换机、华为 UPS 实测)。
+            # 不改写的话手机会跟着跳到一个到不了的地址。
+            L.append("\t\theader_down Location \"%s\" \"https://%s\"" % (up, host))
+            L.append("\t\theader_down Location \"http://%s\" \"https://%s\"" % (ip, host))
+        if p.get("fix_referer"):
+            # 有些设备校验 Referer/Origin 必须是自己的地址(华为 UPS2000 实测, 否则返回
+            # Error Referer Request!)。要在上行方向改回去。
+            L.append("\t\theader_up Referer \"%s/\"" % up)
+            L.append("\t\theader_up Origin \"%s\"" % up)
+        L.append("\t}")
+        L.append("}")
+        L.append("")
+
+    return "\n".join(L)
+
+
+def legacy_tls_panels(cfg):
+    """需要放宽 TLS 套件的面板名。
+
+    老设备可能只提供 AES256-GCM-SHA384(RSA 密钥交换), Go 1.22 起默认禁用 —— 表现是 502
+    加 handshake failure, **看着像证书问题**。这不是靠 Caddyfile 能解决的, 要给进程加
+    GODEBUG=tlsrsakex=1, 所以单独列出来给 unit 生成用。
+    """
+    return [p["name"] for p in cfg.get("panels", []) if isinstance(p, dict) and p.get("legacy_tls")]
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(__doc__.strip().splitlines()[-4])
+        return 3
+    mode, path = argv[1], argv[2]
+    try:
+        cfg = load(path)
+    except (OSError, ValueError) as e:
+        print("读不了面板表 %s: %s" % (path, e))
+        return 3
+
+    if mode == "check":
+        errs = validate(cfg)
+        for e in errs:
+            print(e)
+        return 2 if errs else 0
+
+    if mode == "targets":
+        for ip, port in targets(cfg):
+            print("%s\t%d" % (ip, port))
+        return 0
+
+    if mode == "render":
+        certs, bind = None, "127.0.0.1"
+        rest = argv[3:]
+        while rest:
+            if rest[0] == "--certs" and len(rest) > 1:
+                certs, rest = rest[1], rest[2:]
+            elif rest[0] == "--bind" and len(rest) > 1:
+                bind, rest = rest[1], rest[2:]
+            else:
+                print("认不出的参数: %s" % rest[0])
+                return 3
+        if not certs:
+            print("render 要 --certs <证书目录>")
+            return 3
+        try:
+            sys.stdout.write(render_caddy(cfg, certs, bind))
+        except PanelError as e:
+            print(str(e))
+            return 2
+        return 0
+
+    print("认不出的子命令: %s" % mode)
+    return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/deploy/bot/lanroute.py
+++ b/deploy/bot/lanroute.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""内网面板(方案 B)的**门一**: 判断家里通告过来的子网路由能不能接受。
+
+为什么这道门是灾难级、必须写进代码而不是文档:
+
+Tailscale 的子网路由一旦被本机接受, 那些网段的流量就**从本机的路由表走进 tailnet**。
+如果通告的网段与本项目正在用的段有交集, 手机的分流数据面会直接错乱 —— 而且从任何一份
+配置上都看不出来: nft 规则没变、mosdns 没变、mihomo 没变, 只是包不再走原来那条路了。
+排查这种故障要先想到"是不是别人给我通告了一个网段", 而那正是最难想到的一层。
+
+所以判据必须在**接受之前**跑, 并且拒绝时点名是哪个网段与什么冲突。笼统说一句
+"路由不合法"等于把上面那段排查过程原样丢回给用户。
+
+判据是纯计算: 输入全部由调用方采集好传进来, 这里一个系统调用都不做。这样 doctor 能常驻
+跑它, 测试也不必去造网络现场。
+
+用法:
+  lanroute.py judge --internal <CIDR> [--local <CIDR>]... [--] <通告段>...
+退出码: 0=全部可接受; 2=至少一个被拒(理由写到 stdout); 3=参数不合法。
+"""
+import argparse
+import ipaddress
+import sys
+
+# 拒绝理由的稳定标识。调用方(pdg lan / doctor)按它分类, 不去匹配中文文案 ——
+# 文案会为了讲清楚而改, 标识不会。
+R_DEFAULT = "default-route"
+R_INTERNAL = "overlap-internal"
+R_LOCAL = "overlap-local"
+R_TAILNET = "overlap-tailnet"
+R_LOOPBACK = "overlap-loopback"
+
+# Tailscale 自己的地址段。家里把它整个通告过来, 等于让 tailnet 的流量绕道回家 ——
+# 结果是 tailnet 自身失联, 而 tailnet 正是唯一能把它救回来的通道。
+TAILNET_V4 = ipaddress.ip_network("100.64.0.0/10")
+TAILNET_V6 = ipaddress.ip_network("fd7a:115c:a1e0::/48")
+
+
+def parse_net(s):
+    """接受 CIDR 文本, 返回 ip_network。带主机位的写法(192.168.1.5/24)一律按网段取整,
+    因为"接口地址所在网段"本来就是这个含义 —— 让调用方先算一遍反而多一处出错的地方。"""
+    return ipaddress.ip_network(s.strip(), strict=False)
+
+
+def judge_one(net, internal, locals_, ):
+    """判一个通告段。返回 (标识, 说明) 的列表 —— 一个网段可能同时踩中好几条,
+    全列出来比只报第一条有用: 用户改完第一条又撞上第二条, 那种来回是能一次说完的。"""
+    bad = []
+
+    # ① 默认路由。这不是"网段太大", 是性质不同的一件事: 接受之后本机的**所有**出站流量
+    #    都会走进 tailnet 去家里那台, 网关变成家里的出口节点。手机的国际流量会绕地球一圈,
+    #    而且家里那台的带宽和公网 IP 会替网关背锅。
+    if net.prefixlen == 0:
+        bad.append((R_DEFAULT, "%s 是默认路由 —— 接受它会把网关变成你家的出口节点, "
+                               "手机的所有流量都要绕经家里" % net))
+        return bad          # 已经是最坏情形, 再比对下面几条没有信息量
+
+    # ② 与本项目的内网卡来源段相交。这是最隐蔽的一条: 分流的判据就是"源地址在这个段里",
+    #    段被路由劫走之后, 判据还在、包却不来了。
+    if internal is not None and net.version == internal.version and net.overlaps(internal):
+        bad.append((R_INTERNAL, "%s 与内网卡来源段 %s 相交 —— 手机的流量会被路由进 tailnet, "
+                                "分流数据面直接错乱" % (net, internal)))
+
+    # ③ 与本机某个接口所在网段相交。命中之后本机发往那个网段的包会被送进 tailnet,
+    #    最典型的后果是**本机自己的默认网关到不了**, 表现为整台机器断网。
+    for loc in locals_:
+        if net.version == loc.version and net.overlaps(loc):
+            bad.append((R_LOCAL, "%s 与本机接口网段 %s 相交 —— 本机发往该段的包会被送进 "
+                                 "tailnet, 严重时整台机器断网" % (net, loc)))
+
+    # ④ 与 tailnet 自身的段相交。踩中这条会把救援通道本身弄断。
+    for ts in (TAILNET_V4, TAILNET_V6):
+        if net.version == ts.version and net.overlaps(ts):
+            bad.append((R_TAILNET, "%s 与 Tailscale 自身地址段 %s 相交 —— tailnet 会失联, "
+                                   "而它正是唯一能把机器救回来的通道" % (net, ts)))
+
+    # ⑤ 环回。没有任何正当用途, 但写错网段时很容易撞上(比如手滑写成 127.0.0.0/8)。
+    if net.is_loopback or (net.version == 4 and net.overlaps(ipaddress.ip_network("127.0.0.0/8"))):
+        bad.append((R_LOOPBACK, "%s 覆盖环回地址 —— 这不会有正当用途, 多半是网段写错了" % net))
+
+    return bad
+
+
+def judge(advertised, internal=None, locals_=()):
+    """返回 [(网段文本, [(标识, 说明), ...]), ...], 只含**被拒**的那些。全部可接受时返回空列表。"""
+    out = []
+    for a in advertised:
+        try:
+            net = parse_net(a)
+        except ValueError as e:
+            out.append((a, [("bad-cidr", "%s 不是合法网段(%s)" % (a, e))]))
+            continue
+        bad = judge_one(net, internal, locals_)
+        if bad:
+            out.append((str(net), bad))
+    return out
+
+
+USAGE = "用法: lanroute.py judge --internal <CIDR> [--local <CIDR>]... <通告段>..."
+
+
+def main(argv):
+    # 子命令自己取, 不交给 argparse: 两个位置参数被 --internal 隔开时 argparse 会把
+    # 后面的网段当成"多余参数"报错(nets 被贪婪地绑到第一组位置参数上)。踩过一次,
+    # 表现是合法调用直接退 3, 而错误信息里只字不提真正的原因。
+    if len(argv) < 2 or argv[1] != "judge":
+        print(USAGE)
+        return 3
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--internal", default=None)
+    ap.add_argument("--local", action="append", default=[])
+    ap.add_argument("nets", nargs="*")
+    try:
+        ns = ap.parse_args(argv[2:])
+    except SystemExit:
+        print(USAGE)
+        return 3
+
+    internal = None
+    if ns.internal:
+        try:
+            internal = parse_net(ns.internal)
+        except ValueError:
+            print("内网卡来源段不合法: %s" % ns.internal)
+            return 3
+    locs = []
+    for l in ns.local:
+        try:
+            locs.append(parse_net(l))
+        except ValueError:
+            print("本机接口网段不合法: %s" % l)
+            return 3
+    if not ns.nets:
+        return 0
+
+    rejected = judge(ns.nets, internal, locs)
+    for cidr, reasons in rejected:
+        for tag, why in reasons:
+            print("%s\t%s" % (tag, why))
+    return 2 if rejected else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/deploy/bot/mihomorender.py
+++ b/deploy/bot/mihomorender.py
@@ -292,6 +292,27 @@ def read_mitm_domains(path, platform):
     return out
 
 
+def read_lan_domains(path):
+    """内网面板(方案 B)的域名列表, 读面板表 —— 与反代配置、出站白名单**同一个真源**。
+
+    读不出来一律返回空列表(功能没启用时它本来就不存在)。这里不做校验: 门二在
+    `pdg lan add` 那一侧已经拦过, 而渲染路径上再拒一次的后果是**整份 mihomo 配置渲染
+    不出来** —— 面板配错不该把用户的全部流量一起搞停。
+    """
+    out = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            d = json.load(f)
+    except (OSError, ValueError):
+        return out
+    for panel in (d.get("panels") or []):
+        if isinstance(panel, dict) and isinstance(panel.get("host"), str):
+            h = panel["host"].strip().lower()
+            if h and h not in out:
+                out.append(h)
+    return out
+
+
 def read_platform(path):
     """手机平台标记: ios / android(读不到默认 android —— 不启用 iOS 专属的 MITM 等)。"""
     try:
@@ -304,7 +325,7 @@ def read_platform(path):
 
 
 # ── 渲染与判废 ──────────────────────────────────────────────────────────────
-def render_bytes(model, *, rulesets, mitm_domains, tls_ports):
+def render_bytes(model, *, rulesets, mitm_domains, tls_ports, lan_domains):
     """从给定 model 渲染出 mihomo 配置的**字节**(不落盘)。返回 (bytes, meta)。
 
     事务在候选阶段用它: 内核配置是 model 的派生物, 必须和 model 在同一笔事务里一起校验、
@@ -316,6 +337,7 @@ def render_bytes(model, *, rulesets, mitm_domains, tls_ports):
     cfg, meta = sb2mihomo.singbox_to_mihomo(
         model, redir_port=MIHOMO_REDIR, rulesets=rulesets,
         mitm_domains=mitm_domains, mitm_port=MITM_PORT, tls_ports=tls_ports,
+        lan_domains=lan_domains,
         **panel_args(model))
     # mihomo 只吃 YAML; JSON 是 YAML 的子集, 直接可解析
     return json.dumps(cfg, ensure_ascii=False, indent=2).encode("utf-8"), meta
@@ -361,19 +383,19 @@ def _dropped_items(dropped):
     return out
 
 
-def derive_bytes(staged, *, rulesets, mitm_domains, tls_ports):
+def derive_bytes(staged, *, rulesets, mitm_domains, tls_ports, lan_domains):
     """pdgtx deriver 的公共主体: 由**候选** model 渲染并判废。
 
     候选里如果带着 rs_meta, 调用方应当据此算出 rulesets 再传进来 —— 读现网旧文件会让新增的
     规则集"翻译不了"被丢掉, 或者已删的又冒出来。"""
     model = json.loads(staged["model"].decode("utf-8"))
     data, meta = render_bytes(model, rulesets=rulesets, mitm_domains=mitm_domains,
-                              tls_ports=tls_ports)
+                              tls_ports=tls_ports, lan_domains=lan_domains)
     check_meta(meta)
     return data
 
 
-def deriver_from_paths(*, rs_meta_path, mitm_hijack_file, platform_file):
+def deriver_from_paths(*, rs_meta_path, mitm_hijack_file, platform_file, lan_table_file):
     """给**不能 import bot** 的调用方(配置恢复、救援的紧急默认出口)用的 deriver 工厂。
 
     返回一个 pdgtx 认的 deriver(staged → bytes)。路径显式传入, 因为这些调用方跑在事务沙箱
@@ -391,7 +413,8 @@ def deriver_from_paths(*, rs_meta_path, mitm_hijack_file, platform_file):
         try:
             return derive_bytes(staged, rulesets=rulesets_arg(meta),
                                 mitm_domains=read_mitm_domains(mitm_hijack_file, plat),
-                                tls_ports=[443] if plat == "ios" else None)
+                                tls_ports=[443] if plat == "ios" else None,
+                                lan_domains=read_lan_domains(lan_table_file))
         except RenderRefused as e:
             # 边界映射: 事务层认 TxRefused, 于是配置恢复/救援能给出可解释的拒绝而不是 500。
             # 详情一律取 detail()(它自己脱敏); 事务核心不在就把 RenderRefused 原样抛出去 ——

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -32,6 +32,9 @@ import mihomorender                              # 渲染链的共享实现(救�
 MIHOMO_REDIR = mihomorender.MIHOMO_REDIR
 MITM_PORT = mihomorender.MITM_PORT                # MITM 服务(socks5)监听; mihomo 把接管域名路由到这
 MITM_HIJACK_FILE = "/etc/mosdns/rules/mitm_hijack.txt"   # 接管域名(mosdns 强制劫持集, 与 mihomo 路由同源)
+# 内网面板表(方案 B)。渲染 mihomo 配置时要据它把面板域名指到本机反代 ——
+# 与反代配置、出站白名单同一个真源。
+LAN_TABLE_FILE = "/etc/privdns-gateway/lan-panels.json"
 # mihomo 有路径安全限制: external-ui 等文件路径须在工作目录(-d)下或 SAFE_PATHS 白名单内。
 # 观测面板 UI 在 /etc/sing-box/ui/dist(与 sing-box 共用), 不在 /etc/mihomo 下 → 用 SAFE_PATHS 放行,
 # 使 mihomo 服务运行 + 本进程发起的所有 `mihomo -t` 校验都认这个 UI 路径。
@@ -1008,7 +1011,8 @@ def _render_mihomo_bytes(model, rs_meta=None, mitm_domains=None):
     return mihomorender.render_bytes(
         model, rulesets=_mihomo_rulesets(rs_meta),
         mitm_domains=_mitm_domains() if mitm_domains is None else mitm_domains,
-        tls_ports=[443] if _platform() == "ios" else None)
+        tls_ports=[443] if _platform() == "ios" else None,
+        lan_domains=mihomorender.read_lan_domains(LAN_TABLE_FILE))
 
 
 def _render_mihomo_file():

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -1024,7 +1024,13 @@ def _render_mihomo_file():
     tls_ports = [443] if _platform() == "ios" else None
     cfg, meta = sb2mihomo.singbox_to_mihomo(
         model, redir_port=MIHOMO_REDIR, rulesets=_mihomo_rulesets(),
-        mitm_domains=_mitm_domains(), mitm_port=MITM_PORT, tls_ports=tls_ports, **_panel_render_args(model))
+        mitm_domains=_mitm_domains(), mitm_port=MITM_PORT, tls_ports=tls_ports,
+        # 这条路**直接调 sb2mihomo**, 不经 _render_mihomo_bytes —— 于是每加一个渲染入参
+        # 都要在两处各写一遍。漏了一处的后果不是报错: 这条路渲染出来的配置会静默少掉那块
+        # 能力(本轮就是面板路由全丢, 而事务那条路好好的)。
+        # tests/test-render-shared.py 有一条守卫盯着两条路的产出必须逐字节相同。
+        lan_domains=mihomorender.read_lan_domains(LAN_TABLE_FILE),
+        **_panel_render_args(model))
     _write_mihomo(cfg)
     return meta
 

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -2215,6 +2215,7 @@ menu(){
     echo " 12) 识别内网卡段"
     echo " 13) 卸载"
     echo "  s) SSH 来源限制 (可选: 只允许经 Tailscale 登录)"
+    echo "  l) 内网面板 (可选: 手机零 App 访问家里的 Web 面板)"
     echo "  0) 退出"
     echo "  下次打开本菜单命令: pdg"
     printf "选择: "
@@ -2234,6 +2235,9 @@ menu(){
       11) cmd_report;;
       12) cmd_detect_cidr;;
       s|ssh) cmd_ssh_source "$(read -rp "  [status|tailnet|any|confirm] (回车=status): " a; echo "${a:-status}")";;
+      l|lan) read -rp "  [status|list|check|routes|add|rm] (回车=status): " a
+         # shellcheck disable=SC2086  # 参数要按空白拆开传给子命令, 这里是有意为之
+         cmd_lan ${a:-status};;
       13) read -rp "卸载: 留空取消 / yes 仅卸载 / purge 连配置一起删: " x
          case "$x" in yes) cmd_uninstall;; purge) cmd_uninstall --purge;; *) echo "已取消";; esac;;
       0|q) exit 0;;
@@ -4844,6 +4848,185 @@ _ssh_revert_arm(){              # 起自动回退定时器
 _ssh_revert_disarm(){ systemctl stop "$_SSH_REVERT_UNIT.timer" >/dev/null 2>&1 || true
                       systemctl reset-failed "$_SSH_REVERT_UNIT" >/dev/null 2>&1 || true; }
 
+# ══ 内网面板(方案 B) ═════════════════════════════════════════════════════════
+# 手机零 App 访问家里的内网面板: 手机 →(SIM)→ 网关 → tailnet → 家里的设备。
+# 设计与三道门见 docs/design-lan-panels.md。这里是面板表的增删查与门一的判定入口;
+# 反代与证书的生命周期另见 `pdg lan enable/disable`。
+LAN_TABLE_PATH="${PDG_LAN_TABLE:-/etc/privdns-gateway/lan-panels.json}"
+
+# 面板表的**当前内容**(不存在则给一张空表)。给空表而不是报错: 第一次 add 之前它本来
+# 就不该存在, 让用户先手动建一个空 JSON 是没有道理的仪式。
+_lan_cur(){
+  if [[ -s "$LAN_TABLE_PATH" ]]; then cat "$LAN_TABLE_PATH"
+  else printf '{\n  "panels": []\n}\n'; fi
+}
+
+# 一笔事务改面板表。骨架与 _pdg_cidr_transact 相同 —— 候选由 lanpanel.py 生成(不写盘),
+# 落盘、校验、观察、回滚全交给 pdgtx。
+#   $1 = 事务 op 名(进台账, 事后能看出这笔是谁发起的)
+#   $2.. = 传给 lanpanel.py 的子命令与参数
+_lan_transact(){
+  local op="$1"; shift
+  local mod txm wd txid sha rc=0
+  mod="$(_pdg_module lanpanel.py)" || { c_y "❌ 找不到 lanpanel.py, 未改动任何文件。"; return 1; }
+  txm="$(_pdg_module pdgtx.py)"    || { c_y "❌ 找不到 pdgtx.py(事务核心缺失), 未改动任何文件。"; return 1; }
+
+  local pend; pend="$(python3 "$txm" pending 2>/dev/null)"
+  if [[ -n "$pend" ]]; then
+    c_y "⛔ 有未完成的配置事务, 本次拒绝执行(未改动任何文件):"
+    printf '%s\n' "$pend" | sed 's/^/    /'
+    c_y "   请先 sudo pdg tx show <id> 查看, 再 sudo pdg tx recover <id> 收尾。"
+    return 1
+  fi
+
+  wd="$(mktemp -d)" || { c_y "❌ 无法创建临时目录"; return 1; }
+  _lan_cur > "$wd/cur.json"
+
+  # 先在候选上跑一遍, 不合法就在**碰事务之前**停下 —— 开了事务再失败要多一次 abort,
+  # 而失败原因(表不合法)与事务毫无关系。
+  if ! python3 "$mod" "$@" "$wd/cur.json" > "$wd/new.json" 2>"$wd/err"; then
+    c_y "❌ 拒绝改动(未改动任何文件):"
+    [[ -s "$wd/err" ]] && sed 's/^/    /' "$wd/err"
+    [[ -s "$wd/new.json" ]] && sed 's/^/    /' "$wd/new.json"
+    rm -rf "$wd"; return 1
+  fi
+
+  txid="$(python3 "$txm" new --source cli --op "$op" 2>"$wd/err")" || {
+    c_y "❌ 无法开始配置事务: $(tr -d '\n' < "$wd/err")"; rm -rf "$wd"; return 1; }
+
+  # 前置条件: 生成候选时表是什么样。不存在用 "-" 表示 —— 第一次 add 走的正是这条路。
+  if [[ -s "$LAN_TABLE_PATH" ]]; then
+    if ! python3 "$txm" read --target lan_panels > "$wd/raw" 2>"$wd/err"; then
+      c_y "❌ 读不到面板表: $(tr -d '\n' < "$wd/err") → 未改动任何文件。"
+      python3 "$txm" abort "$txid" >/dev/null 2>&1 || true; rm -rf "$wd"; return 1
+    fi
+    sha="$(head -1 "$wd/raw")"
+  else
+    sha="-"
+  fi
+
+  if ! python3 "$txm" stage --tx "$txid" --target lan_panels --file "$wd/new.json" --expect "$sha" 2>"$wd/err"; then
+    c_y "❌ 暂存候选失败: $(tr -d '\n' < "$wd/err") → 未改动任何文件。"
+    python3 "$txm" abort "$txid" >/dev/null 2>&1 || true; rm -rf "$wd"; return 1
+  fi
+
+  local out; out="$(python3 "$txm" apply --tx "$txid" 2>"$wd/err")"; rc=$?
+  if [[ "$rc" == 0 ]]; then rm -rf "$wd"; return 0; fi
+  case "$rc" in
+    4) c_y "⛔ 已有配置操作在执行(锁被占用), 本次未改动任何文件。";;
+    5) c_y "⛔ 拒绝执行(未改动任何文件):"; [[ -s "$wd/err" ]] && sed 's/^/    /' "$wd/err";;
+    *) c_y "❌ 面板表变更失败, 已按 before-image 回滚:"
+       [[ -s "$wd/err" ]] && sed 's/^/    /' "$wd/err"
+       [[ -n "$out" ]] && printf '%s\n' "$out" | sed 's/^/    /';;
+  esac
+  rm -rf "$wd"; return 1
+}
+
+_lan_list(){
+  local mod; mod="$(_pdg_module lanpanel.py)" || { echo "找不到 lanpanel.py"; return 1; }
+  local t; t="$(mktemp)"; _lan_cur > "$t"
+  python3 "$mod" list "$t"; local rc=$?; rm -f "$t"; return $rc
+}
+
+# 门一: 判一批网段能不能接受。判据全部来自本机现状 —— 内网卡来源段取 profile.env,
+# 本机接口网段现读, 不让调用方传, 免得"传错一个参数"变成"判据看起来通过了"。
+_lan_routes(){
+  local mod; mod="$(_pdg_module lanroute.py)" || { echo "找不到 lanroute.py"; return 1; }
+  [[ $# -gt 0 ]] || { echo "用法: pdg lan routes <网段>...  (判断家里通告的子网路由能不能接受)"; return 1; }
+  local internal; internal="$(sed -n 's/^[[:space:]]*PDG_INTERNAL_CIDR=//p' "$PROFILE_ENV" 2>/dev/null | tail -1)"
+  local -a args=(judge)
+  if [[ -n "$internal" ]]; then
+    args+=(--internal "$internal")
+  else
+    # 取不到内网卡来源段 = 门一里**最要紧的那条判据跑不了**。放行与拒绝两条路上都要说,
+    # 而不是只在成功时轻描淡写提一句 —— 否则用户会拿着一个"✅ 可以接受"去接受一个
+    # 其实会把分流打烂的网段, 而那正是这道门存在的全部理由。
+    c_y "⚠️ 读不到 PDG_INTERNAL_CIDR($PROFILE_ENV) —— **与内网卡来源段相交**这条判据本次没跑。"
+    c_y "   下面的结论只覆盖了默认路由、本机接口、tailnet 自身段、环回这四条。"
+    echo
+  fi
+  local a
+  while read -r a; do [[ -n "$a" ]] && args+=(--local "$a"); done < <(
+    ip -o -4 addr show scope global 2>/dev/null | awk '{print $4}'
+    ip -o -6 addr show scope global 2>/dev/null | awk '{print $4}')
+  local out rc
+  out="$(python3 "$mod" "${args[@]}" "$@" 2>&1)"; rc=$?
+  case "$rc" in
+    0) c_g "✅ 这些网段可以接受:"; printf '  %s\n' "$@"
+       echo "   判据: 与内网卡来源段(${internal:-未配置})、本机接口网段、tailnet 自身段都不相交, 也不是默认路由。"
+       return 0;;
+    2) c_y "⛔ 有网段不能接受 —— 接受它们会让手机的分流数据面错乱, 而配置上看不出来:"
+       printf '%s\n' "$out" | while IFS=$'\t' read -r tag why; do echo "   [$tag] $why"; done
+       [[ -z "$internal" ]] && c_y "   (再说一遍: 与内网卡来源段相交那条**没跑**, 所以这份清单可能还不全)"
+       echo
+       echo "   家里那侧改小通告范围之后再来。别在本机 \`tailscale set --accept-routes\` 硬接 ——"
+       echo "   那会让上面这些后果真的发生。"
+       return 1;;
+    *) c_y "❌ 判定没跑起来: $out"; return 1;;
+  esac
+}
+
+_lan_status(){
+  echo "内网面板(方案 B)"
+  if [[ -s "$LAN_TABLE_PATH" ]]; then
+    local n; n="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("panels",[])))' "$LAN_TABLE_PATH" 2>/dev/null || echo '?')"
+    echo "  面板表: $LAN_TABLE_PATH ($n 条)"
+    local mod; mod="$(_pdg_module lanpanel.py)" || mod=""
+    if [[ -n "$mod" ]]; then
+      if python3 "$mod" check "$LAN_TABLE_PATH" >/dev/null 2>&1; then
+        c_g "  门二(白名单映射): 通过"
+      else
+        c_y "  ⚠️ 门二: 面板表**没通过校验** —— 跑 pdg lan check 看具体哪条"
+      fi
+    fi
+  else
+    echo "  面板表: 还没有(用 pdg lan add 加第一条)"
+  fi
+  if command -v tailscale >/dev/null 2>&1 && ip -o link show tailscale0 >/dev/null 2>&1; then
+    local acc; acc="$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit()
+r=(d.get("Self") or {}).get("AllowedIPs") or []
+print(" ".join(x for x in r if not x.startswith(("100.","fd7a:"))))' 2>/dev/null)"
+    echo "  Tailscale: 已连接${acc:+; 本机通告 $acc}"
+  else
+    c_y "  ⚠️ Tailscale 没在跑 —— 方案 B 的整条链路都要经它, 先把它装好并认证"
+  fi
+}
+
+cmd_lan(){
+  local sub="${1:-status}"; shift 2>/dev/null || true
+  case "$sub" in
+    status|"") _lan_status;;
+    list)      _lan_list;;
+    check)     local mod; mod="$(_pdg_module lanpanel.py)" || return 1
+               local t; t="$(mktemp)"; _lan_cur > "$t"
+               if python3 "$mod" check "$t"; then c_g "✅ 面板表通过门二校验"; rm -f "$t"; return 0
+               else rm -f "$t"; return 1; fi;;
+    routes)    _lan_routes "$@";;
+    add)       need_root lan
+               _lan_transact lan-add add "$@" && { c_g "✅ 已加入面板表。"; _lan_list; };;
+    rm)        need_root lan
+               [[ -n "${1:-}" ]] || { echo "用法: pdg lan rm <面板名>"; return 1; }
+               _lan_transact lan-rm rm "$1" && { c_g "✅ 已从面板表移除。"; _lan_list; };;
+    *)
+      echo "用法: pdg lan <status|list|check|routes|add|rm>"
+      echo "  status                    当前状态(面板数、门二、Tailscale)"
+      echo "  list                      面板清单"
+      echo "  check                     跑一遍门二校验"
+      echo "  routes <网段>...          门一: 判断家里通告的子网路由能不能接受"
+      echo "  add --name <短名> --host <域名> --target <http(s)://字面IP[:端口]> [选项]"
+      echo "      --insecure|--no-insecure   上游是 https 时**必须**二选一(家用设备多是自签证书,"
+      echo "                                 但默认跳过校验是错的 —— 那该由你按设备逐个确认)"
+      echo "      --rewrite-location         设备把自己的局域网 IP 写进跳转头时用"
+      echo "      --fix-referer              设备校验 Referer/Origin 必须是自己地址时用"
+      echo "      --legacy-tls               老设备只有 RSA 密钥交换套件(表现是 502 + handshake failure)"
+      echo "      --entry-query <q>          前后端分离的应用要在入口带的参数, 如 magicpath=xxxx"
+      echo "  rm <面板名>"
+      return 1;;
+  esac
+}
+
 cmd_ssh_source(){
   need_root ssh-source
   local sub="${1:-status}"
@@ -5126,6 +5309,7 @@ case "${1:-menu}" in
   platform)      shift || true; cmd_platform "$@";;
   hijack-mode)   shift || true; cmd_hijack_mode "$@";;
   ssh-source)    shift || true; cmd_ssh_source "$@";;
+  lan)           shift || true; cmd_lan "$@";;
   link)          shift || true; cmd_link "$@";;
   uninstall|rm)  shift || true; cmd_uninstall "$@";;
   rescue)        shift || true; cmd_rescue "$@";;

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5113,10 +5113,17 @@ for p in d.get("panels",[]):
 # 证书: DNS-01 签发。凭据放 600 文件, 由 acme.sh 从环境读 —— 不进命令行(ps 看得见),
 # 不进日志。
 _lan_cert(){
-  local dnsapi="${1:-}"
-  [[ -n "$dnsapi" ]] || { echo "用法: pdg lan cert <acme.sh 的 DNS 插件名, 如 dns_cf>"; 
+  local dnsapi="${1:-}" alias_zone="${2:-}"
+  [[ -n "$dnsapi" ]] || { echo "用法: pdg lan cert <acme.sh 的 DNS 插件名, 如 dns_cf> [委派zone]"; 
     echo "  凭据写进 $LAN_DNS_ENV (600), 一行一个 KEY=值 —— 具体要哪些看 acme.sh 的 dnsapi 文档。"
-    echo "  例(Cloudflare): CF_Token=...   然后 pdg lan cert dns_cf"; return 1; }
+    echo "  例(Cloudflare): CF_Token=...   然后 pdg lan cert dns_cf"
+    echo
+    echo "  [委派zone] 用来把 DNS token 的爆炸半径收窄, **强烈建议给**:"
+    echo "    先在主域下给每个面板加一条 CNAME:"
+    echo "      _acme-challenge.<面板域名>  CNAME  <面板域名>.<委派zone>"
+    echo "    然后 token 只需要能改**委派 zone**, 不再需要能改主域 —— 于是一台被拿下的"
+    echo "    网关**签不了你自己的 DoT 域名**, 风险从"权限升级"降回"多一个凭据"。"
+    echo "    例: pdg lan cert dns_cf acme-deleg.example.net"; return 1; }
   [[ -s "$LAN_DNS_ENV" ]] || { c_y "❌ 缺 $LAN_DNS_ENV —— DNS 服务商的凭据要先放好(600)。"; return 1; }
   local mode; mode="$(stat -c %a "$LAN_DNS_ENV" 2>/dev/null)"
   [[ "$mode" == 600 ]] || { c_y "❌ $LAN_DNS_ENV 权限是 $mode, 应为 600 —— 里面是能改你 DNS 的凭据。"; return 1; }
@@ -5131,8 +5138,12 @@ _lan_cert(){
   (
     set -a; # shellcheck disable=SC1090
     source "$LAN_DNS_ENV"; set +a
+    # --challenge-alias: 把 _acme-challenge 的写入指到**委派 zone**。这不是便利选项 ——
+    # 没有它, token 必须能改主域, 而主域里通常还有本项目自己的 DoT 域名(见 lanpanel.zone_risk)。
+    local -a alias_arg=()
+    [[ -n "$alias_zone" ]] && alias_arg=(--challenge-alias "$alias_zone")
     "$ACME_HOME/acme.sh" --home "$ACME_HOME/data" --issue --dns "$dnsapi" \
-      "${doms[@]}" --server letsencrypt --keylength ec-256
+      "${doms[@]}" "${alias_arg[@]+"${alias_arg[@]}"}" --server letsencrypt --keylength ec-256
   ) || { c_y "❌ 签发失败 —— 看上面 acme.sh 给的原因(多半是凭据权限不足或域名不在该 zone)。"; return 1; }
   while read -r h; do
     [[ -n "$h" ]] || continue
@@ -5416,7 +5427,7 @@ cmd_lan(){
                _lan_transact lan-rm rm "$1" && { c_g "✅ 已从面板表移除。"; _lan_list; };;
     enable)    _lan_enable;;
     disable)   _lan_disable;;
-    cert)      need_root lan; _lan_cert "${1:-}";;
+    cert)      need_root lan; _lan_cert "${1:-}" "${2:-}";;
     render)    need_root lan
                _lan_render || return 1
                c_g "✅ 反代配置与出站白名单已按面板表重新生成。"
@@ -5437,7 +5448,9 @@ cmd_lan(){
       echo "      --legacy-tls               老设备只有 RSA 密钥交换套件(表现是 502 + handshake failure)"
       echo "      --entry-query <q>          前后端分离的应用要在入口带的参数, 如 magicpath=xxxx"
       echo "  rm <面板名>"
-      echo "  cert <dns插件名>          DNS-01 签发(凭据放 /etc/privdns-gateway/lan-dns.env, 600)"
+      echo "  cert <dns插件名> [委派zone]  DNS-01 签发(凭据放 /etc/privdns-gateway/lan-dns.env, 600)"
+      echo "                            给了委派 zone, token 就只需要能改那一个 zone ——"
+      echo "                            被拿下的网关签不了你自己的 DoT 域名(见 pdg lan status 的风险提示)"
       echo "  enable / disable          启用/停用反代"
       echo "  render                    面板表改过之后重新生成全部派生物(反代/白名单/DNS/分流)"
       echo "  wire                      只同步 DNS 劫持集与 mihomo 分流(反代配置不动)"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5045,7 +5045,14 @@ LAN_ETC="/etc/pdg-lan"
 LAN_CADDYFILE="$LAN_ETC/caddy.conf"
 LAN_NFT_CONF="/etc/nftables-pdg-lan.conf"
 LAN_CERT_DIR="$LAN_ETC/certs"
-LAN_DNS_ENV="/etc/privdns-gateway/lan-dns.env"
+# DNS 服务商凭据。放 $LAN_ETC 下而不是 /etc/privdns-gateway/:
+#   · 普通卸载会把 $LAN_ETC 整个删掉 —— 凭据因此跟着走。服务没了而能改你 DNS 记录的
+#     token 还留在盘上, 比不卸载更糟。
+#   · /etc/privdns-gateway 在普通卸载路径上**必须一个字节都不碰**(里面有 iOS 描述文件的
+#     身份记录, 丢了手机上那份描述文件从此无法更新, 而界面什么都不报)。
+#   · 目录是 750 root:pdg-lan, 但这个文件是 **600 root:root** —— 反代能穿越目录,
+#     读不到文件。目录可穿越不等于文件可读。
+LAN_DNS_ENV="$LAN_ETC/dns.env"
 LAN_UNIT="/etc/systemd/system/pdg-lan.service"
 LAN_STATE_DIR="/var/lib/pdg-lan"
 ACME_HOME="/opt/pdg-acme"
@@ -5125,8 +5132,11 @@ _lan_cert(){
     echo "    网关**签不了你自己的 DoT 域名** —— 风险从权限升级降回只是多一个凭据。"
     echo "    例: pdg lan cert dns_cf acme-deleg.example.net"; return 1; }
   [[ -s "$LAN_DNS_ENV" ]] || { c_y "❌ 缺 $LAN_DNS_ENV —— DNS 服务商的凭据要先放好(600)。"; return 1; }
-  local mode; mode="$(stat -c %a "$LAN_DNS_ENV" 2>/dev/null)"
+  local mode owner
+  mode="$(stat -c %a "$LAN_DNS_ENV" 2>/dev/null)"; owner="$(stat -c %U "$LAN_DNS_ENV" 2>/dev/null)"
   [[ "$mode" == 600 ]] || { c_y "❌ $LAN_DNS_ENV 权限是 $mode, 应为 600 —— 里面是能改你 DNS 的凭据。"; return 1; }
+  # 属主也要查: 目录对 pdg-lan 组可穿越, 文件若属主是 pdg-lan, 600 反而变成"只有反代能读"。
+  [[ "$owner" == root ]] || { c_y "❌ $LAN_DNS_ENV 属主是 $owner, 应为 root。"; return 1; }
   _lan_install_acme || return 1
   local -a doms=(); local h
   while read -r h; do [[ -n "$h" ]] && doms+=(-d "$h"); done < <(_lan_hosts)
@@ -5448,7 +5458,7 @@ cmd_lan(){
       echo "      --legacy-tls               老设备只有 RSA 密钥交换套件(表现是 502 + handshake failure)"
       echo "      --entry-query <q>          前后端分离的应用要在入口带的参数, 如 magicpath=xxxx"
       echo "  rm <面板名>"
-      echo "  cert <dns插件名> [委派zone]  DNS-01 签发(凭据放 /etc/privdns-gateway/lan-dns.env, 600)"
+      echo "  cert <dns插件名> [委派zone]  DNS-01 签发(凭据放 $LAN_DNS_ENV, 600 root:root)"
       echo "                            给了委派 zone, token 就只需要能改那一个 zone ——"
       echo "                            被拿下的网关签不了你自己的 DoT 域名(见 pdg lan status 的风险提示)"
       echo "  enable / disable          启用/停用反代"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -4884,7 +4884,11 @@ _lan_transact(){
 
   # 先在候选上跑一遍, 不合法就在**碰事务之前**停下 —— 开了事务再失败要多一次 abort,
   # 而失败原因(表不合法)与事务毫无关系。
-  if ! python3 "$mod" "$@" "$wd/cur.json" > "$wd/new.json" 2>"$wd/err"; then
+  # lanpanel.py 的契约是 `<子命令> <表路径> [选项...]` —— 表路径在**第二位**, 不是最后。
+  # 拼在最后会让 --name 被当成表路径, 报出来的错是"读不了面板表 --name", 与真正的原因
+  # 隔着一层。
+  local sub="$1"; shift
+  if ! python3 "$mod" "$sub" "$wd/cur.json" "$@" > "$wd/new.json" 2>"$wd/err"; then
     c_y "❌ 拒绝改动(未改动任何文件):"
     [[ -s "$wd/err" ]] && sed 's/^/    /' "$wd/err"
     [[ -s "$wd/new.json" ]] && sed 's/^/    /' "$wd/new.json"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5122,7 +5122,7 @@ _lan_cert(){
     echo "    先在主域下给每个面板加一条 CNAME:"
     echo "      _acme-challenge.<面板域名>  CNAME  <面板域名>.<委派zone>"
     echo "    然后 token 只需要能改**委派 zone**, 不再需要能改主域 —— 于是一台被拿下的"
-    echo "    网关**签不了你自己的 DoT 域名**, 风险从"权限升级"降回"多一个凭据"。"
+    echo "    网关**签不了你自己的 DoT 域名** —— 风险从权限升级降回只是多一个凭据。"
     echo "    例: pdg lan cert dns_cf acme-deleg.example.net"; return 1; }
   [[ -s "$LAN_DNS_ENV" ]] || { c_y "❌ 缺 $LAN_DNS_ENV —— DNS 服务商的凭据要先放好(600)。"; return 1; }
   local mode; mode="$(stat -c %a "$LAN_DNS_ENV" 2>/dev/null)"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -4970,6 +4970,43 @@ _lan_routes(){
   esac
 }
 
+# 风险②: 签面板证书的 DNS token 会不会顺带能签本项目自己的 DoT 域名。
+#
+# 这不是"多一个凭据"而是**权限升级**: token 按 zone 授权, 而面板域名与 DoT 域名通常在
+# 同一个 zone 里 —— 一台被拿下的网关可以用它签发 DoT 域名的证书, 进而 MITM 用户自己的
+# DNS。面板被看到是一回事, DNS 被劫持是另一回事。
+#
+# 只警告不阻断: 用户完全可以接受这个风险(自己家、自己用), 那是他的决定。但他必须**知道**
+# 自己在决定什么 —— 这条不能只写在文档第 7 节里等人去读。
+_lan_zone_warn(){
+  local mod dot risks
+  mod="$(_pdg_module lanpanel.py)" || return 0
+  dot="$(cat /opt/pdg-bot/dot-domain 2>/dev/null)"
+  [[ -n "$dot" ]] || return 0
+  # 退出码要**逐个分辨**, 不能只分"成功/其他": 0=没风险, 2=有风险, 其余=判据没跑起来。
+  # 写成 `... && return 0` 的话, 任何一种失败(模块旧、参数不认、python 挂了)都会被当成
+  # "有风险", 而错误文本会被原样当成风险清单打出来 —— 一条本该提醒人的警告变成噪音,
+  # 用户下次就不看它了。
+  local rc
+  risks="$(python3 "$mod" zone-risk "$LAN_TABLE_PATH" "$dot" 2>/dev/null)"; rc=$?
+  case "$rc" in
+    0) return 0;;
+    2) : ;;                     # 有风险, 往下报
+    *) c_y "  ⚠️ 同 zone 风险判据没跑起来(lanpanel.py zone-risk 退出码 $rc) —— 这一条本次没检查。"
+       return 0;;
+  esac
+  [[ -n "$risks" ]] || return 0
+  echo
+  c_y "  ⚠️ 风险: 面板域名与本项目的 DoT 域名($dot)在同一个 zone 里"
+  printf '%s\n' "$risks" | while IFS=$'\t' read -r h z; do echo "       $h  ←同 zone→  $dot   ($z)"
+  done
+  c_y "     签发面板证书要一个能改这个 zone 的 DNS token, 而那个 token **也能签发 $dot**。"
+  c_y "     于是一台被拿下的网关可以给你的 DoT 域名签一张真证书, 反过来 MITM 你自己的 DNS ——"
+  c_y "     面板被看到是一回事, DNS 被劫持是另一回事。"
+  echo "     收窄的办法: 面板用单独的子域, 并把 _acme-challenge 用 CNAME 委派到一个**单独的 zone**,"
+  echo "     让 token 只控制那一个 zone。"
+}
+
 _lan_status(){
   echo "内网面板(方案 B)"
   if [[ -s "$LAN_TABLE_PATH" ]]; then
@@ -4982,6 +5019,7 @@ _lan_status(){
       else
         c_y "  ⚠️ 门二: 面板表**没通过校验** —— 跑 pdg lan check 看具体哪条"
       fi
+      _lan_zone_warn
     fi
   else
     echo "  面板表: 还没有(用 pdg lan add 加第一条)"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5228,8 +5228,7 @@ _lan_enable(){
   if systemctl is-active --quiet pdg-lan; then
     _profile_set PDG_LAN_ENABLED 1 || c_y "⚠️ profile.env 写入失败, 启用意图未持久化。"
     c_g "✅ 内网面板已启用。反代监听 127.0.0.1:443, 出站白名单已按面板表加载。"
-    echo "   还差最后一步: 让 mosdns 把这些域名劫持到网关、mihomo 把它们指到本机反代。"
-    echo "   现在直接从手机访问还不通 —— 这一段见 pdg lan wire(尚未实现)。"
+    _lan_wire && c_g "   DNS 劫持集与 mihomo 分流已同步 —— 手机侧现在应该能打开了。"
   else
     c_y "❌ pdg-lan 没起来。最近的日志:"
     journalctl -u pdg-lan -n 15 --no-pager 2>/dev/null | sed 's/^/    /'
@@ -5287,6 +5286,119 @@ _lan_purge(){
   return 0
 }
 
+# ── mosdns 侧: 让手机把面板域名解析到网关 ─────────────────────────────────────
+# 少了这一段, 手机查面板域名拿到的是 NXDOMAIN(那些域名没有公网 A 记录), 前面整条链路
+# 一次都不会被触发 —— 反代跑得好好的, 面板就是打不开, 而哪里都不报错。
+LAN_HIJACK_FILE="/etc/mosdns/rules/lan_hijack.txt"
+
+# 一次性迁移: 把 lan_hijack.txt 挂进现有的**明确代理集**。
+#
+# 为什么复用 explicit_proxy 而不是另起一条序列: 面板域名的 DNS 行为与"明确指到出口的
+# 域名"完全一样 —— 抑制 AAAA/HTTPS、A 记录劫持到网关, 剩下的交给 mihomo 按 SNI 分流。
+# 另造一条一模一样的序列只会多一处要同步的地方。
+#
+# 幂等; 只认本项目的标准形态; 备份 → 生成 → 校验 → 失败还原。$1 可指定文件(供测试)。
+# shellcheck disable=SC2120
+migrate_mosdns_lan(){
+  local f="${1:-/etc/mosdns/config.yaml}"
+  [[ -f "$f" ]] || return 0
+  grep -q 'lan_hijack.txt' "$f" && return 0                      # 已挂 → 幂等退出
+  grep -q 'tag: explicit_proxy' "$f" || return 0                 # 非标准形态 → 不动(交 doctor)
+  local rdir; rdir="$(grep -oE '"/[^"]*/custom_hijack\.txt"' "$f" | head -1 | tr -d '"')"
+  rdir="$(dirname "$rdir" 2>/dev/null)"; [[ -n "$rdir" && "$rdir" != "." ]] || rdir="/etc/mosdns/rules"
+  install -d -m755 "$rdir" 2>/dev/null || true
+  [[ -e "$rdir/lan_hijack.txt" ]] || : > "$rdir/lan_hijack.txt"  # 空集 = 休眠, 零影响
+  local bak; bak="$f.prelan.$(date +%s)"
+  if ! cp -a "$f" "$bak" 2>/dev/null || ! cmp -s "$f" "$bak"; then
+    c_y "  [面板迁移] 备份失败(磁盘满?), 中止、不动现网。"; rm -f "$bak" 2>/dev/null; return 0
+  fi
+  if ! python3 - "$f" "$rdir" <<'PY'
+import re, sys
+f, rdir = sys.argv[1], sys.argv[2]
+s = open(f, encoding="utf-8").read()
+# 只改 explicit_proxy 那一条 domain_set 的 files 列表。按 tag 定位再在其后找最近的 files,
+# 不用全局正则 —— 配置里有好几个 domain_set, 改错一个的后果是把面板域名塞进 CN 直连集。
+i = s.find("- tag: explicit_proxy")
+assert i >= 0, "找不到 explicit_proxy"
+m = re.compile(r"args:\s*\{\s*files:\s*\[(.*?)\]\s*\}").search(s, i)
+assert m, "explicit_proxy 之后找不到 files 列表"
+inner = m.group(1)
+assert "lan_hijack.txt" not in inner, "已经在里面了"
+new = inner.rstrip() + ',"%s/lan_hijack.txt"' % rdir
+out = s[:m.start(1)] + new + s[m.end(1):]
+open(f, "w", encoding="utf-8").write(out)
+PY
+  then
+    c_y "  [面板迁移] 注入失败, 已还原。"; cp -a "$bak" "$f"; rm -f "$bak"; return 0
+  fi
+  if command -v mosdns >/dev/null 2>&1 && ! mosdns start -d "$(dirname "$f")" -c "$f" --test 2>/dev/null; then
+    : # mosdns 没有 --test 子命令时跳过静态校验, 下面的重启才是真判据
+  fi
+  if systemctl is-active --quiet mosdns 2>/dev/null; then
+    systemctl restart mosdns 2>/dev/null
+    sleep 1
+    if ! systemctl is-active --quiet mosdns; then
+      c_y "  [面板迁移] mosdns 重启失败 → 已还原配置并重启。"
+      cp -a "$bak" "$f"; systemctl restart mosdns 2>/dev/null; rm -f "$bak"; return 1
+    fi
+  fi
+  rm -f "$bak"
+  c_g "  mosdns 已挂上面板劫持集(空文件 = 休眠, 零影响)。"
+}
+
+# 把面板域名写进劫持集 —— 走事务(mosdns_rule:lan_hijack.txt 是现成的动态目标, 自带
+# restart:mosdns), 于是"写了一半 mosdns 起不来"这种状态不存在。
+_lan_write_hijack(){
+  local txm wd txid sha rc=0
+  txm="$(_pdg_module pdgtx.py)" || { c_y "❌ 找不到 pdgtx.py"; return 1; }
+  wd="$(mktemp -d)" || return 1
+  # 内容: 一行一个域名。mosdns 的 domain_set 默认按域名后缀匹配, 与 custom_hijack.txt 同形。
+  _lan_hosts > "$wd/new.txt"
+  # 判据是**存在与否**, 不是"非空"。迁移那一步会先建一个空文件(休眠), `-s` 对它为假,
+  # 于是会传出"文件不存在"的 `-` —— 而事务读到的是一个存在的空文件, 前置条件当场不符,
+  # 报出来的是 PRECONDITION_FAILED, 与真正的原因(判据用错)隔着一层。
+  if [[ -e "$LAN_HIJACK_FILE" ]]; then
+    if python3 "$txm" read --target "mosdns_rule:lan_hijack.txt" > "$wd/raw" 2>"$wd/err"; then
+      sha="$(head -1 "$wd/raw")"
+    else
+      c_y "❌ 读不到劫持集: $(tr -d '\n' < "$wd/err")"; rm -rf "$wd"; return 1
+    fi
+  else
+    sha="-"
+  fi
+  txid="$(python3 "$txm" new --source cli --op lan-hijack 2>"$wd/err")" || {
+    c_y "❌ 无法开始事务: $(tr -d '\n' < "$wd/err")"; rm -rf "$wd"; return 1; }
+  if ! python3 "$txm" stage --tx "$txid" --target "mosdns_rule:lan_hijack.txt" \
+        --file "$wd/new.txt" --expect "$sha" 2>"$wd/err"; then
+    c_y "❌ 暂存劫持集失败: $(tr -d '\n' < "$wd/err")"
+    python3 "$txm" abort "$txid" >/dev/null 2>&1 || true; rm -rf "$wd"; return 1
+  fi
+  python3 "$txm" apply --tx "$txid" >/dev/null 2>"$wd/err"; rc=$?
+  if [[ "$rc" != 0 ]]; then
+    c_y "❌ 劫持集落盘失败(已回滚): $(tr -d '\n' < "$wd/err")"; rm -rf "$wd"; return 1
+  fi
+  rm -rf "$wd"
+}
+
+# 重渲 mihomo 配置 —— 面板域名变了, 分流规则与 hosts: 段都要跟着变。
+_lan_rerender_mihomo(){
+  if ! ( cd /opt/pdg-bot && python3 -c 'import sys;sys.path.insert(0,"/opt/pdg-bot");import bot; bot._render_mihomo_file()' ) >/dev/null 2>&1; then
+    c_y "⚠️ mihomo 配置重渲失败 —— 面板域名还没进分流规则, 手机侧仍打不开。"
+    c_y "   跑 sudo pdg doctor 看 mihomo 配置那一项。"
+    return 1
+  fi
+  systemctl restart mihomo 2>/dev/null || true
+}
+
+# 手机侧那一整段: 迁移(一次性)→ 写劫持集 → 重渲分流。三步任一失败都要说清楚卡在哪 ——
+# 半通的状态(DNS 劫持了但 mihomo 不认路由, 或反过来)从表面上看都是"面板打不开"。
+_lan_wire(){
+  migrate_mosdns_lan || return 1
+  _lan_write_hijack || { c_y "   卡在: 写 DNS 劫持集。手机会拿到 NXDOMAIN, 整条链路不会被触发。"; return 1; }
+  _lan_rerender_mihomo || { c_y "   卡在: 重渲 mihomo 分流。DNS 已劫持到网关, 但 mihomo 不认这些域名 —— 手机会连上网关然后被按默认规则处理。"; return 1; }
+  return 0
+}
+
 cmd_lan(){
   local sub="${1:-status}"; shift 2>/dev/null || true
   case "$sub" in
@@ -5305,7 +5417,11 @@ cmd_lan(){
     enable)    _lan_enable;;
     disable)   _lan_disable;;
     cert)      need_root lan; _lan_cert "${1:-}";;
-    render)    need_root lan; _lan_render && c_g "✅ 反代配置与出站白名单已按面板表重新生成。";;
+    render)    need_root lan
+               _lan_render || return 1
+               c_g "✅ 反代配置与出站白名单已按面板表重新生成。"
+               _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;
+    wire)      need_root lan; _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;
     purge)     _lan_purge "${1:-}";;
     *)
       echo "用法: pdg lan <status|list|check|routes|add|rm>"
@@ -5323,7 +5439,8 @@ cmd_lan(){
       echo "  rm <面板名>"
       echo "  cert <dns插件名>          DNS-01 签发(凭据放 /etc/privdns-gateway/lan-dns.env, 600)"
       echo "  enable / disable          启用/停用反代"
-      echo "  render                    面板表改过之后重新生成反代配置与出站白名单"
+      echo "  render                    面板表改过之后重新生成全部派生物(反代/白名单/DNS/分流)"
+      echo "  wire                      只同步 DNS 劫持集与 mihomo 分流(反代配置不动)"
       echo "  purge [--keep-table]      连配置、证书、DNS 凭据、caddy 一起清掉"
       return 1;;
   esac

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5036,6 +5036,257 @@ print(" ".join(x for x in r if not x.startswith(("100.","fd7a:"))))' 2>/dev/null
   fi
 }
 
+LAN_USER="pdg-lan"
+# 反代以 pdg-lan 身份跑, 它要读的东西全放这里(750 root:pdg-lan)。
+# **不放 /etc/privdns-gateway/** —— 那个目录是 700 root:root, 里面有 profile.env 与
+# DNS API 凭据; 为了让反代读一份配置就把它开出去是不划算的交换。而且只给文件 640 也没用:
+# 进不去父目录一样 permission denied, 而报错显示的是"读配置失败"。
+LAN_ETC="/etc/pdg-lan"
+LAN_CADDYFILE="$LAN_ETC/caddy.conf"
+LAN_NFT_CONF="/etc/nftables-pdg-lan.conf"
+LAN_CERT_DIR="$LAN_ETC/certs"
+LAN_DNS_ENV="/etc/privdns-gateway/lan-dns.env"
+LAN_UNIT="/etc/systemd/system/pdg-lan.service"
+LAN_STATE_DIR="/var/lib/pdg-lan"
+ACME_HOME="/opt/pdg-acme"
+
+_lan_arch(){ case "$(dpkg --print-architecture 2>/dev/null)" in amd64) echo amd64;; arm64) echo arm64;; *) return 1;; esac; }
+
+# Caddy: 官方原版静态二进制, 钉版本 + 钉 SHA256。已经是钉死版就不重下。
+_lan_install_caddy(){
+  local arch t want
+  arch="$(_lan_arch)" || { c_y "❌ 不支持的架构: $(dpkg --print-architecture 2>/dev/null)"; return 1; }
+  # shellcheck source=lib/versions.sh
+  source "$REPO_DIR/lib/versions.sh" 2>/dev/null || { c_y "❌ 读不到 lib/versions.sh"; return 1; }
+  if [[ -x /usr/local/bin/caddy ]] && /usr/local/bin/caddy version 2>/dev/null | grep -qF "${CADDY_VER}"; then
+    echo "  Caddy 已是钉死版 $CADDY_VER"; return 0
+  fi
+  want="${PDG_SHA256[caddy-$arch]:-}"
+  [[ -n "$want" ]] || { c_y "❌ lib/versions.sh 里没有 caddy-$arch 的钉死 SHA256, 拒绝安装。"; return 1; }
+  t="$(mktemp -d)" || return 1
+  c_g "下载 Caddy $CADDY_VER ($arch)…"
+  if ! curl -fsSL --max-time 180 \
+       "https://github.com/caddyserver/caddy/releases/download/${CADDY_VER}/caddy_${CADDY_VER#v}_linux_${arch}.tar.gz" \
+       -o "$t/caddy.tgz"; then
+    c_y "❌ 下载失败"; rm -rf "$t"; return 1
+  fi
+  pdg_verify_sha256 "$t/caddy.tgz" "$want" "caddy $CADDY_VER ($arch)" || { rm -rf "$t"; return 1; }
+  tar -xzf "$t/caddy.tgz" -C "$t" caddy 2>/dev/null || { c_y "❌ 解包失败"; rm -rf "$t"; return 1; }
+  install -m755 "$t/caddy" /usr/local/bin/caddy || { rm -rf "$t"; return 1; }
+  rm -rf "$t"
+  c_g "  Caddy $CADDY_VER 已安装"
+}
+
+# acme.sh: 按 commit sha 钉。clone 之后逐字核对 —— tag 可以被移动, commit sha 不能。
+_lan_install_acme(){
+  # shellcheck source=lib/versions.sh
+  source "$REPO_DIR/lib/versions.sh" 2>/dev/null || return 1
+  if [[ -x "$ACME_HOME/acme.sh" ]] && \
+     [[ "$(git -C "$ACME_HOME" rev-parse HEAD 2>/dev/null)" == "$ACME_SH_COMMIT" ]]; then
+    echo "  acme.sh 已是钉死 commit"; return 0
+  fi
+  c_g "获取 acme.sh $ACME_SH_VER…"
+  rm -rf "$ACME_HOME"
+  git clone -q --depth 50 --branch "$ACME_SH_VER" https://github.com/acmesh-official/acme.sh "$ACME_HOME" 2>/dev/null \
+    || { c_y "❌ clone 失败"; return 1; }
+  local got; got="$(git -C "$ACME_HOME" rev-parse HEAD 2>/dev/null)"
+  if [[ "$got" != "$ACME_SH_COMMIT" ]]; then
+    # 不是"警告后继续": 对不上就说明拿到的不是我们审过的那份代码, 而这份代码接下来
+    # 要拿着你的 DNS API token 去改真实 DNS 记录。
+    c_y "❌ acme.sh commit 对不上, 拒绝使用(已删除):"
+    c_y "   期望 $ACME_SH_COMMIT"
+    c_y "   实际 ${got:-<读不出>}"
+    rm -rf "$ACME_HOME"; return 1
+  fi
+  chmod 755 "$ACME_HOME/acme.sh"
+  c_g "  acme.sh 已就位(commit 逐字核对通过)"
+}
+
+_lan_hosts(){
+  python3 -c 'import json,sys
+try: d=json.load(open(sys.argv[1]))
+except Exception: sys.exit(0)
+for p in d.get("panels",[]):
+    if isinstance(p,dict) and p.get("host"): print(p["host"])' "$LAN_TABLE_PATH" 2>/dev/null
+}
+
+# 证书: DNS-01 签发。凭据放 600 文件, 由 acme.sh 从环境读 —— 不进命令行(ps 看得见),
+# 不进日志。
+_lan_cert(){
+  local dnsapi="${1:-}"
+  [[ -n "$dnsapi" ]] || { echo "用法: pdg lan cert <acme.sh 的 DNS 插件名, 如 dns_cf>"; 
+    echo "  凭据写进 $LAN_DNS_ENV (600), 一行一个 KEY=值 —— 具体要哪些看 acme.sh 的 dnsapi 文档。"
+    echo "  例(Cloudflare): CF_Token=...   然后 pdg lan cert dns_cf"; return 1; }
+  [[ -s "$LAN_DNS_ENV" ]] || { c_y "❌ 缺 $LAN_DNS_ENV —— DNS 服务商的凭据要先放好(600)。"; return 1; }
+  local mode; mode="$(stat -c %a "$LAN_DNS_ENV" 2>/dev/null)"
+  [[ "$mode" == 600 ]] || { c_y "❌ $LAN_DNS_ENV 权限是 $mode, 应为 600 —— 里面是能改你 DNS 的凭据。"; return 1; }
+  _lan_install_acme || return 1
+  local -a doms=(); local h
+  while read -r h; do [[ -n "$h" ]] && doms+=(-d "$h"); done < <(_lan_hosts)
+  [[ ${#doms[@]} -gt 0 ]] || { c_y "❌ 面板表里一个域名都没有, 没什么可签的。"; return 1; }
+  install -d -m750 -o root -g "$LAN_USER" "$LAN_ETC" 2>/dev/null || install -d -m750 "$LAN_ETC"
+  install -d -m750 -o root -g "$LAN_USER" "$LAN_CERT_DIR" 2>/dev/null || install -d -m750 "$LAN_CERT_DIR"
+  c_g "签发证书(DNS-01, 插件 $dnsapi)…"
+  # set -a 让 EnvironmentFile 里的键成为环境变量; 用子 shell 圈住, 不污染当前进程。
+  (
+    set -a; # shellcheck disable=SC1090
+    source "$LAN_DNS_ENV"; set +a
+    "$ACME_HOME/acme.sh" --home "$ACME_HOME/data" --issue --dns "$dnsapi" \
+      "${doms[@]}" --server letsencrypt --keylength ec-256
+  ) || { c_y "❌ 签发失败 —— 看上面 acme.sh 给的原因(多半是凭据权限不足或域名不在该 zone)。"; return 1; }
+  while read -r h; do
+    [[ -n "$h" ]] || continue
+    local name; name="$(python3 -c 'import json,sys
+d=json.load(open(sys.argv[1]))
+print(next((p["name"] for p in d["panels"] if p.get("host")==sys.argv[2]), ""))' "$LAN_TABLE_PATH" "$h" 2>/dev/null)"
+    [[ -n "$name" ]] || continue
+    "$ACME_HOME/acme.sh" --home "$ACME_HOME/data" --install-cert -d "$h" --ecc \
+      --fullchain-file "$LAN_CERT_DIR/$name.crt" --key-file "$LAN_CERT_DIR/$name.key" \
+      --reloadcmd "systemctl reload pdg-lan 2>/dev/null || true" >/dev/null 2>&1 \
+      || c_y "  ⚠️ $h 的证书装不到 $LAN_CERT_DIR/$name.*"
+  done < <(_lan_hosts)
+  # 私钥给**组**读而不是 600: 反代不是 root, 它必须读得到。目录 750 root:pdg-lan 已经
+  # 把范围限在这个用户上了, 再把文件锁成 600 只会让服务起不来。
+  chown root:"$LAN_USER" "$LAN_CERT_DIR"/* 2>/dev/null || true
+  chmod 640 "$LAN_CERT_DIR"/*.key "$LAN_CERT_DIR"/*.crt 2>/dev/null || true
+  c_g "✅ 证书已就位: $LAN_CERT_DIR"
+}
+
+# 由面板表**派生**反代配置与出站白名单。两份都从同一张表来 —— 这是门三成立的前提:
+# 白名单与反代实际会连的地址不可能不一致。
+_lan_render(){
+  local mod tmpc tmpn legacy
+  mod="$(_pdg_module lanpanel.py)" || { c_y "❌ 找不到 lanpanel.py"; return 1; }
+  tmpc="$(mktemp)"; tmpn="$(mktemp)"
+  if ! python3 "$mod" render "$LAN_TABLE_PATH" --certs "$LAN_CERT_DIR" > "$tmpc" 2>"$tmpc.err"; then
+    c_y "❌ 生成反代配置失败:"; sed 's/^/    /' "$tmpc.err" "$tmpc" 2>/dev/null | head -10
+    rm -f "$tmpc" "$tmpn" "$tmpc.err"; return 1
+  fi
+  if ! python3 "$mod" nft "$LAN_TABLE_PATH" --uid "$LAN_USER" > "$tmpn" 2>"$tmpn.err"; then
+    c_y "❌ 生成出站白名单失败:"; sed 's/^/    /' "$tmpn.err" 2>/dev/null | head -10
+    rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"; return 1
+  fi
+  # 反代配置先让 caddy 自己判一遍再落盘。落一份它读不懂的配置, 症状是服务起不来,
+  # 而那时旧配置已经被覆盖 —— 连"退回去"都没得退。
+  if [[ -x /usr/local/bin/caddy ]]; then
+    if ! /usr/local/bin/caddy validate --config "$tmpc" --adapter caddyfile >/dev/null 2>&1; then
+      c_y "❌ 生成出来的反代配置 caddy 自己判为不合法, 拒绝落盘(现有配置未动):"
+      /usr/local/bin/caddy validate --config "$tmpc" --adapter caddyfile 2>&1 | head -6 | sed 's/^/    /'
+      rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"; return 1
+    fi
+  fi
+  install -m640 -o root -g "$LAN_USER" "$tmpc" "$LAN_CADDYFILE" 2>/dev/null || install -m644 "$tmpc" "$LAN_CADDYFILE"
+  install -m644 "$tmpn" "$LAN_NFT_CONF"
+  rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"
+  legacy="$(python3 -c 'import importlib.util,sys
+spec=importlib.util.spec_from_file_location("lp",sys.argv[1]); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+import json; print("1" if m.legacy_tls_panels(json.load(open(sys.argv[2]))) else "")' "$mod" "$LAN_TABLE_PATH" 2>/dev/null)"
+  # shellcheck source=lib/units.sh
+  source "$REPO_DIR/lib/units.sh" 2>/dev/null || { c_y "❌ 读不到 lib/units.sh"; return 1; }
+  pdg_unit_lan_caddy "$legacy" > "$LAN_UNIT" && chmod 644 "$LAN_UNIT"
+  systemctl daemon-reload 2>/dev/null || true
+}
+
+_lan_preflight(){
+  local rc=0 h missing=""
+  [[ -s "$LAN_TABLE_PATH" ]] || { c_y "⛔ 面板表是空的 —— 先 pdg lan add 加至少一条。"; return 1; }
+  local mod; mod="$(_pdg_module lanpanel.py)" || return 1
+  python3 "$mod" check "$LAN_TABLE_PATH" || { c_y "⛔ 面板表没通过门二校验(见上), 拒绝启用。"; return 1; }
+  # Tailscale 是整条链路的必经之处。没有它, 反代起来了也连不到家里 —— 那种"服务 active
+  # 但什么都打不开"的状态最难查, 不如在这里就停下。
+  if ! command -v tailscale >/dev/null 2>&1 || ! ip -o link show tailscale0 >/dev/null 2>&1; then
+    c_y "⛔ Tailscale 没在跑 —— 方案 B 的整条链路都要经它。先装好并认证, 再回来。"
+    rc=1
+  fi
+  while read -r h; do
+    [[ -n "$h" ]] || continue
+    local name; name="$(python3 -c 'import json,sys
+d=json.load(open(sys.argv[1]))
+print(next((p["name"] for p in d["panels"] if p.get("host")==sys.argv[2]), ""))' "$LAN_TABLE_PATH" "$h" 2>/dev/null)"
+    [[ -s "$LAN_CERT_DIR/$name.crt" && -s "$LAN_CERT_DIR/$name.key" ]] || missing="$missing $h"
+  done < <(_lan_hosts)
+  if [[ -n "$missing" ]]; then
+    c_y "⛔ 这些面板还没有证书:$missing"
+    c_y "   先跑 pdg lan cert <dns插件名> 签发。反代读的是落盘的证书, 它自己不去要。"
+    rc=1
+  fi
+  _lan_zone_warn
+  return $rc
+}
+
+_lan_enable(){
+  need_root lan
+  _lan_install_caddy || return 1
+  id "$LAN_USER" >/dev/null 2>&1 || useradd -r -s /usr/sbin/nologin -d "$LAN_STATE_DIR" "$LAN_USER"
+  install -d -m750 -o "$LAN_USER" -g "$LAN_USER" "$LAN_STATE_DIR"
+  install -d -m750 -o root -g "$LAN_USER" "$LAN_ETC"
+  install -d -m750 -o root -g "$LAN_USER" "$LAN_CERT_DIR"
+  _lan_preflight || return 1
+  _lan_render || return 1
+  systemctl enable --now pdg-lan >/dev/null 2>&1
+  sleep 2
+  if systemctl is-active --quiet pdg-lan; then
+    _profile_set PDG_LAN_ENABLED 1 || c_y "⚠️ profile.env 写入失败, 启用意图未持久化。"
+    c_g "✅ 内网面板已启用。反代监听 127.0.0.1:443, 出站白名单已按面板表加载。"
+    echo "   还差最后一步: 让 mosdns 把这些域名劫持到网关、mihomo 把它们指到本机反代。"
+    echo "   现在直接从手机访问还不通 —— 这一段见 pdg lan wire(尚未实现)。"
+  else
+    c_y "❌ pdg-lan 没起来。最近的日志:"
+    journalctl -u pdg-lan -n 15 --no-pager 2>/dev/null | sed 's/^/    /'
+    c_y "   ExecStartPre 会先加载出站白名单 —— 那一步失败也会让服务起不来(这是有意的:"
+    c_y "   白名单加载不上就不该让反代跑起来)。"
+    return 1
+  fi
+}
+
+_lan_disable(){
+  need_root lan
+  systemctl disable --now pdg-lan >/dev/null 2>&1 || true
+  nft delete table inet pdglan 2>/dev/null || true
+  _profile_set PDG_LAN_ENABLED 0 || true
+  c_g "✅ 内网面板已停用(反代已停、出站白名单已撤)。"
+  echo "   保留: 面板表、证书、Caddy 二进制 —— 重新 enable 就能用。"
+  echo "   要连这些一起清干净: pdg lan purge"
+}
+
+# 连配置与凭据一起清干净。与 disable 的分界: disable 是"先停一停", purge 是"不用了"。
+#
+# 要点名说清楚删了什么, 尤其是 DNS API 凭据与 acme 账户密钥 —— 那两样删掉之后
+# 证书续期就断了, 而用户可能只是想"清理一下"。
+_lan_purge(){
+  need_root lan
+  local keep_table="${1:-}"
+  _lan_disable >/dev/null 2>&1 || true
+  systemctl disable --now pdg-lan >/dev/null 2>&1 || true
+  rm -f "$LAN_UNIT"; systemctl daemon-reload 2>/dev/null || true
+  rm -f "$LAN_NFT_CONF"
+  nft delete table inet pdglan 2>/dev/null || true
+  local removed="" had_creds=""
+  [[ -e "$LAN_DNS_ENV" || -e "$ACME_HOME" ]] && had_creds=1
+  [[ -e "$LAN_ETC" ]] && { rm -rf "$LAN_ETC"; removed="$removed 反代配置与证书($LAN_ETC)"; }
+  [[ -e "$LAN_STATE_DIR" ]] && { rm -rf "$LAN_STATE_DIR"; removed="$removed 运行态($LAN_STATE_DIR)"; }
+  [[ -e "$LAN_DNS_ENV" ]] && { rm -f "$LAN_DNS_ENV"; removed="$removed DNS-API凭据"; }
+  [[ -e "$ACME_HOME" ]] && { rm -rf "$ACME_HOME"; removed="$removed acme.sh与账户密钥"; }
+  [[ -x /usr/local/bin/caddy ]] && { rm -f /usr/local/bin/caddy; removed="$removed caddy二进制"; }
+  if [[ "$keep_table" != "--keep-table" && -e "$LAN_TABLE_PATH" ]]; then
+    rm -f "$LAN_TABLE_PATH"; removed="$removed 面板表"
+  fi
+  id "$LAN_USER" >/dev/null 2>&1 && { userdel "$LAN_USER" 2>/dev/null || true; removed="$removed 用户$LAN_USER"; }
+  _profile_set PDG_LAN_ENABLED 0 >/dev/null 2>&1 || true
+  c_g "✅ 内网面板已清除。"
+  [[ -n "$removed" ]] && echo "   删掉了:$removed"
+  # 只在**确实存在过**的时候才说删了它们。声称删掉一个本来就不在的东西, 会让人以为
+  # 自己曾经配过 DNS 凭据 —— 而下一步他会去找一个不存在的备份。
+  if [[ -n "$had_creds" ]]; then
+    c_y "   注意: DNS API 凭据与 acme 账户密钥都删了 —— 证书续期从此不再进行。"
+    c_y "   已经签出去的证书到期就失效, 重新用要再跑一遍 pdg lan cert。"
+  else
+    echo "   (本机上没有 DNS 凭据与 acme 账户, 所以没有可删的; 证书也从未由本项目签发过。)"
+  fi
+  [[ "$keep_table" == "--keep-table" ]] && echo "   面板表按你的要求留下了: $LAN_TABLE_PATH"
+  return 0
+}
+
 cmd_lan(){
   local sub="${1:-status}"; shift 2>/dev/null || true
   case "$sub" in
@@ -5051,6 +5302,11 @@ cmd_lan(){
     rm)        need_root lan
                [[ -n "${1:-}" ]] || { echo "用法: pdg lan rm <面板名>"; return 1; }
                _lan_transact lan-rm rm "$1" && { c_g "✅ 已从面板表移除。"; _lan_list; };;
+    enable)    _lan_enable;;
+    disable)   _lan_disable;;
+    cert)      need_root lan; _lan_cert "${1:-}";;
+    render)    need_root lan; _lan_render && c_g "✅ 反代配置与出站白名单已按面板表重新生成。";;
+    purge)     _lan_purge "${1:-}";;
     *)
       echo "用法: pdg lan <status|list|check|routes|add|rm>"
       echo "  status                    当前状态(面板数、门二、Tailscale)"
@@ -5065,6 +5321,10 @@ cmd_lan(){
       echo "      --legacy-tls               老设备只有 RSA 密钥交换套件(表现是 502 + handshake failure)"
       echo "      --entry-query <q>          前后端分离的应用要在入口带的参数, 如 magicpath=xxxx"
       echo "  rm <面板名>"
+      echo "  cert <dns插件名>          DNS-01 签发(凭据放 /etc/privdns-gateway/lan-dns.env, 600)"
+      echo "  enable / disable          启用/停用反代"
+      echo "  render                    面板表改过之后重新生成反代配置与出站白名单"
+      echo "  purge [--keep-table]      连配置、证书、DNS 凭据、caddy 一起清掉"
       return 1;;
   esac
 }

--- a/deploy/bot/pdgtx.py
+++ b/deploy/bot/pdgtx.py
@@ -135,6 +135,10 @@ _STATIC = {
     # 救援平面的运行状态(紧急默认出口的原值等)。放 /var/lib 而不是 /etc: 它是运行态不是配置。
     # 0600 —— 里面有出口 tag; 它们不是凭据, 但也没有任何理由让别的用户读到。
     "rescue_state":   ("/var/lib/privdns-gateway/rescue-state.json", 0o600, False, ("json_any",)),
+    # 内网面板表(方案 B)。0600 —— 里面是用户家里的内网 IP 与设备端口, 那不是凭据, 但也
+    # 没有任何理由让别的用户读到。反代配置与出站白名单都由它派生, 所以它是**单一真源**:
+    # 手改派生出来的那两份迟早与它不一致, 而不一致的方向恰恰是"防火墙按表放行、反代连别处"。
+    "lan_panels":     ("/etc/privdns-gateway/lan-panels.json", 0o600, False, ("json_any",)),
 }
 _MOSDNS_RULE_RE = re.compile(r"^[A-Za-z0-9_!.-]+\.txt$")
 _RULESET_RE = re.compile(r"^[A-Za-z0-9_.-]+\.(json|mrs)$")
@@ -190,6 +194,10 @@ _TARGET_ACTIONS = {
     # 纯记录与纯产物: 没有任何运行中的服务读它们。动作**显式写成空**而不是不写 ——
     # actions_for_targets 对没登记的目标是 fail-closed, 靠"遗漏"表达"不需要动作"会在
     # 恢复时变成一次拒绝, 而那看起来像是恢复功能坏了。
+    # 面板表是源, 没有任何运行中的服务读它 —— 读的是由它派生出来的反代配置与 nft 白名单。
+    # 动作**显式写成空**而不是不写: actions_for_targets 对没登记的目标 fail-closed,
+    # 靠"遗漏"表达"不需要动作"会在恢复时变成一次拒绝, 而那看起来像恢复功能坏了。
+    "lan_panels": (),
     "ios_profile_state": (),
     "ios_profile_current": (),
     "ios_profile_previous": (),

--- a/deploy/bot/sb2mihomo.py
+++ b/deploy/bot/sb2mihomo.py
@@ -414,7 +414,8 @@ def _mixed_listeners(sb, direct_tags):
 def singbox_to_mihomo(sb, *, redir_port=7893, controller="127.0.0.1:9090",
                       secret=None, external_ui=None, external_ui_url=None,
                       tls_ports=None, http_ports=None, rulesets=None,
-                      mitm_domains=None, mitm_port=7894):
+                      mitm_domains=None, mitm_port=7894,
+                      lan_domains=None, lan_addr="127.0.0.1"):
     """把 sing-box 配置 dict 翻译成 mihomo 配置 dict。
 
     rulesets: 可选 {name: {url, behavior, format}} —— 提供则渲染 rule-providers + RULE-SET,
@@ -472,6 +473,27 @@ def singbox_to_mihomo(sb, *, redir_port=7893, controller="127.0.0.1:9090",
                         "server": "127.0.0.1", "port": mitm_port, "udp": False})
         rules = rules[:i] + [f"DOMAIN-SUFFIX,{d},MITM-OUT" for d in mitm_domains] + rules[i:]
 
+    # ── 内网面板(方案 B): 面板域名 → 本机反代 ──────────────────────────────
+    # **必须排在反自环 IP-CIDR REJECT 之前**, 而不是像 MITM 那样排在之后。原因实测定案:
+    #
+    #   · `no-resolve` 的含义是"不要为这条规则发起 DNS 查询", **不是**"目的是域名时不
+    #     匹配"。面板域名在下面的 hosts: 段里被映射到本机地址, 于是 IP 在规则匹配阶段
+    #     就已知 —— `IP-CIDR,127.0.0.0/8,REJECT,no-resolve` 会**命中**并把连接拒掉。
+    #     真机日志: `match IPCIDR(127.0.0.0/8) using REJECT`。
+    #   · MITM 能排在 REJECT 之后, 是因为它的域名**没有 hosts 条目**(匹配时 IP 未知),
+    #     而 MITM-OUT 出站自己连 127.0.0.1:7894 是不过规则的。两者性质不同, 不能照抄。
+    #
+    # 代价: 这**绕过了面板域名的反自环保护**。可接受的前提是**门二禁止面板上游写环回
+    # 地址**(lanpanel.parse_target 的 is_loopback 判据) —— 面板因此不可能指回网关自己。
+    # 那条判据一旦被放宽, 这里就会静默开一个自环的洞, 两处要一起看。
+    #
+    # 前置放在最后做: 上面的 IN-NAME 与 MITM 都按 `i`(= REJECT 之后)插入, 先前置的话
+    # 它们会被算到面板规则前面去, 反而丢掉各自该有的位置。
+    lan_hosts = {}
+    if lan_domains:
+        lan_hosts = {d: lan_addr for d in lan_domains}
+        rules = ["DOMAIN-SUFFIX,%s,DIRECT" % d for d in lan_domains] + rules
+
     tls_ports = tls_ports if tls_ports is not None else DEFAULT_TLS_PORTS
     http_ports = http_ports if http_ports is not None else DEFAULT_HTTP_PORTS
 
@@ -495,6 +517,11 @@ def singbox_to_mihomo(sb, *, redir_port=7893, controller="127.0.0.1:9090",
         "proxies": proxies,
         "proxy-groups": groups,
     }
+    if lan_hosts:
+        # mihomo 的 DIRECT **不读 /etc/hosts**(实测: 加了 hosts 文件条目仍然连不上,
+        # 换成非环回地址也一样 —— 是解析这一步走不通, 不是环回被拒)。要让它连到本机
+        # 反代, 只能用 mihomo 自己的 hosts: 段。
+        cfg["hosts"] = lan_hosts
     if listeners:
         cfg["listeners"] = listeners
     if secret:

--- a/deploy/rescue/rescue.py
+++ b/deploy/rescue/rescue.py
@@ -108,7 +108,11 @@ def _tx_paths():
     root = _fsroot() or ""
     return {"rs_meta_path": root + "/opt/pdg-bot/rulesets.json",
             "mitm_hijack_file": root + "/etc/mosdns/rules/mitm_hijack.txt",
-            "platform_file": root + "/etc/privdns-gateway/platform"}
+            "platform_file": root + "/etc/privdns-gateway/platform",
+            # 内网面板表: 渲染 mihomo 配置时要据它把面板域名指到本机反代。救援路径同样要传
+            # —— 少传的后果不是报错, 而是救援渲染出来的配置**悄悄丢掉所有面板路由**,
+            # 而那正是"救援之后面板全打不开"这种查不出原因的现场。
+            "lan_table_file": root + "/etc/privdns-gateway/lan-panels.json"}
 
 
 def _emergency_digest(stt):

--- a/docs/design-lan-panels.md
+++ b/docs/design-lan-panels.md
@@ -1,7 +1,10 @@
 # 设计:内网面板访问(手机零 App)
 
-> 状态:**设计,未实现**。方案 A 已在一台真机上跑通并实测(2026-08-21,见第 6 节),
-> 方案 B 尚未实现。本文是把 A 的实测经验整理成 B 的实施依据 —— B 才是能给别人用的形态。
+> 状态:**方案 B 已实现**(2026-08-22)。方案 A 的实测经验见第 6 节 —— 那些设备毛病
+> 在 B 里一条都没消失, 反代生成器从第一版就带着它们。
+>
+> **实现到哪一步、哪些没验, 见第 9 节。**别把"沙盒里产物正确"当成"手机能打开面板":
+> 后者要真实的 tailnet 子网路由与真实设备, 沙盒造不出来。
 
 ## 1. 要解决什么
 
@@ -162,3 +165,41 @@ WLOC 是 940 行 + 7 支 —— 所以这个功能**比救援平面小**,与 WLO
 - **不自动发现内网设备**。扫描用户网段并自动建映射,既不礼貌也不可靠。
 - **不代管 Tailscale 的安装与认证**(与 README 第 12 节同一条口径):那是一次性的系统级操作、
   要交互式认证,而真出事时 Bot 可能就起不来 —— 恰恰是 Tailscale 要救的场景。
+
+
+## 9. 实现状态与**没有验过的东西**(2026-08-22)
+
+### 已实现
+
+| 部分 | 落点 |
+|---|---|
+| 门一 路由重叠拒绝 | `deploy/bot/lanroute.py` + `pdg lan routes` + doctor 常驻 |
+| 门二 面板表校验 / 反代生成 | `deploy/bot/lanpanel.py`(含五条设备毛病) |
+| 门三 出站白名单 | `lanpanel.py render_nft` + unit 的 `ExecStartPre` |
+| 风险② DNS token 权限升级 | `pdg lan status` 每次都会说, 不只写在第 7 节 |
+| CLI | `pdg lan status/list/check/routes/add/rm/cert/enable/disable/render/wire/purge` |
+| 反代与证书 | Caddy 官方原版(钉版本+SHA256) + acme.sh(钉 commit) |
+| 手机侧接线 | mosdns `lan_hijack.txt` 挂进 `explicit_proxy`; mihomo `hosts:` + 面板规则 |
+| doctor | 路由重叠 / 白名单漂移 / 证书剩余 / ACL 越界探测(--deep) |
+| 卸载 | `pdg lan purge` 与 `uninstall.sh` 两条路, 残留逐条报出来 |
+
+### 已在沙盒真机上验过的
+
+- 全新安装 → `pdg lan add/rm` 走事务 → 快照回滚能把面板表还原;
+- 反代真跑起来: 以 `pdg-lan` 身份、只监听 `127.0.0.1:443`、TLS 握手成功、SNI 路由生效;
+- **门三的决定性验证**: 同一请求、同一份 Caddyfile、同一个上游, 只改白名单 ——
+  含该上游时 caddy 报 `connection refused`(放行了), 不含时报 `no route to host`(被拒);
+- **规则顺序的正负控**(两个容器走真 nft REDIRECT): 面板规则在 REJECT 之前 → HTTP 200;
+  在之后 → HTTP 000 `match IPCIDR(127.0.0.0/8) using REJECT`;
+- `wire` 之后三份派生物同时正确: mosdns 劫持集、mihomo `hosts:` 段、面板规则在 0/1 位。
+
+### **没有验过的**(别当成验过了)
+
+- **手机真的打开了面板** —— 整条链路端到端。这要真实的 tailnet 子网路由 + 真实设备,
+  沙盒造不出来。上面验的全是"产物正确", 不是"链路通"。
+- **ACL 越界探测**打在真 tailnet 上的表现。判据的三种读法有单元测试覆盖(连上/被拒/
+  不可达), 但没在真 ACL 上跑过。
+- **acme.sh 的真实签发**。容器里签不了 `.example.com`, 证书全是自签顶替的。
+  证书装到位之后 Caddy 能读、能握手 —— 这一段验过; 签发本身没有。
+- **续期**。acme.sh 装的 cron 是否真的把证书续上, 没有跨越 60 天验证过。
+  doctor 的证书项就是为这条不确定性存在的。

--- a/lib/modules.sh
+++ b/lib/modules.sh
@@ -47,6 +47,8 @@ deploy/bot/mihomorender.py mihomorender.py 755
 deploy/bot/cfgrestore.py cfgrestore.py 755
 deploy/bot/emergency.py emergency.py 755
 deploy/bot/cidrgen.py cidrgen.py 755
+deploy/bot/lanroute.py lanroute.py 755
+deploy/bot/lanpanel.py lanpanel.py 755
 deploy/bot/rescue_const.py rescue_const.py 755
 deploy/bot/rescue_nft.py rescue_nft.py 755
 deploy/rescue/rescue.py rescue.py 755

--- a/lib/units.sh
+++ b/lib/units.sh
@@ -39,6 +39,59 @@ WantedBy=multi-user.target
 EOF
 }
 
+# 内网面板(方案 B)的反代。$1 = 是否需要放宽 TLS 套件(1/空)。
+#
+# 三条不是可选项:
+#   ① ExecStartPre 加载出站白名单, 前缀 `+` 表示以 root 跑(主进程是 pdg-lan)。
+#      白名单那份是 fail-open 的 —— 加载不上时规则不存在而反代照跑, 于是它必须挡在
+#      启动路径上: 加载不了就别起来。这是门三能不能成立的前提, 不是加固。
+#   ② CAP_NET_BIND_SERVICE: 反代监听 127.0.0.1:443, 低端口, 而它不是 root。
+#      少了这一条的症状是"服务起不来 + permission denied", 看着像文件权限问题。
+#   ④ 反代要读的东西全在 /etc/pdg-lan/(750 root:pdg-lan), **不在** /etc/privdns-gateway/。
+#      后者是 700 root:root: 里面有 profile.env 与 DNS API 凭据, 不该为了让反代读一份
+#      配置就把它开出去。踩过 —— 文件给了 640 root:pdg-lan 仍然 permission denied,
+#      因为进不去父目录; 症状显示成"读配置失败", 与真正的原因(目录不可穿越)隔着一层。
+#      分开之后"pdg-lan 需要读什么"看一个目录就有答案。
+#
+#   ③ XDG_DATA_HOME: Caddy 默认把数据写到 $HOME/.local/share, 而系统用户没有可写的
+#      HOME —— 不指的话它会在一个谁也想不到的位置建目录, 或者直接起不来。
+#      它必须与 ReadWritePaths **同一个目录**: ProtectSystem=strict 之下别处全只读,
+#      指到 /var/lib 而只放行 /var/lib/pdg-lan 的话, Caddy 会去写 /var/lib/caddy 然后
+#      permission denied —— 症状看着像文件属主不对, 其实是 sandbox 把它挡了。
+#
+# GODEBUG=tlsrsakex=1 只在**确有面板需要**时才加(面板表里有 legacy_tls)。老设备可能只
+# 提供 AES256-GCM-SHA384(RSA 密钥交换), Go 1.22 起默认禁用, 症状是 502 + handshake
+# failure —— 看着像证书问题。但这是**全进程**的开关, 不需要就不该开: 给所有上游都放宽
+# 密钥交换, 只为了迁就其中一台。
+pdg_unit_lan_caddy(){
+  local legacy="${1:-}"
+  cat <<EOF
+[Unit]
+Description=pdg-lan (PrivDNS Gateway LAN panel reverse proxy)
+After=network-online.target nftables.service
+Wants=network-online.target
+[Service]
+User=pdg-lan
+Group=pdg-lan
+ExecStartPre=+/usr/sbin/nft -f /etc/nftables-pdg-lan.conf
+ExecStart=/usr/local/bin/caddy run --config /etc/pdg-lan/caddy.conf --adapter caddyfile
+ExecReload=/usr/local/bin/caddy reload --config /etc/pdg-lan/caddy.conf --adapter caddyfile --force
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/pdg-lan
+Environment=XDG_DATA_HOME=/var/lib/pdg-lan${legacy:+
+Environment=GODEBUG=tlsrsakex=1}
+Restart=on-failure
+RestartSec=3
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
 # 内核 svc 名 → 对应 unit 生成函数(mihomo 为唯一内核; 保留此壳以便将来扩展/调用方不改)。
 pdg_unit_for_core_svc(){
   case "$1" in

--- a/lib/versions.sh
+++ b/lib/versions.sh
@@ -13,6 +13,17 @@ MOSDNS_VER="v5.3.4"
 MIHOMO_VER="v1.19.29"         # 流量内核: mihomo/clash.meta, sniffer.override-destination 无版本天花板, 活跃维护可更新
 ZASHBOARD_VER="v3.15.0"       # 观测面板(纯静态前端, 由 external_ui 托管; dist-no-fonts 最小、不依赖 CDN; mihomo 原生 clash 核也可托管)
 
+# ── 内网面板(方案 B)专用: 反代 + 证书签发 ──────────────────────────────────
+# Caddy 用**官方原版**(不带任何 DNS 插件)。带插件要用 xcaddy 按服务商各构建一个 46MB
+# 二进制, 等于只支持一家 DNS 服务商; 签发交给 acme.sh(覆盖 150+ 家), 证书落盘后 Caddy
+# 用 `tls <cert> <key>` 读 —— 于是换服务商不用换二进制。
+CADDY_VER="v2.11.4"
+# acme.sh 按**commit sha** 钉, 不按 tarball 哈希。它是个 git 仓库而不是发布二进制,
+# tag 可以被移动, 而 commit sha 是内容寻址的 —— clone 之后逐字核对这个 sha, 对不上就拒装。
+# 自己算一份 tarball 哈希再钉上去只是 TOFU: 第一次下载就被换掉的话, 钉的正是被换过的那份。
+ACME_SH_VER="3.1.4"
+ACME_SH_COMMIT="3661fd86b6304115e42f43910e6dd452ab9866d6"
+
 # key = <name>-<arch>(arch: amd64 / arm64); zashboard 为纯前端, 与架构无关(单一哈希)
 declare -A PDG_SHA256=(
   [mosdns-amd64]="3abcc73080789eb1ccca78dab5049b85ac1e9b8f865ab60158a527b77cd72e85"
@@ -21,6 +32,12 @@ declare -A PDG_SHA256=(
   [mihomo-amd64]="60de76a35a6cbf7b4fa4a20f5c257c24345d1d635ab1aa3877022a1997ef413c"
   [mihomo-arm64]="9a868b5e4e0ad91d9d71e1b41b0cfce78aaba44360c30df74a723f8e3926a86c"
   [zashboard]="403b351d3663f5fe65db053cb2f3dc980108d8f86e8c6968d56164d3452592e1"
+  # Caddy 官方 release 的 caddy_<ver>_linux_<arch>.tar.gz。
+  # 上游发布的校验和文件里是 **SHA-512**, 本项目统一用 SHA-256, 所以这两个值是
+  # "先用上游的 SHA-512 校验下载物、确认无误之后再算出来的" —— 不是直接对一个来路
+  # 不明的文件算哈希盖章。换版本时按同一顺序重做: 先验 SHA-512, 再取 SHA-256。
+  [caddy-amd64]="527fbf917c39189a1e3b31d34fa955601680b2d5c8055d2a87b8b9588dec7bb9"
+  [caddy-arm64]="52d42ae12b3462097e9868da6dfed3c9648ae12edd3b3638102312af84cb6904"
 )
 
 # ── 内核版本判定: 必须精确匹配, 不能用子串 ──────────────────────────────────

--- a/tests/negctl/lan-egress-live.sh
+++ b/tests/negctl/lan-egress-live.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 门三(反代出站白名单)的**真 nft 行为验证** —— 本地门, 不进 CI。
+#
+# 为什么不进 CI: 加载 nft 规则要 NET_ADMIN, GitHub Actions 的 job 容器没有这个 cap。
+# 实测过, 连 `nft -c -f`(只校验不加载)都会停在 `cache initialization failed:
+# Operation not permitted`。所以 CI 里只能验生成出来的**文本结构**
+# (tests/test-lanpanel.py 第 ⑭ 组), 规则到底挡不挡得住必须在有权限的地方跑。
+#
+# 三路探测, 第三路是**标定**:
+#   A 白名单内的端口, 以反代 uid 连 → 该是 Connection refused(防火墙放行了, 只是没人监听)
+#   B 白名单外的端口, 以反代 uid 连 → 该是 EHOSTUNREACH(被 admin-prohibited 拒了)
+#   C 与 B 完全相同的连接, 换 root 连 → 该是 Connection refused
+#
+# 没有 C 就证明不了 B: B 失败也可能是环境本来就不通。C 一旦和 B 一样, 说明这次
+# 测量里 uid 判据根本没起作用, 整轮结果作废。
+#
+# 跑法(需要 root + NET_ADMIN, 建议在一次性容器里):
+#   sudo bash tests/negctl/lan-egress-live.sh
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+USER_NAME="pdg-lan-negctl"
+# 探测目标取默认路由的下一跳 —— 容器/虚机里都存在, 且几乎不会真有人监听这两个高位端口。
+PEER="$(ip -4 route show default 2>/dev/null | awk '{print $3; exit}')"
+PORT_OK=9101
+PORT_NO=9102
+PASS=0; FAIL=0
+ok(){  echo "[OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# ── 前置: 没权限就**明确失败**, 不静默跳过 ──────────────────────────────────
+# 跳过是本项目明确不接受的形态: 一支永远跳过的测试和没写是一回事, 而它在汇总里
+# 看起来是绿的。
+[ "$(id -u)" -eq 0 ] || { echo "[SKIP-FATAL] 要 root 才能加载 nft 规则"; exit 2; }
+command -v nft >/dev/null 2>&1 || { echo "[SKIP-FATAL] 没装 nft"; exit 2; }
+[ -n "$PEER" ] || { echo "[SKIP-FATAL] 取不到默认路由下一跳, 没有可用的探测目标"; exit 2; }
+nft list tables >/dev/null 2>&1 || { echo "[SKIP-FATAL] nft 用不了(多半缺 NET_ADMIN)"; exit 2; }
+
+id "$USER_NAME" >/dev/null 2>&1 || useradd -r -s /usr/sbin/nologin "$USER_NAME"
+
+TABLE="$(python3 - "$ROOT" "$USER_NAME" "$PEER" "$PORT_OK" <<'PY'
+import importlib.util, sys, json
+root, uid, peer, port = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+spec = importlib.util.spec_from_file_location("lp", root + "/deploy/bot/lanpanel.py")
+lp = importlib.util.module_from_spec(spec); spec.loader.exec_module(lp)
+cfg = {"panels": [{"name": "negctl", "host": "negctl.example.com",
+                   "target": "http://%s:%d" % (peer, port)}]}
+sys.stdout.write(lp.render_nft(cfg, uid))
+PY
+)"
+[ -n "$TABLE" ] || { echo "[FAIL] 生成不出规则"; exit 1; }
+
+TMP="$(mktemp)"; printf '%s' "$TABLE" > "$TMP"
+cleanup(){ nft delete table inet pdglan 2>/dev/null; userdel "$USER_NAME" 2>/dev/null; rm -f "$TMP"; }
+trap cleanup EXIT
+
+nft -f "$TMP" || { echo "[FAIL] 规则加载失败"; exit 1; }
+
+probe(){    # $1=端口 → 打印 errno 名
+  python3 -c '
+import socket, sys
+s = socket.socket(); s.settimeout(4)
+try:
+    s.connect((sys.argv[1], int(sys.argv[2]))); print("CONNECTED")
+except OSError as e:
+    print(getattr(e, "errno", "?"))
+' "$PEER" "$1"
+}
+
+A="$(su -s /bin/bash "$USER_NAME" -c "$(declare -f probe); PEER=$PEER probe $PORT_OK")"
+B="$(su -s /bin/bash "$USER_NAME" -c "$(declare -f probe); PEER=$PEER probe $PORT_NO")"
+C="$(probe "$PORT_NO")"
+
+echo "  A(白名单内, $USER_NAME) = $A"
+echo "  B(白名单外, $USER_NAME) = $B"
+echo "  C(白名单外, root 标定)  = $C"
+
+# ── 标定先判: C 不成立就整轮作废 ────────────────────────────────────────────
+if [ "$C" = "113" ]; then
+  bad "标定失效: root 连白名单外的端口也不通($C) —— 这次测量里 uid 判据没起作用, B 的结果无意义"
+  echo "汇总: 通过 $PASS, 失败 $FAIL"; exit 1
+else
+  ok "标定成立: 换 uid 就能连出去($C), 说明拦截确实来自 uid 判据"
+fi
+
+[ "$A" = "111" ] && ok "白名单内放行(ECONNREFUSED = 防火墙没挡, 只是没人监听)" \
+                 || bad "白名单内应为 111(ECONNREFUSED), 实际 $A"
+[ "$B" = "113" ] && ok "白名单外被拒(EHOSTUNREACH = admin-prohibited)" \
+                 || bad "白名单外应为 113(EHOSTUNREACH), 实际 $B"
+
+echo "汇总: 通过 $PASS, 失败 $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test-clean-root.py
+++ b/tests/test-clean-root.py
@@ -169,7 +169,8 @@ PROBE = textwrap.dedent('''
     import mihomorender as M, emergency as E, cfgrestore as C
     model = json.loads(%r)
     # 走真实链路: cfgrestore 的 deriver → mihomorender → sb2mihomo → 候选字节
-    fn = M.deriver_from_paths(rs_meta_path="/nonexistent/rulesets.json",
+    fn = M.deriver_from_paths(lan_table_file="/nonexistent/lan-panels.json",
+                              rs_meta_path="/nonexistent/rulesets.json",
                               mitm_hijack_file="/nonexistent/hijack.txt",
                               platform_file="/nonexistent/platform")
     data = fn({"model": json.dumps(model).encode()})

--- a/tests/test-emergency-exit.py
+++ b/tests/test-emergency-exit.py
@@ -103,9 +103,37 @@ def load_em(box):
 
 
 def paths_for(box):
+    """渲染派生要用的路径。**这是 rescue.py 的 _tx_paths() 的一份复制** —— 那边读 FSROOT,
+    这里读沙箱 box.root, 所以没法直接复用。复制就会漂移, 于是下面加了一条键集一致性断言:
+    以后往 _tx_paths 里加路径而忘了这里, 会当场红, 而不是等到某支用例莫名其妙失败。"""
     return {"rs_meta_path": box.root + "/opt/pdg-bot/rulesets.json",
             "mitm_hijack_file": box.root + "/etc/mosdns/rules/mitm_hijack.txt",
-            "platform_file": box.root + "/etc/privdns-gateway/platform"}
+            "platform_file": box.root + "/etc/privdns-gateway/platform",
+            "lan_table_file": box.root + "/etc/privdns-gateway/lan-panels.json"}
+
+
+def _assert_paths_parity():
+    """本文件这份 paths 与 rescue.py 的 _tx_paths() 必须**键完全一致**。
+
+    少一个键的后果不是报错而是静默降级: deriver 拿不到那条路径, 渲染出来的配置就少掉
+    对应的那块能力(比如面板路由全丢), 而事务照样提交成功。
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "pdgrescue", os.path.join(ROOT, "deploy/rescue/rescue.py"))
+    m = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(m)
+    except Exception:  # noqa: BLE001
+        return                      # 救援模块起不来是另一支用例的事, 这里不重复报
+    if not hasattr(m, "_tx_paths"):
+        return
+    mine = set(paths_for(type("B", (), {"root": "/x"})()))
+    theirs = set(m._tx_paths())
+    assert mine == theirs, (
+        "paths 键集漂移了 —— 本文件 %r vs rescue._tx_paths %r。"
+        "少的那个键会让派生出来的 mihomo 配置静默少掉一块能力。"
+        % (sorted(mine - theirs), sorted(theirs - mine)))
 
 
 def read_model(box):
@@ -135,6 +163,7 @@ print("── 1. 启用 ──")
 box = make_box()
 em = load_em(box)
 before = read_model(box)
+_assert_paths_parity()
 res = em.enable("hk", paths=paths_for(box))
 eq("启用提交成功", res["state"], "COMMITTED")
 after = read_model(box)

--- a/tests/test-invariants.py
+++ b/tests/test-invariants.py
@@ -85,8 +85,8 @@ if not missing:
     ok("快照含全部 %d 个必需顶层字段" % len(need))
 else:
     bad("缺字段: %s" % "、".join(missing))
-if snap["manifest"]["count"] == 27 and len(snap["static_files"]) == 27:
-    ok("Android 平台记录 27 项静态成员(数量漂移会直接失败)")
+if snap["manifest"]["count"] == 29 and len(snap["static_files"]) == 29:
+    ok("Android 平台记录 29 项静态成员(数量漂移会直接失败)")
 else:
     bad("成员数不对: manifest=%d static=%d"
         % (snap["manifest"]["count"], len(snap["static_files"])))
@@ -162,7 +162,8 @@ NCS = [
     ("删除证书指纹字段",
      lambda d: d["credentials"].pop("rescue_cert_fingerprint"), "required-field", {}),
     ("nft 磁盘/内核计数漂移",
-     lambda d: d["firewall"].update(disk_rescue_rules=99), "firewall.disk_rescue_rules", {}),
+     lambda d: d["firewall"].update(disk_rescue_rules=d["firewall"].get("disk_rescue_rules", 0) + 99),
+     "firewall.disk_rescue_rules", {}),
     ("prewrite 场景 NRestarts 增加",
      lambda d: _bump_restart(d), "nrestarts", {}),
     ("留下 APPLYING pending tx",
@@ -174,8 +175,12 @@ NCS = [
      lambda d: d["user_data"]["rulesets"].update(sha256="deadbeef" * 8), "user_data.rulesets", {}),
     ("静态文件 uid 变了但内容相同",
      lambda d: _chown_static(d), "uid", {}),
+    # 变更要**相对当前值**, 不能锚字面量: 写死 status_lines=7 时, 只要跑测试的那棵树
+    # 恰好有 7 个改动文件, 这一改就是个空操作 —— 比较器如实报"无差异", 负控随之失去
+    # 判别力。真发生过(内网面板那一轮, 工作树正好 7 个改动)。
     ("原仓库工作树被弄脏",
-     lambda d: d["source_repo"].update(status_lines=7), "source_repo", {}),
+     lambda d: d["source_repo"].update(status_lines=d["source_repo"].get("status_lines", 0) + 1),
+     "source_repo", {}),
     ("stub 冒充 real",
      lambda d: d["capabilities"].update(systemd="stub"), "capability",
      {"extra": ["--require-real", "systemd"]}),

--- a/tests/test-ios-profile-persist.py
+++ b/tests/test-ios-profile-persist.py
@@ -311,7 +311,21 @@ else:
 un = open(os.path.join(ROOT, "uninstall.sh"), encoding="utf-8").read()
 i = un.find('== "--purge"')
 outside, inside = (un[:i], un[i:]) if i >= 0 else (un, "")
-if "/etc/privdns-gateway" not in outside and "/etc/privdns-gateway" in inside:
+
+
+def _code_only(text):
+    """去掉整行注释再判。
+
+    这条判据原来是**纯文本搜索**, 于是一句"这里特意不碰 /etc/privdns-gateway"的注释
+    也会把它触发 —— 而那正是该写下来的说明。判据要认的是**代码里有没有动它**, 不是
+    "这五个字有没有出现过"。
+    只去整行注释, 不去行尾注释: 行尾注释挨着真代码, 保守一点不会漏判。
+    """
+    return "\n".join(l for l in text.split("\n") if not l.lstrip().startswith("#"))
+
+
+outside_code, inside_code = _code_only(outside), _code_only(inside)
+if "/etc/privdns-gateway" not in outside_code and "/etc/privdns-gateway" in inside_code:
     ok("只有 uninstall --purge 才会连记录一起删, 普通卸载保留")
 else:
     bad("普通卸载路径上出现了 /etc/privdns-gateway 删除")

--- a/tests/test-lan-doctor.py
+++ b/tests/test-lan-doctor.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""内网面板(方案 B)四项自检的判据测试。
+
+打桩替掉 _run / _lan_cfg / _lan_on, 把每条分支都走到 —— 尤其是那些**只在出事时才成立**
+的分支: 它们在真机上一辈子也许都不触发一次, 而那正是最容易写错又没人发现的地方。
+
+ACL 越界探测那一项的三种读法要分清, 不是"成功/失败"两分:
+  连上了 → fail; 连接被拒(RST, 说明包到达了对端) → **同样 fail**; 不可达/超时 → ok。
+"""
+import importlib.util
+import json
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "deploy" / "bot"))
+spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
+C = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(C)
+
+PASS = [0]
+
+
+def ok(m):
+    PASS[0] += 1
+
+
+def cfg_with(*targets):
+    return {"panels": [{"name": "p%d" % n, "host": "p%d.home.example.com" % n,
+                        "target": "http://%s:%d" % t}
+                       for n, t in enumerate(targets)]}
+
+
+def stub(**kw):
+    """临时替换 checks 模块里的若干属性, 用完还原。"""
+    old = {k: getattr(C, k) for k in kw}
+    for k, v in kw.items():
+        setattr(C, k, v)
+    return old
+
+
+def restore(old):
+    for k, v in old.items():
+        setattr(C, k, v)
+
+
+# ══ ① check_lan_whitelist ═══════════════════════════════════════════════════
+CFG = cfg_with(("192.168.50.10", 443), ("192.168.50.20", 8080))
+
+
+def nft_json(pairs):
+    return json.dumps({"nftables": [
+        {"rule": {"table": "pdglan", "expr": [
+            {"match": {"left": {"payload": {"field": "daddr"}}, "right": ip}},
+            {"match": {"left": {"payload": {"field": "dport"}}, "right": port}},
+        ]}} for ip, port in pairs]})
+
+
+def run_wl(pairs, active=True, rc=0, err=""):
+    old = stub(_lan_cfg=lambda: CFG,
+               _lan_on=lambda: (True, active),
+               _run=lambda cmd, t=10: (rc, nft_json(pairs) if rc == 0 else "", err))
+    try:
+        return C.check_lan_whitelist()
+    finally:
+        restore(old)
+
+
+st, _n, msg = run_wl([("192.168.50.10", 443), ("192.168.50.20", 8080)])
+assert st == "ok", (st, msg)
+ok("白名单与面板表一致 → ok")
+
+st, _n, msg = run_wl([("192.168.50.10", 443)])
+assert st == "fail" and "缺少" in msg and "192.168.50.20:8080" in msg, msg
+ok("白名单少一条 → fail 且点名")
+
+st, _n, msg = run_wl([("192.168.50.10", 443), ("192.168.50.20", 8080), ("10.9.9.9", 22)])
+assert st == "fail" and "多出" in msg and "10.9.9.9:22" in msg, msg
+ok("白名单多一条 → fail 且点名")
+
+# 表根本不存在: 服务在跑 = 严重(反代此刻无约束); 服务没跑 = 只是没启用
+st, _n, msg = run_wl([], active=True, rc=1, err="No such file or directory")
+assert st == "fail" and "正在运行" in msg, msg
+ok("表不在 + 服务在跑 → fail")
+
+st, _n, msg = run_wl([], active=False, rc=1, err="No such file or directory")
+assert st == "warn" and "没在跑" in msg, msg
+ok("表不在 + 服务没跑 → warn(不是 fail)")
+
+# nft 用不了 ≠ 表不存在 —— 混成一句会让缺权限的机器看起来像防火墙丢了
+st, _n, msg = run_wl([], rc=1, err="Operation not permitted")
+assert st == "warn" and "读不到" in msg, msg
+ok("nft 用不了 → warn, 与'表不存在'分开")
+
+# 停用时不该报红
+old = stub(_lan_cfg=lambda: CFG, _lan_on=lambda: (False, False))
+st, _n, msg = C.check_lan_whitelist()
+restore(old)
+assert st == "ok" and "已停用" in msg, msg
+ok("功能停用 → 不报红")
+
+# 从来没配过 → 整项不显示
+old = stub(_lan_cfg=lambda: None)
+assert C.check_lan_whitelist() is None
+restore(old)
+ok("没配过 → 返回 None(不占版面)")
+
+
+# ══ ② check_lan_routes ══════════════════════════════════════════════════════
+def ts_json(routes):
+    return json.dumps({"Peer": {"n1": {"PrimaryRoutes": routes}}})
+
+
+def run_routes(routes, internal="172.22.0.0/16", have_iface=True):
+    devfile = tempfile.NamedTemporaryFile("w", delete=False, suffix=".dev")
+    devfile.write("Inter-|   Receive\n face |bytes\n")
+    if have_iface:
+        devfile.write("tailscale0: 0 0\n")
+    devfile.close()
+
+    def _run(cmd, t=10):
+        if cmd[:2] == ["tailscale", "status"]:
+            return (0, ts_json(routes), "")
+        if cmd[0] == "ip":
+            return (0, "2: eth0    inet 10.7.0.5/24 scope global eth0\\n", "")
+        return (1, "", "")
+
+    old = stub(_run=_run, _profile=lambda k: internal if k == "PDG_INTERNAL_CIDR" else None)
+    real_open = C.open if hasattr(C, "open") else open
+    import builtins
+    ob = builtins.open
+
+    def fake_open(path, *a, **k):
+        if str(path) == "/proc/net/dev":
+            return ob(devfile.name, *a, **k)
+        return ob(path, *a, **k)
+    builtins.open = fake_open
+    old_exists = os.path.exists
+    os.path.exists = lambda p: True if p == "/proc/net/dev" else old_exists(p)
+    try:
+        return C.check_lan_routes()
+    finally:
+        builtins.open = ob
+        os.path.exists = old_exists
+        restore(old)
+        os.unlink(devfile.name)
+
+
+st, _n, msg = run_routes(["192.168.50.0/24"])
+assert st == "ok", (st, msg)
+ok("不相交的通告路由 → ok")
+
+st, _n, msg = run_routes(["172.22.9.0/24"])
+assert st == "fail" and "172.22" in msg, msg
+ok("与内网卡段相交 → fail")
+
+st, _n, msg = run_routes(["0.0.0.0/0"])
+assert st == "fail", msg
+ok("默认路由 → fail")
+
+st, _n, msg = run_routes(["10.7.0.0/24"])
+assert st == "fail" and "10.7.0" in msg, msg
+ok("与本机接口网段相交 → fail")
+
+# 读不到内网卡段: 最要紧的判据没跑, 即使其余都过也只能是 warn
+st, _n, msg = run_routes(["192.168.50.0/24"], internal=None)
+assert st == "warn" and "PDG_INTERNAL_CIDR" in msg, msg
+ok("读不到内网卡段 → warn 并说明哪条没跑")
+
+st, _n, msg = run_routes([])
+assert st == "ok" and "没有从别的节点接受" in msg, msg
+ok("没接受任何路由 → ok")
+
+assert run_routes(["192.168.50.0/24"], have_iface=False) is None
+ok("没有 tailscale0 → 整项不适用")
+
+
+# ══ ③ check_deep_lan_acl: 三种读法 ══════════════════════════════════════════
+def run_acl(exc):
+    class FakeSock:
+        def settimeout(self, t): pass
+        def connect(self, addr):
+            if exc is not None:
+                raise exc
+        def close(self): pass
+
+    old = stub(_lan_cfg=lambda: CFG, _lan_on=lambda: (True, True))
+    real = socket.socket
+    socket.socket = lambda *a, **k: FakeSock()
+    try:
+        return C.check_deep_lan_acl()
+    finally:
+        socket.socket = real
+        restore(old)
+
+
+st, _n, msg = run_acl(None)
+assert st == "fail" and "能连上" in msg, msg
+ok("连上了 → fail")
+
+st, _n, msg = run_acl(ConnectionRefusedError(111, "refused"))
+assert st == "fail" and "RST" in msg, msg
+ok("连接被拒 → **同样 fail**(包到达了对端才会有 RST)")
+
+st, _n, msg = run_acl(socket.timeout())
+assert st == "ok", msg
+ok("超时 → ok")
+
+st, _n, msg = run_acl(OSError(113, "No route to host"))
+assert st == "ok" and "丢弃" in msg, msg
+ok("EHOSTUNREACH → ok")
+
+st, _n, msg = run_acl(OSError(13, "Permission denied"))
+assert st == "warn" and "没跑成" in msg, msg
+ok("其它错误 → warn(不冒充结论)")
+
+# 探测地址必须**不在**面板表里
+pick = C._lan_probe_target(CFG)
+assert pick is not None
+assert pick[0] not in ("192.168.50.10", "192.168.50.20"), pick
+assert pick[0].startswith("192.168.50."), pick
+ok("探测地址与面板同网段但不在表里: %s:%d" % (pick[0], pick[1]))
+
+# ══ ④ check_lan_cert ═══════════════════════════════════════════════════════
+# 判据用 `openssl x509 -checkend`, 不自己解析 notAfter —— 那个格式带时区缩写,
+# strptime 在不同 locale 下解出来的东西不一样。桩按 checkend 的秒数分支即可。
+def run_cert(present, expired=(), soon=()):
+    d = tempfile.mkdtemp()
+    for n_ in present:
+        open(os.path.join(d, "%s.crt" % n_), "w").write("x")
+
+    def _run(cmd, t=10):
+        if cmd[:2] == ["openssl", "x509"]:
+            name = os.path.basename(cmd[-1])[:-4]
+            secs = int(cmd[cmd.index("-checkend") + 1])
+            if name in expired:
+                return (1, "", "")
+            if secs > 0 and name in soon:
+                return (1, "", "")
+            return (0, "", "")
+        return (1, "", "")
+
+    old = stub(_lan_cfg=lambda: CFG, _lan_on=lambda: (True, True),
+               LAN_CERT_DIR=d, _run=_run)
+    try:
+        return C.check_lan_cert()
+    finally:
+        restore(old)
+
+
+st, _n, msg = run_cert(["p0", "p1"])
+assert st == "ok", (st, msg)
+ok("证书齐全且未临期 → ok")
+
+st, _n, msg = run_cert(["p0"])
+assert st == "fail" and "p1" in msg, msg
+ok("缺证书 → fail 且点名")
+
+st, _n, msg = run_cert(["p0", "p1"], expired=("p1",))
+assert st == "fail" and "已过期" in msg and "p1" in msg, msg
+ok("证书已过期 → fail")
+
+st, _n, msg = run_cert(["p0", "p1"], soon=("p0",))
+assert st == "warn" and "14 天内" in msg and "p0" in msg, msg
+assert "续期链" in msg, "临期要提醒续期链可能断了 —— 它断掉时不会有任何报错"
+ok("证书 14 天内到期 → warn 并提醒续期链")
+
+old = stub(_lan_cfg=lambda: CFG, _lan_on=lambda: (False, False))
+assert C.check_lan_cert() is None
+restore(old)
+ok("功能停用 → 证书项不适用(过不过期都不影响任何东西)")
+
+print("test-lan-doctor.py: 通过 %d 项" % PASS[0])

--- a/tests/test-lan-doctor.py
+++ b/tests/test-lan-doctor.py
@@ -15,6 +15,9 @@ import sys
 import tempfile
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tmpguard          # 一次性临时目录: 建了就登记, 退出即清
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "deploy" / "bot"))
 spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
@@ -229,7 +232,9 @@ ok("探测地址与面板同网段但不在表里: %s:%d" % (pick[0], pick[1]))
 # 判据用 `openssl x509 -checkend`, 不自己解析 notAfter —— 那个格式带时区缩写,
 # strptime 在不同 locale 下解出来的东西不一样。桩按 checkend 的秒数分支即可。
 def run_cert(present, expired=(), soon=()):
-    d = tempfile.mkdtemp()
+    # 走 tmpguard 而不是裸 mkdtemp: 这个仓库的测试经常并发跑, 按前缀扫 /tmp 清理等于
+    # 随机破坏隔壁进程的沙箱。登记表是唯一安全的依据。(tests/test-tmp-hygiene 会拦裸调。)
+    d = tmpguard.mkdtemp(prefix="lan-doctor.")
     for n_ in present:
         open(os.path.join(d, "%s.crt" % n_), "w").write("x")
 

--- a/tests/test-lan-wire.py
+++ b/tests/test-lan-wire.py
@@ -92,4 +92,42 @@ assert alt["hosts"] == {d: "100.64.0.5" for d in LAN}
 # ── ⑦ 产出仍是合法 JSON/YAML 可序列化 ──────────────────────────────────────
 json.dumps(cfg)
 
+# ── ⑧ 守卫: 两条渲染路径都必须传环境入参 ───────────────────────────────────
+# bot.py 里有**两条**渲染路径:
+#   · _render_mihomo_bytes → mihomorender.render_bytes(事务用)
+#   · _render_mihomo_file  → **直接调** sb2mihomo.singbox_to_mihomo(CLI 用)
+# 每加一个环境入参都要在两处各写一遍。漏了一处不会报错 —— 那条路渲染出来的配置会静默
+# 少掉那块能力。本轮就踩了: 面板路由在事务那条路上好好的, 从 CLI 重渲出来的配置里一条
+# 都没有, 而两边都"成功"。
+#
+# 这条守卫按**源码**判(AST), 不按运行结果: 运行结果要造齐整套环境才测得到, 而源码里
+# "有没有把这个参数传下去"是确定的。
+import ast
+
+ENV_KWARGS = {"mitm_domains", "lan_domains"}
+RENDER_CALLS = {"singbox_to_mihomo", "render_bytes"}
+
+for src in ("deploy/bot/pdg-bot.py", "deploy/bot/mihomorender.py"):
+    tree = ast.parse(open(Path(__file__).resolve().parents[1] / src, encoding="utf-8").read())
+    seen = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fname = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+        if fname not in RENDER_CALLS:
+            continue
+        # 定义处不算(那是 def, 不是 call); 只看真正的调用
+        kw = {k.arg for k in node.keywords if k.arg}
+        # **不能因为带了 `**kwargs` 就跳过**。第一版守卫就是这么写的, 结果它恰好放过了
+        # 本轮那个 bug —— 出问题的那处调用正好带着 `**_panel_render_args(model)`。
+        # 一个会跳过目标场景的守卫比没有守卫更糟: 它让人以为这一类问题已经被盯住了。
+        # 环境入参一律要求**显式写出来**; 真有哪天要从 ** 里传, 那次改动本来就该看这条断言。
+        missing = ENV_KWARGS - kw
+        assert not missing, (
+            "%s 第 %d 行调用 %s 时漏了环境入参 %s —— 这条渲染路径产出的配置会"
+            "静默少掉那块能力, 而调用方拿到的是成功。"
+            % (src, node.lineno, fname, sorted(missing)))
+        seen += 1
+    assert seen >= 1, "%s 里没找到任何渲染调用 —— 守卫本身失效了(重构改了函数名?)" % src
+
 print("test-lan-wire.py: OK")

--- a/tests/test-lan-wire.py
+++ b/tests/test-lan-wire.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""内网面板(方案 B)的 mihomo 分流接线: 面板域名 → 本机反代。
+
+本文件最要紧的是**规则顺序**那组断言, 而顺序这件事是实测定案的, 不是推理:
+
+  · `no-resolve` 的含义是"不要为这条规则发起 DNS 查询", **不是**"目的是域名时不匹配"。
+    面板域名在 hosts: 段里被映射到本机地址, 于是 IP 在规则匹配阶段就已知 ——
+    `IP-CIDR,127.0.0.0/8,REJECT,no-resolve` 会命中并把连接拒掉。
+  · 真机(mihomo v1.19.29, 两个容器走真 nft REDIRECT)上的正负控:
+        面板规则在前 → HTTP 200, `match DomainSuffix using DIRECT`
+        REJECT 在前  → HTTP 000, `match IPCIDR(127.0.0.0/8) using REJECT`
+
+所以"面板规则排在 REJECT 之前"不是风格问题, 是这条链路成不成立的分界。任何一次把它
+改回去的重构都必须先在真机上重做那组对照。
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "deploy" / "bot"))
+import sb2mihomo  # noqa: E402
+
+SB = {
+    "outbounds": [
+        {"type": "shadowsocks", "tag": "ss1", "server": "1.1.1.1", "server_port": 8388,
+         "method": "aes-256-gcm", "password": "sp"},
+        {"type": "direct", "tag": "direct"},
+    ],
+    "route": {
+        "rules": [
+            # 生产模型用的是 action: reject(不是 outbound: reject) —— 夹具要跟真源同形,
+            # 否则规则根本生成不出来, 而顺序断言会在一个空列表上"通过"。
+            {"ip_cidr": ["177.0.142.153/32", "127.0.0.0/8"], "action": "reject"},
+            {"domain_suffix": ["openai.com"], "outbound": "ss1"},
+        ],
+        "final": "direct",
+    },
+}
+LAN = ["nas.home.example.com", "ups.home.example.com"]
+
+
+def idx(rules, needle):
+    for n, r in enumerate(rules):
+        if needle in r:
+            return n
+    return -1
+
+
+# ── ① 不给 lan_domains 时, 什么都不该变(向后兼容) ────────────────────────────
+base, _ = sb2mihomo.singbox_to_mihomo(SB)
+assert "hosts" not in base, "没有面板时不该凭空生成 hosts: 段"
+assert not any("home.example.com" in r for r in base["rules"])
+
+# ── ② 给了之后: hosts 段 + DOMAIN-SUFFIX 规则 ───────────────────────────────
+cfg, _ = sb2mihomo.singbox_to_mihomo(SB, lan_domains=LAN)
+assert cfg["hosts"] == {d: "127.0.0.1" for d in LAN}, cfg.get("hosts")
+for d in LAN:
+    assert "DOMAIN-SUFFIX,%s,DIRECT" % d in cfg["rules"]
+
+# ── ③ **顺序**: 面板规则必须在反自环 REJECT 之前 ────────────────────────────
+r = cfg["rules"]
+i_panel = idx(r, "nas.home.example.com")
+i_rej = idx(r, "IP-CIDR,127.0.0.0/8,REJECT")
+assert i_panel >= 0 and i_rej >= 0, (i_panel, i_rej)
+assert i_panel < i_rej, (
+    "面板规则排到了 REJECT 之后 —— 真机上这会让面板全部打不开(match IPCIDR REJECT)。"
+    "顺序: %r" % r[:6])
+# 另一条反自环(劫持假 IP)同样要在面板规则之后
+assert i_panel < idx(r, "IP-CIDR,177.0.142.153/32,REJECT")
+
+# ── ④ 空测: 顺序断言得有牙 ─────────────────────────────────────────────────
+# 把面板规则挪到 REJECT 之后, 上面那条断言必须失败 —— 否则它证明不了任何事。
+shuffled = [x for x in r if "home.example.com" not in x]
+shuffled = shuffled[:2] + [x for x in r if "home.example.com" in x] + shuffled[2:]
+assert idx(shuffled, "nas.home.example.com") > idx(shuffled, "IP-CIDR,127.0.0.0/8,REJECT"), \
+    "空测本身构造错了"
+
+# ── ⑤ MITM 的位置不能被面板规则带偏 ────────────────────────────────────────
+# MITM 必须仍排在 REJECT **之后**: 它的域名没有 hosts 条目, 匹配时 IP 未知, 所以那个
+# 位置是对的; 而且 MITM-OUT 出站自己连本机是不过规则的。两者性质不同, 不能一起挪。
+both, _ = sb2mihomo.singbox_to_mihomo(SB, lan_domains=LAN, mitm_domains=["gsp-ssl.ls.apple.com"])
+b = both["rules"]
+i_mitm = idx(b, "MITM-OUT")
+i_rej2 = idx(b, "IP-CIDR,127.0.0.0/8,REJECT")
+i_panel2 = idx(b, "nas.home.example.com")
+assert i_panel2 < i_rej2 < i_mitm, ("面板 < REJECT < MITM 这个次序被破坏了: %r" % b[:8])
+
+# ── ⑥ lan_addr 可配(将来若改成绑非环回地址, 不必动渲染逻辑) ────────────────
+alt, _ = sb2mihomo.singbox_to_mihomo(SB, lan_domains=LAN, lan_addr="100.64.0.5")
+assert alt["hosts"] == {d: "100.64.0.5" for d in LAN}
+
+# ── ⑦ 产出仍是合法 JSON/YAML 可序列化 ──────────────────────────────────────
+json.dumps(cfg)
+
+print("test-lan-wire.py: OK")

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -201,4 +201,59 @@ try:
 except lp.PanelError:
     pass
 
+# ── ⑮ 候选生成: add / rm 不写盘, 只产出新表 ─────────────────────────────────
+base = cfg(P())
+c2 = lp.add_panel(base, {"name": "ups", "host": "ups.home.example.com",
+                         "target": "http://192.168.1.9:8080"})
+assert len(c2["panels"]) == 2
+assert len(base["panels"]) == 1, "add_panel 不该改原对象"
+
+# 候选要**整体**过校验, 不只校验新增那条 —— 撞 name/host 只有放在一起看才发现得了
+for dup in ({"name": "nas", "host": "x.home.example.com", "target": "http://10.0.0.1"},
+            {"name": "other", "host": "nas.home.example.com", "target": "http://10.0.0.1"}):
+    try:
+        lp.add_panel(base, dup)
+        raise AssertionError("重复的 %r 不该加得进去" % dup["name"])
+    except lp.PanelError as ex:
+        assert "重复" in str(ex), ex
+
+# 删不到要报错, 不能静默成功 —— "删了个不存在的"和"删掉了"事后看起来一模一样
+try:
+    lp.rm_panel(base, "nope")
+    raise AssertionError("删不存在的面板不该成功")
+except lp.PanelError as ex:
+    assert "没有名叫" in str(ex), ex
+
+c3 = lp.rm_panel(c2, "nas")
+assert [p["name"] for p in c3["panels"]] == ["ups"]
+assert len(c2["panels"]) == 2, "rm_panel 不该改原对象"
+
+# 落盘文本要稳定 —— 事务比对 before/after, 格式抖动会让"没改内容"看起来像改过
+assert lp.dumps(base) == lp.dumps(json.loads(lp.dumps(base)))
+
+# 命令行 add: 生成候选到 stdout, 原文件一个字节都不动
+with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as f:
+    json.dump(base, f)
+    tpath = f.name
+before = open(tpath, encoding="utf-8").read()
+p_ = subprocess.run([sys.executable, str(MOD), "add", tpath, "--name", "ups",
+                     "--host", "ups.home.example.com", "--target", "http://192.168.1.9:8080"],
+                    capture_output=True, text=True)
+assert p_.returncode == 0, p_.stdout + p_.stderr
+assert len(json.loads(p_.stdout)["panels"]) == 2
+assert open(tpath, encoding="utf-8").read() == before, "add 不该写原文件"
+
+# https 上游没表态 → 拒绝, 且原文件仍不动
+p_ = subprocess.run([sys.executable, str(MOD), "add", tpath, "--name", "z",
+                     "--host", "z.home.example.com", "--target", "https://192.168.1.11"],
+                    capture_output=True, text=True)
+assert p_.returncode == 2 and "insecure_upstream" in p_.stdout, p_.stdout
+assert open(tpath, encoding="utf-8").read() == before
+
+# --no-insecure 是表过态的
+p_ = subprocess.run([sys.executable, str(MOD), "add", tpath, "--name", "z",
+                     "--host", "z.home.example.com", "--target", "https://192.168.1.11",
+                     "--no-insecure"], capture_output=True, text=True)
+assert p_.returncode == 0, p_.stdout
+
 print("test-lanpanel.py: OK")

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -149,4 +149,56 @@ assert rc == 3, (rc, out)
 rc, out = cli("render", "--certs", "/c", table=cfg(P(target="https://nas.lan")))
 assert rc == 2 and "字面 IP" in out, (rc, out)
 
+# ── ⑭ 门三: 出站白名单的**结构**(真 nft 的行为验证要 NET_ADMIN, CI 给不了 ──────
+#     见 tests/negctl/lan-egress-live.sh, 那是本地门)
+def nft(cfg_, uid="pdg-lan"):
+    return lp.render_nft(cfg_, uid)
+
+
+rules = nft(cfg(P(), P(name="ups", host="ups.home.example.com",
+                       target="http://192.168.1.9:8080")))
+lines = [l.strip() for l in rules.splitlines() if l.strip() and not l.strip().startswith("#")]
+
+# uid 判据必须**排在白名单之前**。排在后面的话白名单对所有进程生效 —— 那正好把
+# "按 uid 过滤"这条设计取消掉, 而规则看起来一条不少。
+i_uid = next(n for n, l in enumerate(lines) if "skuid" in l)
+i_first_allow = next(n for n, l in enumerate(lines) if "daddr" in l)
+assert i_uid < i_first_allow, (i_uid, i_first_allow)
+
+# reject 必须是链里最后一条 —— 后面还有规则的话它们永远走不到
+i_reject = next(n for n, l in enumerate(lines) if l.startswith("reject"))
+assert all("daddr" not in l for l in lines[i_reject:]), lines[i_reject:]
+
+# 白名单逐条对上面板表, 不多不少
+assert rules.count("ip daddr 192.168.1.50 tcp dport 443 accept") == 1
+assert rules.count("ip daddr 192.168.1.9 tcp dport 8080 accept") == 1
+assert "192.168.1.1" not in rules, "表里没有的地址不该出现在规则里"
+
+# 环回响应要放行, 否则反代回不了包
+assert "oif lo accept" in rules
+
+# IPv6 用 ip6 daddr
+v6 = nft(cfg(P(target="https://[fd00::5]:8443")))
+assert "ip6 daddr fd00::5 tcp dport 8443 accept" in v6, v6
+
+# **空表必须是"什么都不许连", 不能是"随便连"**。一份没有面板的配置最容易被当成
+# "还没配, 先放开" —— 那会让反代在配置好之前拥有整个内网的可达性。
+empty = nft(cfg())
+assert "daddr" not in empty and "reject with icmpx admin-prohibited" in empty, empty
+
+# uid 形态不合法就拒绝生成(拼错的用户名会让 nft 加载失败 —— 而那是 fail-open 的)
+for bad_uid in ("", "Root", "a b", "x" * 40, 1000):
+    try:
+        nft(cfg(P()), bad_uid)
+        raise AssertionError("uid %r 不该被接受" % (bad_uid,))
+    except lp.PanelError:
+        pass
+
+# 面板表不合法时连规则也不生成 —— 否则会派生出一份"按半张表放行"的白名单
+try:
+    nft(cfg(P(target="https://nas.lan")))
+    raise AssertionError("不合法的表不该派生出防火墙规则")
+except lp.PanelError:
+    pass
+
 print("test-lanpanel.py: OK")

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -256,4 +256,26 @@ p_ = subprocess.run([sys.executable, str(MOD), "add", tpath, "--name", "z",
                      "--no-insecure"], capture_output=True, text=True)
 assert p_.returncode == 0, p_.stdout
 
+# ── ⑯ 风险②: DNS token 的爆炸半径(面板域名与 DoT 域名同 zone = 权限升级) ─────
+assert lp.shared_zone("nas.home.example.com", "dot.example.com") == "example.com"
+assert lp.shared_zone("nas.lan.mydom.io", "dot.mydom.io") == "mydom.io"
+# 空测: 不同注册域不该报
+assert lp.shared_zone("nas.home.example.com", "dot.other.net") is None
+assert lp.shared_zone("a.example.com", "b.example.org") is None
+# 只共有 TLD 不算 —— 否则所有 .com 域名两两之间都会报, 这条判据立刻变成噪音
+assert lp.shared_zone("a.com", "b.com") is None
+assert lp.shared_zone("x.co.uk", "y.co.uk") == "co.uk"    # 宁可多报: co.uk 会命中
+# 大小写与末尾点不影响判定(DNS 里它们是同一个名字)
+assert lp.shared_zone("NAS.Home.Example.COM", "dot.example.com.") == "example.com"
+
+r = lp.zone_risk(cfg(P(host="nas.home.example.com"),
+                     P(name="b", host="b.elsewhere.net", target="http://10.0.0.2")),
+                 "dot.example.com")
+assert r == [("nas.home.example.com", "example.com")], r
+# 空测: 没配 DoT 域名时不报(判据没有输入, 不能凭空成立)
+assert lp.zone_risk(cfg(P()), "") == []
+assert lp.zone_risk(cfg(P()), None) == []
+# 空测: DoT 在别的注册域时不报
+assert lp.zone_risk(cfg(P(host="nas.home.example.com")), "dot.other.net") == []
+
 print("test-lanpanel.py: OK")

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""面板表校验(门二)与反代生成的测试。
+
+同样的纪律: **每条判据配空测**。生成器这边尤其要紧 —— 那些改写指令(Location / Referer /
+TLS transport)只在面板显式要求时才该出现, 一个"总是全都加上"的实现能让所有正面用例通过,
+而它在真机上的后果是给不需要改写的设备也改了头, 症状隐蔽得多。
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MOD = ROOT / "deploy/bot/lanpanel.py"
+
+spec = importlib.util.spec_from_file_location("lanpanel", MOD)
+lp = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(lp)
+
+
+def cfg(*panels):
+    return {"panels": list(panels)}
+
+
+def P(**kw):
+    base = {"name": "nas", "host": "nas.home.example.com",
+            "target": "https://192.168.1.50", "insecure_upstream": True}
+    base.update(kw)
+    return base
+
+
+# ── ① 合法表通过 ─────────────────────────────────────────────────────────────
+assert lp.validate(cfg(P())) == []
+assert lp.validate(cfg(P(), P(name="router", host="r.home.example.com",
+                             target="https://192.168.1.1:8443"))) == []
+# http 上游不需要 insecure_upstream(没有证书可校验)
+assert lp.validate(cfg(P(target="http://192.168.1.7", insecure_upstream=None))) == []
+
+# ── ② 通配 host —— 门二的核心 ────────────────────────────────────────────────
+e = lp.validate(cfg(P(host="*.home.example.com")))
+assert e and "通配" in e[0], e
+# 空测: 普通域名不该被当成通配
+assert lp.validate(cfg(P(host="a.b.c.home.example.com"))) == []
+
+# ── ③ 上游必须是字面 IP ──────────────────────────────────────────────────────
+e = lp.validate(cfg(P(target="https://nas.lan")))
+assert e and "字面 IP" in e[0], e
+# 空测: 字面 IP 放行, IPv6 也放行
+assert lp.validate(cfg(P(target="https://192.168.1.50"))) == []
+assert lp.validate(cfg(P(target="https://[fd00::1]:8443"))) == []
+# 环回上游指向网关自己, 拒
+e = lp.validate(cfg(P(target="https://127.0.0.1:8443")))
+assert e and "环回" in e[0], e
+
+# ── ④ https 上游必须显式表态 ────────────────────────────────────────────────
+e = lp.validate(cfg(P(insecure_upstream=None)))
+assert e and "insecure_upstream" in e[0], e
+# 空测: 显式写 false 也算表过态
+assert lp.validate(cfg(P(insecure_upstream=False))) == []
+
+# ── ⑤ 重复 ───────────────────────────────────────────────────────────────────
+e = lp.validate(cfg(P(), P(host="other.home.example.com")))          # name 重复
+assert any("name" in x and "重复" in x for x in e), e
+e = lp.validate(cfg(P(), P(name="two")))                             # host 重复
+assert any("host" in x and "重复" in x for x in e), e
+
+# ── ⑥ 认不出的字段不能静默忽略 ──────────────────────────────────────────────
+e = lp.validate(cfg(P(insecure_upstrem=True)))     # 故意拼错
+assert any("认不出" in x for x in e), e
+
+# ── ⑦ 派生出站白名单 ────────────────────────────────────────────────────────
+t = lp.targets(cfg(P(), P(name="r", host="r.home.example.com", target="http://192.168.1.1:8443")))
+assert t == [("192.168.1.50", 443), ("192.168.1.1", 8443)], t
+# 省略端口时按 scheme 取默认值 —— 防火墙要的是具体端口
+assert lp.targets(cfg(P(target="http://10.0.0.9"))) == [("10.0.0.9", 80)]
+
+# ── ⑧ 生成: 改写指令只在被要求时出现(这是本文件最要紧的一组空测) ────────────
+plain = lp.render_caddy(cfg(P()), "/c")
+assert "header_down Location" not in plain, "没要求就不该改 Location"
+assert "header_up Referer" not in plain, "没要求就不该改 Referer"
+assert "redir" not in plain, "没要求就不该注入跳转"
+
+loc = lp.render_caddy(cfg(P(rewrite_location=True)), "/c")
+assert "header_down Location" in loc
+assert "header_up Referer" not in loc, "只要了 Location, 不该顺手改 Referer"
+
+ref = lp.render_caddy(cfg(P(fix_referer=True)), "/c")
+assert "header_up Referer" in ref and "header_up Origin" in ref
+assert "header_down Location" not in ref
+
+q = lp.render_caddy(cfg(P(entry_query="magicpath=abc123")), "/c")
+assert "redir @bare /?magicpath=abc123 302" in q
+
+# ── ⑨ 生成: 上游协议决定 transport ──────────────────────────────────────────
+https = lp.render_caddy(cfg(P()), "/c")
+assert "tls_insecure_skip_verify" in https
+http = lp.render_caddy(cfg(P(target="http://192.168.1.7", insecure_upstream=None)), "/c")
+assert "transport http" not in http, "http 上游不该生成 tls transport"
+assert "tls_insecure_skip_verify" not in http
+strict = lp.render_caddy(cfg(P(insecure_upstream=False)), "/c")
+assert "transport http" in strict and "tls_insecure_skip_verify" not in strict, \
+    "显式 false 时要用 tls 但不跳过校验"
+
+# ── ⑩ 生成前先校验, 不合法就拒绝落盘 ────────────────────────────────────────
+try:
+    lp.render_caddy(cfg(P(host="*.evil.example.com")), "/c")
+    raise AssertionError("通配的表不该能生成出配置")
+except lp.PanelError as ex:
+    assert "通配" in str(ex), ex
+
+# ── ⑪ 老 TLS 套件的面板单独列出(要给 unit 加 GODEBUG, Caddyfile 管不了) ─────
+assert lp.legacy_tls_panels(cfg(P(legacy_tls=True))) == ["nas"]
+assert lp.legacy_tls_panels(cfg(P())) == []
+
+# ── ⑫ 生成的配置里每个面板都要 bind 到指定地址 ──────────────────────────────
+two = lp.render_caddy(cfg(P(), P(name="r", host="r.home.example.com",
+                                 target="http://192.168.1.1:8443")), "/c", bind="100.64.1.2")
+assert two.count("bind 100.64.1.2") == 2
+assert two.count("tls /c/") == 2
+
+# ── ⑬ 命令行契约 ─────────────────────────────────────────────────────────────
+def cli(*args, table=None):
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as f:
+        json.dump(table if table is not None else cfg(P()), f)
+        path = f.name
+    p = subprocess.run([sys.executable, str(MOD), args[0], path] + list(args[1:]),
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout
+
+
+rc, out = cli("check")
+assert rc == 0 and out.strip() == "", (rc, out)
+
+rc, out = cli("check", table=cfg(P(host="*.x.example.com")))
+assert rc == 2 and "通配" in out, (rc, out)
+
+rc, out = cli("targets")
+assert rc == 0 and out.strip() == "192.168.1.50\t443", (rc, out)
+
+rc, out = cli("render", "--certs", "/etc/pdg/lan-certs")
+assert rc == 0 and "reverse_proxy https://192.168.1.50:443" in out, (rc, out)
+
+rc, out = cli("render")           # 缺 --certs
+assert rc == 3, (rc, out)
+
+rc, out = cli("render", "--certs", "/c", table=cfg(P(target="https://nas.lan")))
+assert rc == 2 and "字面 IP" in out, (rc, out)
+
+print("test-lanpanel.py: OK")

--- a/tests/test-lanroute.py
+++ b/tests/test-lanroute.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""门一(子网路由重叠拒绝)的判据测试。
+
+**每条判据都配一条"空测"**: 把触发条件拿掉之后必须放行。只测"会拒"不够 ——
+一个永远返回"拒绝"的实现也能让那些用例全绿, 而它在真机上的表现是谁都用不了。
+
+反过来同样要紧: 作者自己的家用段(192.168.100.0/24)与网关的 172.22.0.0/16 天然不相交,
+在真机上跑门一会一路放行。所以**不能拿"真机没报错"当作门一在工作的证据**, 必须另造
+一个确实相交的样本 —— 见 test_internal_overlap_has_teeth。
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MOD = ROOT / "deploy/bot/lanroute.py"
+
+spec = importlib.util.spec_from_file_location("lanroute", MOD)
+lr = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(lr)
+
+INTERNAL = "172.22.0.0/16"
+
+
+def tags(advertised, internal=INTERNAL, locals_=()):
+    """跑一次判定, 返回命中的标识集合(不比中文文案 —— 文案会改)。"""
+    locs = [lr.parse_net(x) for x in locals_]
+    inet = lr.parse_net(internal) if internal else None
+    out = lr.judge([advertised], inet, locs)
+    if not out:
+        return set()
+    return {t for _, reasons in out for t, _ in reasons}
+
+
+# ── ① 干净样本必须放行 ────────────────────────────────────────────────────────
+assert tags("192.168.1.0/24") == set()
+assert tags("192.168.100.0/24") == set()          # 作者家里的真实段
+assert tags("10.9.9.0/24", locals_=["10.0.0.5/24"]) == set()
+
+# ── ② 默认路由 ───────────────────────────────────────────────────────────────
+assert lr.R_DEFAULT in tags("0.0.0.0/0")
+assert lr.R_DEFAULT in tags("::/0")
+# 空测: 只要不是 /0 就不该按默认路由拒。0.0.0.0/1 大得离谱但性质不同 ——
+# 它不会把网关变成出口节点, 判据不能把"大"和"默认路由"混为一谈。
+assert lr.R_DEFAULT not in tags("0.0.0.0/1")
+
+# ── ③ 与内网卡来源段相交 ─────────────────────────────────────────────────────
+assert lr.R_INTERNAL in tags("172.22.0.0/24")     # 被包含
+assert lr.R_INTERNAL in tags("172.22.0.0/16")     # 完全相同
+assert lr.R_INTERNAL in tags("172.0.0.0/8")       # 反过来包含内网段
+
+
+def test_internal_overlap_has_teeth():
+    """这条判据的**牙**: 相邻但不相交的段必须放行, 相交的必须拒。
+
+    两者只差一个 bit —— 如果实现写成"前两段相同就算相交"之类的近似, 这里会立刻塌。
+    """
+    assert tags("172.21.255.0/24") == set(), "相邻不相交, 不该拒"
+    assert lr.R_INTERNAL in tags("172.22.255.0/24"), "在 /16 之内, 必须拒"
+    # 边界的两头各取一个
+    assert lr.R_INTERNAL in tags("172.22.0.0/32")
+    assert lr.R_INTERNAL in tags("172.22.255.255/32")
+    assert tags("172.23.0.0/32") == set()
+
+
+test_internal_overlap_has_teeth()
+
+# 空测: 没给内网段时, 这条判据不该凭空成立
+assert lr.R_INTERNAL not in tags("172.22.0.0/24", internal=None)
+
+# ── ④ 与本机接口网段相交 ─────────────────────────────────────────────────────
+assert lr.R_LOCAL in tags("10.0.0.0/24", locals_=["10.0.0.5/24"])
+assert lr.R_LOCAL in tags("10.0.0.0/8", locals_=["10.0.0.5/24"])
+# 空测: 不给本机接口就不该有这条
+assert lr.R_LOCAL not in tags("10.0.0.0/24")
+# 空测: 接口在别的段, 放行
+assert tags("10.0.0.0/24", locals_=["192.168.50.7/24"]) == set()
+
+# ── ⑤ Tailscale 自身段 ───────────────────────────────────────────────────────
+assert lr.R_TAILNET in tags("100.64.0.0/10")
+assert lr.R_TAILNET in tags("100.100.0.0/16")     # /10 之内
+assert lr.R_TAILNET in tags("fd7a:115c:a1e0::/48", internal=None)
+# 空测: 100.128/9 在 100.64/10 之外(CGNAT 只到 100.127.255.255)
+assert lr.R_TAILNET not in tags("100.128.0.0/9")
+
+# ── ⑥ 环回 ───────────────────────────────────────────────────────────────────
+assert lr.R_LOOPBACK in tags("127.0.0.0/8")
+assert lr.R_LOOPBACK in tags("127.0.0.1/32")
+assert lr.R_LOOPBACK not in tags("128.0.0.0/8")
+
+# ── ⑦ IPv4 / IPv6 不许互相误判 ───────────────────────────────────────────────
+# 不同协议族之间谈"相交"没有意义; 实现里若漏了 version 判断, ipaddress 会直接抛异常,
+# 那会变成一个看起来像 bug 的崩溃而不是一条清楚的拒绝理由。
+assert tags("2001:db8::/32", internal=INTERNAL) == set()
+assert tags("192.168.1.0/24", internal=None, locals_=["2001:db8::1/64"]) == set()
+
+# ── ⑧ 一个网段同时踩中多条时要全列出来 ──────────────────────────────────────
+multi = tags("172.22.0.0/16", locals_=["172.22.5.1/24"])
+assert lr.R_INTERNAL in multi and lr.R_LOCAL in multi, multi
+
+# ── ⑨ 形态不合法 ─────────────────────────────────────────────────────────────
+assert "bad-cidr" in tags("192.168.1.0/33")
+assert "bad-cidr" in tags("不是网段")
+# 带主机位的写法按网段取整, 不算错 —— "接口地址所在网段"本来就是这个意思
+assert tags("192.168.7.9/24") == set()
+
+# ── ⑩ 命令行契约(pdg lan 与 doctor 都按退出码分支) ──────────────────────────
+def cli(*args):
+    p = subprocess.run([sys.executable, str(MOD)] + list(args),
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout
+
+
+rc, out = cli("judge", "--internal", INTERNAL, "192.168.1.0/24")
+assert rc == 0 and out.strip() == "", (rc, out)
+
+rc, out = cli("judge", "--internal", INTERNAL, "172.22.9.0/24")
+assert rc == 2 and lr.R_INTERNAL in out, (rc, out)
+
+rc, out = cli("judge", "--internal", "垃圾", "192.168.1.0/24")
+assert rc == 3, (rc, out)
+
+# 一次判多个: 只要有一个被拒, 整体就是 2 —— 调用方不必逐个跑
+rc, out = cli("judge", "--internal", INTERNAL, "192.168.1.0/24", "0.0.0.0/0")
+assert rc == 2 and lr.R_DEFAULT in out, (rc, out)
+
+# 空测: 什么都不给, 不该报错
+rc, out = cli("judge", "--internal", INTERNAL)
+assert rc == 0, (rc, out)
+
+print("test-lanroute.py: OK")

--- a/tests/test-mitm-wloc-txn.py
+++ b/tests/test-mitm-wloc-txn.py
@@ -370,8 +370,21 @@ def main():
             ok("%s → 事务自己收尾成 %s, 候选材料已删" % (label, sts[-1][1]))
         else:
             bad("%s 之后残留: %s" % (label, sts))
-        metas = "".join(open(os.path.join(box.env["PDG_TX_ROOT"], d, "meta.json"),
-                             encoding="utf-8").read() for d, _s, _c in sts)
+        # 判据找的是**候选正文**有没有漏进 meta。txid 与 started_at/ended_at 不是候选
+        # 内容, 但它们的格式(`…SS.mmm…` / `1787378576.055…`)天然可能含有 "35.6" 这四个
+        # 字符 —— 那会让这条断言在某些时刻凭空变红。CI 上真撞过一次(同一 commit 重跑即绿)。
+        # 所以先把这几个字段摘掉再搜: 剔的是干草, 不是针 —— "35.6" 仍是原来那根针。
+        def _no_ts(raw):
+            try:
+                d_ = json.loads(raw)
+            except ValueError:
+                return raw
+            for k in ("txid", "started_at", "ended_at"):
+                d_.pop(k, None)
+            return json.dumps(d_, ensure_ascii=False)
+
+        metas = "".join(_no_ts(open(os.path.join(box.env["PDG_TX_ROOT"], d, "meta.json"),
+                                    encoding="utf-8").read()) for d, _s, _c in sts)
         if "BACKUP-PASSWORD" not in metas and "35.6" not in metas:
             ok("%s: meta 里没有候选正文/坐标" % label)
         else:

--- a/tests/test-render-refusal.py
+++ b/tests/test-render-refusal.py
@@ -89,7 +89,7 @@ PROBE = textwrap.dedent('''
     import mihomorender as M
     model = json.loads(%r)
     meta = json.loads(%r)
-    data, rmeta = M.render_bytes(model, rulesets=M.rulesets_arg(meta),
+    data, rmeta = M.render_bytes(model, lan_domains=[], rulesets=M.rulesets_arg(meta),
                                  mitm_domains=[], tls_ports=None)
     try:
         M.check_meta(rmeta)

--- a/tests/test-render-shared.py
+++ b/tests/test-render-shared.py
@@ -100,7 +100,7 @@ import hashlib, json, sys
 import mihomorender as M
 model = json.loads(%r)
 meta = json.loads(%r)
-data, meta_out = M.render_bytes(model, rulesets=M.rulesets_arg(meta),
+data, meta_out = M.render_bytes(model, lan_domains=[], rulesets=M.rulesets_arg(meta),
                                 mitm_domains=[], tls_ports=None)
 print("SHA:" + hashlib.sha256(data).hexdigest())
 print("RS:" + json.dumps(M.rulesets_arg(meta), sort_keys=True))
@@ -155,7 +155,8 @@ d = tempfile.mkdtemp()
 try:
     open(os.path.join(d, "platform"), "w").write("android\\n")
     json.dump(json.loads(%r), open(os.path.join(d, "rulesets.json"), "w"))
-    fn = M.deriver_from_paths(rs_meta_path=os.path.join(d, "rulesets.json"),
+    fn = M.deriver_from_paths(lan_table_file=os.path.join(d, "lan-panels.json"),
+                              rs_meta_path=os.path.join(d, "rulesets.json"),
                               mitm_hijack_file=os.path.join(d, "mitm_hijack.txt"),
                               platform_file=os.path.join(d, "platform"))
     data = fn({"model": json.dumps(json.loads(%r)).encode()})
@@ -202,7 +203,8 @@ try:
     bot_bytes, _m = bot._render_mihomo_bytes(MODEL, rs_meta=META, mitm_domains=[])
 finally:
     bot._platform = _p
-shared_bytes, _m2 = M.render_bytes(MODEL, rulesets=shared_rs, mitm_domains=[], tls_ports=None)
+shared_bytes, _m2 = M.render_bytes(MODEL, rulesets=shared_rs, mitm_domains=[], tls_ports=None,
+                                   lan_domains=[])
 if hashlib.sha256(bot_bytes).hexdigest() == hashlib.sha256(shared_bytes).hexdigest():
     ok("bot._render_mihomo_bytes 与 mihomorender.render_bytes 逐字节相同")
 else:

--- a/tests/test-tx-recover-source.py
+++ b/tests/test-tx-recover-source.py
@@ -358,11 +358,20 @@ if inst.start():
         ok("客户端中途断开: 服务端的恢复仍然跑完")
     else:
         bad("断开后恢复没完成")
-    rec = [r for r in audit_recs(box) if r.get("event") == "recover"]
+    # 状态到位**不等于**审计已落盘: 上面那个循环等的是 meta.json 的 state, 而审计是
+    # 另一次写。机器慢的时候(CI 上真撞过)state 已经是 ROLLED_BACK 而审计还没 flush,
+    # 于是这条断言拿到空列表。要等就各等各的, 不能拿一个信号去代表两件事。
+    rec = []
+    _dl = time.time() + 15
+    while time.time() < _dl:
+        rec = [r for r in audit_recs(box) if r.get("event") == "recover"]
+        if rec and rec[-1].get("trigger_source") == "rescue":
+            break
+        time.sleep(0.3)
     if rec and rec[-1].get("trigger_source") == "rescue":
         ok("客户端中途断开: 最终审计仍然落盘(trigger_source=rescue)")
     else:
-        bad("断开后审计缺失: %r" % rec)
+        bad("断开后审计缺失(等了 15s): %r" % rec)
     if inst.proc.poll() is None:
         ok("客户端中途断开: 服务进程没有被写响应失败搞崩")
     else:

--- a/tests/test-update-faults.sh
+++ b/tests/test-update-faults.sh
@@ -209,7 +209,11 @@ done
 # 第一个 / 中间 / 最后一个受管目标各失败一次 —— 覆盖遍历的头、中、尾
 assert_fail_rollback "受管目标 #1 安装失败"  "PLATFORM=ios FAIL_NTH=1"
 assert_fail_rollback "受管目标 #12 安装失败" "PLATFORM=ios FAIL_NTH=12"
-assert_fail_rollback "受管目标 #33 安装失败" "PLATFORM=ios FAIL_NTH=33"   # 清单末项(iOS 全集 33 条; 6.1C 加 nftlive.py, 6.2B 加 dotwitness.py)
+# 清单**末项**。数字跟着 lib/modules.sh 的 iOS 全集走 —— tests/test-false-green-guard.sh
+# 会核对这里的 FAIL_NTH 是否等于当前全集项数, 对不上就红。改清单必须一起改这里, 否则
+# "末项失败也能回滚"这条就没被测到, 而它恰恰是最容易漏的那一项。
+# 沿革: 6.1C 加 nftlive.py, 6.2B 加 dotwitness.py, 内网面板加 lanroute.py + lanpanel.py。
+assert_fail_rollback "受管目标 #35 安装失败" "PLATFORM=ios FAIL_NTH=35"
 
 # Android: 这几个 iOS 专属文件根本不该被安装 → 即使注入同名失败也不影响更新。
 # probe81.py 不在此列了 —— 它现在 Android 也装, 装失败必须回滚(见上面的公共件循环)。

--- a/tests/update_invariants.py
+++ b/tests/update_invariants.py
@@ -194,7 +194,10 @@ def capture(args):
     # 不装它 doctor 的防火墙检查会直接 ImportError), 因此两个平台各 +1。
     # 6.2B 加了 dotwitness.py(linkstat 经它的 read_evidence 取 DoT 证据; 证据校验器
     # 只能有一份, 不装它 linkstat 就只能永远报"不可判断"), 两个平台再各 +1。
-    expect = {"android": 27, "ios": 33}.get(plat)
+    # 内网面板(方案 B)加了 lanroute.py(门一, doctor 要常驻跑它)与 lanpanel.py(门二 +
+    # 反代/白名单生成; `pdg lan` 的候选生成也走它)。不装它们, `pdg lan` 与相关 doctor
+    # 检查会直接 ImportError/找不到模块, 因此两个平台各 +2。
+    expect = {"android": 29, "ios": 35}.get(plat)
     if expect is not None and len(members) != expect:
         raise SystemExit("manifest 数量漂移: %s 平台应为 %d 项, 实得 %d" % (plat, expect, len(members)))
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,13 +67,16 @@ fi
 # 比不卸载更糟。
 _LAN_RESIDUE=""
 _LAN_REMOVED=""
-[[ -e /etc/pdg-lan || -e /opt/pdg-acme || -e /etc/privdns-gateway/lan-dns.env \
+[[ -e /etc/pdg-lan || -e /opt/pdg-acme \
    || -x /usr/local/bin/caddy || -e /etc/systemd/system/pdg-lan.service ]] && _LAN_REMOVED=1
 systemctl disable --now pdg-lan 2>/dev/null || true
 systemctl reset-failed pdg-lan 2>/dev/null || true
 rm -f /etc/systemd/system/pdg-lan.service /etc/nftables-pdg-lan.conf
 [[ -n "$_UN_NFT" ]] && "$_UN_NFT" delete table inet pdglan 2>/dev/null || true
-for _lp in /etc/pdg-lan /var/lib/pdg-lan /opt/pdg-acme /etc/privdns-gateway/lan-dns.env; do
+# 注意这里**没有** /etc/privdns-gateway 下的任何路径: 普通卸载路径上碰那个目录是禁止的
+# (tests/test-ios-profile-persist.py 有守卫)。DNS 凭据放在 /etc/pdg-lan/dns.env, 跟着
+# 上面第一项一起走 —— 既删干净了, 又没碰用户配置目录。
+for _lp in /etc/pdg-lan /var/lib/pdg-lan /opt/pdg-acme; do
   [[ -e "$_lp" ]] || continue
   rm -rf "$_lp" 2>/dev/null || true
   [[ -e "$_lp" ]] && _LAN_RESIDUE="$_LAN_RESIDUE $_lp"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -61,6 +61,31 @@ if [[ -f "$_UN_HERE/lib/rescue.sh" ]]; then
 else
   _RESCUE_RESIDUE="找不到 lib/rescue.sh, 救援平面(凭据/状态/放行规则)未清理"
 fi
+# 内网面板(方案 B): 反代 unit、出站白名单、配置与证书、DNS API 凭据、acme 账户密钥、
+# caddy 二进制、专用用户。与救援平面同一条规矩 —— 残留要逐条报出来, 因为这里留下的是
+# **能改用户 DNS 记录的凭据**与**能签发证书的账户密钥**: 服务已经没了而凭据还在,
+# 比不卸载更糟。
+_LAN_RESIDUE=""
+_LAN_REMOVED=""
+[[ -e /etc/pdg-lan || -e /opt/pdg-acme || -e /etc/privdns-gateway/lan-dns.env \
+   || -x /usr/local/bin/caddy || -e /etc/systemd/system/pdg-lan.service ]] && _LAN_REMOVED=1
+systemctl disable --now pdg-lan 2>/dev/null || true
+systemctl reset-failed pdg-lan 2>/dev/null || true
+rm -f /etc/systemd/system/pdg-lan.service /etc/nftables-pdg-lan.conf
+[[ -n "$_UN_NFT" ]] && "$_UN_NFT" delete table inet pdglan 2>/dev/null || true
+for _lp in /etc/pdg-lan /var/lib/pdg-lan /opt/pdg-acme /etc/privdns-gateway/lan-dns.env; do
+  [[ -e "$_lp" ]] || continue
+  rm -rf "$_lp" 2>/dev/null || true
+  [[ -e "$_lp" ]] && _LAN_RESIDUE="$_LAN_RESIDUE $_lp"
+done
+rm -f /usr/local/bin/caddy 2>/dev/null || true
+[[ -e /usr/local/bin/caddy ]] && _LAN_RESIDUE="$_LAN_RESIDUE /usr/local/bin/caddy"
+if id pdg-lan >/dev/null 2>&1; then
+  userdel pdg-lan 2>/dev/null || _LAN_RESIDUE="$_LAN_RESIDUE 用户pdg-lan(删不掉,可能还有进程在跑)"
+fi
+# 面板表跟着 /etc/privdns-gateway 走(purge 模式一起删, 否则保留) —— 与 mosdns/mihomo
+# 配置同一个口径: 它是用户配置, 重装可复用。这里不单独处理。
+
 systemctl disable --now pdg-bot pdg-probe81 pdg-dotwitness mosdns mihomo pdg-mitm pdg-rules-update.timer pdg-health.timer 2>/dev/null || true
 [[ "$SB_OWNED" == 1 ]] && systemctl disable --now sing-box 2>/dev/null || true
 rm -f /etc/systemd/system/{pdg-bot,pdg-probe81,pdg-dotwitness,mosdns,mihomo,pdg-mitm,pdg-rules-update,pdg-health}.service \
@@ -156,6 +181,18 @@ if [[ -n "$_RESCUE_RESIDUE" ]]; then
 else
   echo "救援平面已完全移除(unit、凭据、状态、运行文件与 ${PDG_RESCUE_PORT} 放行规则)。"
 fi
+if [[ -z "$_LAN_RESIDUE" && -n "$_LAN_REMOVED" ]]; then
+  echo "内网面板已完全移除(反代 unit、出站白名单、配置与证书、caddy、专用用户)。"
+  # 单独点名凭据: 删证书和二进制是"卸载本来就该做的", 而删掉 DNS API token 与 acme
+  # 账户密钥意味着**证书续期从此不再进行**, 而且那两样是用户自己去服务商申请来的。
+  echo "  连同 DNS API 凭据与 acme 账户密钥一并删除 —— 已签发的证书到期即失效, 不会再续。"
+fi
+if [[ -n "$_LAN_RESIDUE" ]]; then
+  echo "⚠️  内网面板未能完全清除, 以下仍留在机器上(含 DNS API 凭据 / acme 账户密钥, 请手工删除):"
+  printf '%s\n' "$_LAN_RESIDUE" | tr ' ' '\n' | sed '/^$/d; s/^/    /'
+  _UNINSTALL_FAILED=1
+fi
+
 echo "保留: /etc/mosdns /etc/sing-box /etc/mihomo 与 Let's Encrypt 证书(配置与数据, 重装可复用)。"
 echo "已删除: /opt/pdg-bot 下的事务与救援运行模块(清单见 lib/modules.sh 的 PDG_RUNTIME_MODULES)。"
 # 说"全部"是不准的: install.sh 另有一路把 Bot 本体(bot.py)、MITM 组件、探测脚本等装进同一个


### PR DESCRIPTION
手机零 App 访问家里的内网面板 —— 设计文档里的**方案 B**。链路: 手机 →(SIM)→ 网关 → tailnet → 家里的设备。手机侧一个字都不用改, 它只是在访问一个"普通的 HTTPS 网站"。

设计与三道门见 `docs/design-lan-panels.md`。

## 三道门都写进了代码, 不只写进文档

**门一 · 子网路由重叠拒绝**(唯一的灾难级)。家里通告的网段一旦与网关正在用的段相交, 手机的分流数据面直接错乱, 而 nft / mosdns / mihomo 三份配置**一个字都没变** —— 只是包不走原来那条路了。所以判据必须在接受之前跑, 拒绝时点名是哪个网段与什么冲突。五条判据(默认路由 / 与 `PDG_INTERNAL_CIDR` 相交 / 与本机接口相交 / 与 tailnet 自身段相交 / 覆盖环回), 每条都配了空测。

**门二 · 反代只做白名单映射**。比设计文档多一条更严的要求: **上游必须写字面 IP, 不接受域名** —— 写域名的话决定网关去连哪台机器的是 DNS 而不是这份表, 而这台网关自己就在做 DNS 劫持。

**门三 · 出站白名单**(按 uid, 不按端口)。端口挡不住"别的进程发起同样的连接"。

**风险② 也写进了代码**: 面板域名与本项目 DoT 域名同 zone 时, 签面板证书的 DNS token **也能签发 DoT 域名** —— 那是权限升级而不只是多一个凭据。`pdg lan status` 每次都会说, 不是只写在文档第 7 节里等人去读。

## 有牙的验证

**门三, 真反代进程上**。同一请求、同一份 Caddyfile、同一个上游, 只改白名单:

| 白名单 | Caddy 报的错 |
|---|---|
| 含该上游 | `connect: connection refused`(放行了, 只是没人监听) |
| 不含 | `connect: no route to host`(被 admin-prohibited 挡了) |

**规则顺序, 两个容器走真 nft REDIRECT**(手机 → 网关 443 → mihomo redir-port → 嗅探 SNI):

| 顺序 | 结果 | mihomo 判定 |
|---|---|---|
| 面板规则在 REJECT 前 | HTTP 200 | `match DomainSuffix using DIRECT` |
| 在 REJECT 后 | HTTP 000 | `match IPCIDR(127.0.0.0/8) using REJECT` |

这条**推翻了最初的推理**: `no-resolve` 是"不要为这条规则发起 DNS 查询", **不是**"目的是域名时不匹配"。一旦 `hosts:` 给出了答案, IP 在匹配阶段就已知, REJECT 照样命中。MITM 的模式因此不能照抄 —— 它的域名没有 `hosts` 条目。

代价写进注释了: 这**绕过了面板域名的反自环保护**, 前提是门二禁止面板上游写环回地址。**那条判据一旦被放宽, 这里就会静默开一个自环的洞**, 两处要一起看。

## 过程中修掉的两个静默 bug

**bot.py 有两条渲染路径。**`_render_mihomo_bytes`(事务用)与 `_render_mihomo_file`(CLI 用, 直接调 `sb2mihomo`)。只改前者的后果: 事务那条路好好的, 从 CLI 重渲出来的配置里面板路由一条都没有, **而两边都报成功**。加了 AST 守卫 —— 而**第一版守卫是无效的**: 它写了"见到 `**kwargs` 就跳过", 而出问题那处调用正好带着 `**_panel_render_args(model)`, 口子恰好开在目标场景上。验牙时发现的。

**`tests/test-emergency-exit.py` 自己拼了一份 `paths`**, 是 `rescue.py:_tx_paths()` 的复制。少一个键的后果不是报错, 而是**救援渲染出来的配置悄悄丢掉所有面板路由** —— 正是"救援之后面板全打不开"这种查不出原因的现场。加了键集一致性断言。

## 供应链

Caddy 用**官方原版不带插件**(带插件要按 DNS 服务商各构建一个 46MB 二进制, 等于只支持一家)。上游发的校验和是 SHA-512 而本项目用 SHA-256, 所以钉进来的两个 sha256 是"**先用上游 SHA-512 校验下载物、确认无误之后再算的**", 不是对来路不明的文件算哈希盖章。acme.sh 按 **commit sha** 钉而不是 tarball 哈希 —— tag 可以被移动, commit sha 是内容寻址的; 自算 tarball 哈希只是 TOFU。

## 没有验过的(别当成验过了)

- **手机真的打开了面板** —— 整条链路端到端。要真实的 tailnet 子网路由 + 真实设备, 沙盒造不出来。上面验的全是"产物正确", 不是"链路通"。
- **ACL 越界探测**打在真 tailnet 上的表现(判据的三种读法有单元测试, 但没在真 ACL 上跑过)。
- **acme.sh 的真实签发**(容器里签不了 `.example.com`, 证书全是自签顶替)。证书装到位之后 Caddy 能读能握手 —— 这一段验过, 签发本身没有。
- **续期**(没有跨越 60 天验证过)。doctor 的证书项就是为这条不确定性存在的。

同样列在 `docs/design-lan-panels.md` 第 9 节。

## 兼容性

`lan_domains` 默认 `None` —— 不用这个功能时 mihomo 配置渲染结果**逐字节不变**, 既有 8 支渲染测试全绿。装机清单数量按项目惯例是钉死的, 两个平台各 +2(android 27→29, ios 33→35), 两处硬编码都改了并写明原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
