### PR TITLE
fix(lan): 上游回显本域名时, Location 里的端口要抹掉

### DIFF
--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -219,6 +219,23 @@ def render_caddy(cfg, certs_dir, bind="127.0.0.1"):
             if p.get("insecure_upstream"):
                 L.append("\t\t\ttls_insecure_skip_verify")
             L.append("\t\t}")
+        # 指向**本域名**却带着上游端口(或 http)的 Location, 无条件规范化。
+        #
+        # 上游只要遵从 Host 头就会这么干 —— Apache 的 UseCanonicalName Off 是默认行为,
+        # 它把 Host 原样回显、再补上自己实际监听的端口:
+        #     http://nas.example.com:30035/dir/
+        # 主机名是对的, 错的是 scheme 和端口。而反代只在 443 上, 客户端跟着跳必然到不了,
+        # 表现是浏览器卡在"服务器已停止响应"。真机上撞过: TrueNAS 的 WebDAV(Apache,
+        # 30035)对不带结尾斜杠的目录发 301, iPhone 跟过去就死在那儿。
+        #
+        # **不挂在 rewrite_location 后面**, 因为这条不需要用户判断: Location 指向本域名
+        # 却带上游端口, 对客户端永远是坏的, 不存在"用户可能想要"的情形。上面那条不一样 ——
+        # 改写上游 IP 是设备特性, 得由用户按设备确认。
+        #
+        # 端口段之后要求一个 `/` 收口: 少了它, `nas.example.com.evil.com` 也会被前缀匹配
+        # 吃进来。Location 总是带路径的, 这个要求不会漏掉真实情形。
+        L.append("\t\theader_down Location \"^https?://%s(:[0-9]+)?/\" \"https://%s/\""
+                 % (host_re, host))
         if p.get("rewrite_location"):
             # 设备会把自己的局域网 IP 写进 Location 跳转头(Zyxel 交换机、华为 UPS 实测)。
             # 不改写的话手机会跟着跳到一个到不了的地址。

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -77,11 +77,36 @@ assert t == [("192.168.1.50", 443), ("192.168.1.1", 8443)], t
 # 省略端口时按 scheme 取默认值 —— 防火墙要的是具体端口
 assert lp.targets(cfg(P(target="http://10.0.0.9"))) == [("10.0.0.9", 80)]
 
+import re as _re
+
 # ── ⑧ 生成: 改写指令只在被要求时出现(这是本文件最要紧的一组空测) ────────────
 plain = lp.render_caddy(cfg(P()), "/c")
-assert "header_down Location" not in plain, "没要求就不该改 Location"
 assert "header_up Referer" not in plain, "没要求就不该改 Referer"
 assert "redir" not in plain, "没要求就不该注入跳转"
+# 上游 IP 那条是设备特性, 要用户点名才加
+assert r"192\.168\.1\.50" not in plain, "没要求就不该改写指向上游 IP 的 Location"
+
+# ── ⑧b 指向**本域名**却带着上游端口的 Location, 必须无条件规范化 ──────────────
+# 上游若遵从 Host 头(Apache 的 UseCanonicalName Off 就是默认行为), 它回的 Location 长这样:
+#     http://nas.example.com:30035/dir/
+# 主机名已经是对的, 错的是 scheme 和端口 —— 而反代只在 443 上, 客户端跟着跳必然到不了。
+# 真机上撞过: TrueNAS 的 WebDAV(Apache, 跑在 30035)对不带结尾斜杠的目录发 301, iPhone
+# 跟过去卡死在"服务器已停止响应"。
+#
+# 这条**不挂在 rewrite_location 后面**: 指向本域名却带上游端口的 Location, 对客户端
+# 永远是坏的, 不存在"用户可能想要"的情形。上游 IP 那条不一样 —— 那是设备特性, 需要判断。
+for _src in (plain, lp.render_caddy(cfg(P(rewrite_location=True)), "/c")):
+    _hm = [m for m in _re.finditer(r'header_down Location "([^"]*)" "([^"]*)"', _src)
+           if "example" in m.group(1)]
+    assert _hm, "没有生成指向本域名的 Location 规范化规则:\n" + _src
+    _pat, _rep = _hm[0].group(1), _hm[0].group(2)
+    assert _pat.startswith("^https?://"), "要同时覆盖 http 与 https, 且锚在头部: " + _pat
+    assert "(:[0-9]+)?" in _pat, "要覆盖'带不带端口': " + _pat
+    assert r"\." in _pat, "域名里的点要转义, 否则匹配范围过大: " + _pat
+    assert _pat.rstrip("/").endswith("(:[0-9]+)?"), \
+        "端口段之后要跟 / 收口, 否则 nas.example.com.evil.com 也会被吃进来: " + _pat
+    assert _rep.startswith("https://") and ":" not in _rep[8:].rstrip("/"), \
+        "替换目标必须是不带端口的 https 形式: " + _rep
 
 loc = lp.render_caddy(cfg(P(rewrite_location=True)), "/c")
 assert "header_down Location" in loc
@@ -89,12 +114,11 @@ assert "header_up Referer" not in loc, "只要了 Location, 不该顺手改 Refe
 
 ref = lp.render_caddy(cfg(P(fix_referer=True)), "/c")
 assert "header_up Referer" in ref and "header_up Origin" in ref
-assert "header_down Location" not in ref
+assert r"192\.168\.1\.50" not in ref, "只要了 Referer, 不该顺手改写上游 IP 的 Location"
 # **必须是"替换"形式(两个参数), 不能是"设置"形式(一个参数)**。
 # 无条件设置会给本来没带 Referer 的请求(浏览器首次导航就不带)硬塞一个 —— 华为 UPS2000
 # 实测: 根路径不带 Referer 回 302, 带任何 Referer 都回 404。带不带端口没区别, 决定性的
 # 是"有没有凭空塞一个"。
-import re as _re
 _m = _re.search(r'header_up Referer "([^"]*)" "([^"]*)"', ref)
 assert _m, "Referer 不是替换形式(三参数): " + ref
 # **搜索式必须匹配任意 Referer**, 不能只匹配指向本域名的那种。
@@ -109,8 +133,13 @@ assert "@has_ref" not in ref and "header_up @" not in ref, "header_up 不该带 
 
 # Location 用一条正则覆盖 http/https 与带不带端口 —— 逐条字面替换总会漏一种,
 # 而漏掉的那种表现是手机跳到一个到不了的地址。
-_l = _re.search(r'header_down Location "([^"]*)"', loc)
-assert _l and _l.group(1).startswith("https?://") and "(:[0-9]+)?" in _l.group(1), \
+# 现在有两条 header_down Location: 本域名规范化(无条件, 见 ⑧b)与上游 IP 改写(要 flag)。
+# 这里只验后者, 所以按上游 IP 挑出来 —— 挑"第一条"会抓到前者, 判据就落空了。
+_l = [m for m in _re.finditer(r'header_down Location "([^"]*)"', loc)
+      if "192" in m.group(1)]
+assert _l, "没有生成针对上游 IP 的 Location 改写: " + loc
+_l = _l[0]
+assert _l.group(1).startswith("https?://") and "(:[0-9]+)?" in _l.group(1), \
     "Location 改写不是覆盖式正则: " + (loc)
 # 点要转义, 否则 `.` 会匹配任意字符, 改写范围比预期大
 assert r"192\.168\.1\.50" in _l.group(1), _l.group(1)


### PR DESCRIPTION
上游只要遵从 `Host` 头，就会把 Host 原样回显、再补上**自己实际监听的端口**：

```
http://nas.example.com:30035/dir/
```

主机名是对的，错的是 scheme 和端口。而反代只在 443 上，客户端跟着这个 Location 跳必然
到不了 —— 浏览器上表现为「服务器已停止响应」，卡住不动。

Apache 的 `UseCanonicalName Off` 就是默认行为，所以这不是个别设备的毛病，而是**一整类**：
凡是跑在非标准端口、又遵从 Host 头的上游都会这样。

真机上撞出来的是 TrueNAS 的 WebDAV（Apache 2.4，跑在 30035）：对不带结尾斜杠的目录发
301，iPhone 跟过去就死在那儿。**这个 bug 只有真人用浏览器才看得见** —— 服务端的所有
curl 测试我都习惯带结尾斜杠，永远触发不了那个跳转。

## 原有的 `--rewrite-location` 为什么接不住

那条正则锚的是**上游 IP**：

```
header_down Location "https?://192\.168\.1\.50(:[0-9]+)?" "https://nas.example.com"
```

家里那七台设备是把自己的局域网 IP 写进 Location（Zyxel 交换机、华为 UPS 实测），所以那条
管用。而 Apache 写的是**已经正确的主机名**加**错误的端口**，正则匹配不到。

代码注释里当初写过：

> 逐条穷举总会漏，而漏掉的那种表现是手机跳到一个到不了的地址。

预言应验了，只是漏的不是 http/https 或带不带端口，而是「上游回显 Host」这整一类形态。

## 改法

无条件再生成一条：

```
header_down Location "^https?://nas\.example\.com(:[0-9]+)?/" "https://nas.example.com/"
```

**不挂在 `rewrite_location` 后面**，因为这条不需要用户判断：Location 指向本域名却带着
上游端口，对客户端永远是坏的，不存在「用户可能想要」的情形。上游 IP 那条不一样 —— 改写
别人的地址是设备特性，得由用户按设备逐个确认。

端口段之后要求一个 `/` 收口：少了它，`nas.example.com.evil.com` 也会被前缀匹配吃进来。
Location 总是带路径的，这个要求不会漏掉真实情形。

## 测试

新增 ⑧b，对「有没有要 `rewrite_location`」两种情形都验这条规则存在，并逐项检查正则形态
（锚头部、覆盖 http/https、覆盖带不带端口、点转义、`/` 收口、替换目标不带端口）。

顺带修了两处**会以「通过」的方式失去意义**的旧判据：

- 空测从「没要求就不该有 `header_down Location`」改成「没要求就不该出现**上游 IP**」——
  前者已经不成立，而后者才是当初真正想守的东西；
- 有条断言按「第一条 `header_down Location`」取样，现在会抓到新加的那条，判据当场落空。
  改成按上游 IP 挑。

## 验证

- 判据**先红后绿**；移除新增的那一行，`test-lanpanel.py` 立刻转红（有牙）
- `caddy adapt` 通过 —— 语义层面，不只是语法。这点踩过坑：`header_up @matcher` 那次
  `caddy validate` 通过、`adapt` 才暴露问题
- 单元：`test-lanpanel` / `test-lan-wire` / `test-lan-doctor` / `test-lanroute` 全绿
- 全量回归：Python **134/137**、Shell **40/40**。三支红是已知的宿主环境假红（缺抓包权限、
  本机真跑着 tailscaled 导致 netns 撞名、以及前者的级联），在干净 root 容器里都是绿的，
  与本改动无关
- 静态门：ShellCheck（CI 原样）退出 0、`py_compile`、`git diff --check` 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
