### PR TITLE
fix(lan): 反代重载收成一个入口; doctor 对账 tailnet 直连端口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
       - name: "主防火墙重载的唯一入口(裸调会把内网面板白名单冲掉而不补回)"
         run: bash tests/test-lan-nft-chokepoint.sh
 
+      - name: "反代重载的唯一入口(admin off 下 reload 必败, 只生成不重启=进程用着旧的)"
+        run: bash tests/test-lan-proxy-reload-chokepoint.sh
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
       - name: "反代重载的唯一入口(admin off 下 reload 必败, 只生成不重启=进程用着旧的)"
         run: bash tests/test-lan-proxy-reload-chokepoint.sh
 
+      - name: "Location 改写: 真 Caddy 打真响应头(静态测试证明不了头被改了)"
+        run: bash tests/test-lan-location-live.sh
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -639,6 +639,10 @@ TAILSCALE_BIN = "/usr/bin/tailscale"
 # 包还装着的第二个凭据。Debian 12 上 tailscale 这个 deb 会放下 unit 文件, 它跟接口在不在
 # 完全无关 —— `tailscale down` 或 tailscaled 停着的时候, 它照样在。
 TAILSCALED_UNIT = "/lib/systemd/system/tailscaled.service"
+# Debian 12 的 tailscale 包把监听端口放在这里, unit 经 EnvironmentFile 传给
+# `tailscaled --port=${PORT}`。项目里 41641 是硬编码常量, 靠这份文件对账。
+TAILSCALED_DEFAULTS = "/etc/default/tailscaled"
+TAILNET_DIRECT_COMMENT = "pdg-tailnet-direct"
 
 
 def _tailscale_installed():
@@ -714,6 +718,60 @@ def check_tailscale_residue():
     if bad:
         return ("warn", name, "; ".join(bad))
     return ("ok", name, "没有 tailscale0, 也没有留下 src_valid_mark / 残留二进制")
+
+
+def check_tailnet_direct_port():
+    """放行的 UDP 端口与 tailscaled 实际监听的端口是否还对得上。
+
+    `pdg ssh-source tailnet` 会插一条 `udp dport 41641 accept comment "pdg-tailnet-direct"`。
+    41641 是官方默认值, 但**它是可配的** —— Debian 12 上来自 /etc/default/tailscaled 的
+    `PORT=`。项目里那个数字是硬编码常量, 从不读那份文件。
+
+    用户改了 PORT 之后, 这条放行**静默地双向失效**:
+      · 41641 那条没有监听者, 成了一个永远不会有人应答的陈旧洞;
+      · 真正的端口被 input 链的 policy drop 挡住。
+    于是 `pdg ssh-source` 当初要消除的冷启动窗口原样回来 —— 几小时没用 tailnet, 出事了
+    想连进去, 第一次 SSH 必超时。而从配置上完全看不出两者有关系。
+
+    判据只做**两份配置的对账**, 不发探测包: 端口通不通要发包才知道, 而"探不到"证明不了
+    任何事(同 check_deep_lan_acl 那条教训)。读文件是确定的。
+
+    读不到 /etc/default/tailscaled 就**无结论** —— 那可能是没装 Tailscale、或者不是 deb
+    装的。不猜, 也绝不判 fail: fail 会让 `pdg update` 的自检门整次回滚。
+    """
+    name = "Tailscale 直连端口对账"
+    try:
+        with open(NFT_CONF, encoding="utf-8") as f:
+            nft = f.read()
+    except OSError:
+        return None                       # 读不到防火墙配置, 别的判据会报, 这里不重复
+    m = re.search(r"udp\s+dport\s+(\d+)\s+accept\s+comment\s+\"%s\""
+                  % TAILNET_DIRECT_COMMENT, nft)
+    if not m:
+        return None                       # SSH 没收紧为 tailnet, 整项不适用
+    allowed = int(m.group(1))
+    try:
+        with open(TAILSCALED_DEFAULTS, encoding="utf-8") as f:
+            txt = f.read()
+    except OSError:
+        return ("ok", name,
+                "放行了 UDP %d; 读不到 %s, 没法跟 tailscaled 的实际端口对账(没装 Tailscale "
+                "或不是 deb 装的?), 本项无结论。" % (allowed, TAILSCALED_DEFAULTS))
+    pm = re.search(r"^\s*PORT\s*=\s*[\"']?(\d+)[\"']?", txt, re.M)
+    if not pm:
+        return ("ok", name,
+                "放行了 UDP %d; %s 里没有 PORT= 这一行, 无从对账。"
+                % (allowed, TAILSCALED_DEFAULTS))
+    actual = int(pm.group(1))
+    if actual == allowed:
+        return ("ok", name, "放行的 UDP %d 与 tailscaled 的监听端口一致。" % allowed)
+    return ("warn", name,
+            "防火墙放行的是 UDP %d, 但 %s 里写的是 PORT=%d —— 两边对不上。"
+            "于是 %d 那条成了没有监听者的陈旧放行, 而真正在用的 %d 被 input 链丢掉。"
+            "后果是 `pdg ssh-source tailnet` 本来要消除的冷启动窗口又回来了: 空闲一段之后"
+            "第一次 SSH 会超时。要么把 PORT 改回 %d, 要么跑一次 `pdg ssh-source tailnet` "
+            "让放行跟上(它目前只认 %d, 改端口的话需要手工调 /etc/nftables.conf 里那一行)。"
+            % (allowed, TAILSCALED_DEFAULTS, actual, allowed, actual, allowed, allowed))
 
 
 def _filesha(path):
@@ -2093,7 +2151,7 @@ def check_deep_lan_acl():
 
 ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
-       check_tailscale_isolation, check_tailscale_residue,
+       check_tailscale_isolation, check_tailscale_residue, check_tailnet_direct_port,
        check_lan_routes, check_lan_whitelist, check_lan_cert,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_rescue_firewall, check_geosite_db, check_mem,

--- a/deploy/bot/lanpanel.py
+++ b/deploy/bot/lanpanel.py
@@ -232,9 +232,17 @@ def render_caddy(cfg, certs_dir, bind="127.0.0.1"):
         # 却带上游端口, 对客户端永远是坏的, 不存在"用户可能想要"的情形。上面那条不一样 ——
         # 改写上游 IP 是设备特性, 得由用户按设备确认。
         #
-        # 端口段之后要求一个 `/` 收口: 少了它, `nas.example.com.evil.com` 也会被前缀匹配
-        # 吃进来。Location 总是带路径的, 这个要求不会漏掉真实情形。
-        L.append("\t\theader_down Location \"^https?://%s(:[0-9]+)?/\" \"https://%s/\""
+        # 端口段之后必须有个**边界**, 否则 `nas.example.com.evil.com` 会被前缀匹配吃进来。
+        #
+        # 边界是 `/` `?` `#` 或**字符串结尾**四选一, 不能只认 `/`。RFC 3986 里 authority
+        # 之后可以直接跟 query、fragment, 或者干脆到此为止 —— `http://HOST:30035` 是完全
+        # 合法的 Location。早先只认 `/`, 理由写的是"Location 总是带路径" —— 那是拍脑袋的
+        # 断言不是事实, 于是无路径 / 直接跟 `?` / 直接跟 `#` 三种形态全漏, 而静态测试对此
+        # 一路绿灯。补这一条的同时新增了 tests/test-lan-location-live.sh: 起真 Caddy、打真
+        # 响应头, 因为"生成的文本长这样"和"头真的被改了"是两回事。
+        #
+        # 边界那一段要**原样带回**替换结果, 所以用 $2 引回去 —— 少了它 `?x=1` 会被吃掉。
+        L.append("\t\theader_down Location \"^https?://%s(:[0-9]+)?(/|\\?|#|$)\" \"https://%s$2\""
                  % (host_re, host))
         if p.get("rewrite_location"):
             # 设备会把自己的局域网 IP 写进 Location 跳转头(Zyxel 交换机、华为 UPS 实测)。

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5181,7 +5181,7 @@ _lan_cert(){
   fi
   if ! "$ACME_HOME/acme.sh" --home "$ACME_HOME/data" --install-cert -d "$primary" --ecc \
         --fullchain-file "$LAN_CERT_DIR/panel.crt" --key-file "$LAN_CERT_DIR/panel.key" \
-        --reloadcmd "systemctl reload pdg-lan 2>/dev/null || true"; then
+        --reloadcmd "systemctl restart pdg-lan"; then
     c_y "❌ 证书装不到 $LAN_CERT_DIR/panel.* —— 上面是 acme.sh 给的原因。"
     return 1
   fi
@@ -5292,6 +5292,27 @@ _lan_cert_missing(){
 #
 # 证书**不自动重签**: 那要 DNS 凭据、会打网络、有速率限制。但必须当场说 —— 不说的话新面板
 # 在手机上是证书错误, 而用户手里拿着一句"✅ 已加入面板表"。
+# 让反代真正用上刚生成的东西 —— **反代重载的唯一入口**。
+#
+# **必须 restart, 不能 reload。**两个原因叠在一起, 缺一都以为 reload 能用:
+#   · 出站白名单(门三)是靠 unit 的 ExecStartPre 加载进内核的, 而 reload 只跑 ExecReload;
+#   · 生成的 caddy.conf 里是 `admin off`(刻意的, 不该为了重载去开 2019 端口), 而
+#     ExecReload 是 `caddy reload --config …` —— 那条命令走 admin API, 于是**必败**:
+#         Post "http://localhost:2019/load": connect: connection refused
+#
+# 不重启的后果是"磁盘对了、进程没跟上", 而且没有任何提示。真机上撞过两次:
+#   · 加面板后文件 5 条、内核 4 条 —— 那个面板 502;
+#     删面板那个方向更危险: 内核里多一条, **反代仍能连到已经移除的设备**, 门三形同虚设;
+#   · `pdg lan render` 重新生成了配置却不重启, pdg-lan 停在 9 小时前, 新规则没进内存。
+#
+# 没在跑就什么都不做 —— 那是"还没 enable", 不是故障。
+_lan_apply_proxy(){
+  systemctl is-active --quiet pdg-lan 2>/dev/null || return 0
+  systemctl restart pdg-lan >/dev/null 2>&1 && return 0
+  c_y "⚠️ pdg-lan 重启失败 —— 新的反代配置与出站白名单都还没生效。"
+  return 1
+}
+
 _lan_sync_after_change(){
   local on active
   on="$(_lan_intent)"; active=0
@@ -5302,15 +5323,7 @@ _lan_sync_after_change(){
   fi
   _lan_render || { c_y "⚠️ 反代配置/白名单没能重新生成 —— 新面板还不会生效。"; return 1; }
   _lan_wire   || { c_y "⚠️ DNS 劫持集/分流没能同步 —— 新面板还不会生效。"; return 1; }
-  # **必须 restart, 不能 reload。**出站白名单是靠 unit 的 ExecStartPre 加载进内核的,
-  # 而 reload 只跑 ExecReload —— 于是文件写了新的、内核里还是旧的。
-  # 两个方向都出事, 而且删面板那个方向更危险:
-  #   加面板 → 内核里少一条 → 那个面板 502 打不开(doctor 的白名单漂移检查会报);
-  #   删面板 → 内核里多一条 → **反代仍能连到已经移除的设备**, 门三形同虚设。
-  # 真机上撞过: 加完之后文件 5 条、内核 4 条。
-  if systemctl is-active --quiet pdg-lan 2>/dev/null; then
-    systemctl restart pdg-lan >/dev/null 2>&1 || c_y "⚠️ pdg-lan 重启失败 —— 新的白名单还没进内核。"
-  fi
+  _lan_apply_proxy || true   # 已经自己报过原因了, 不因此中断后面的证书提示
   c_g "✅ 反代配置、出站白名单、DNS 劫持集与分流已同步。"
   local miss; miss="$(_lan_cert_missing)"
   if [[ -n "$miss" ]]; then
@@ -5593,7 +5606,9 @@ cmd_lan(){
     cert)      need_root lan; _lan_cert "${1:-}" "${2:-}";;
     render)    need_root lan
                _lan_render || return 1
-               c_g "✅ 反代配置与出站白名单已按面板表重新生成。"
+               # 只生成不重启 = 文件是新的、进程还用着旧的。撞过一次, 见 _lan_apply_proxy。
+               _lan_apply_proxy || true
+               c_g "✅ 反代配置与出站白名单已按面板表重新生成并生效。"
                _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;
     wire)      need_root lan; _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;
     purge)     _lan_purge "${1:-}";;

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -3580,6 +3580,7 @@ run_all_migrations(){
   # 唯一"失败必须传出"的迁移 —— 失败即让 __migrate 返回非0,
   # cmd_update 据此回滚到更新前快照(其余迁移都是幂等自愈, 失败 best-effort 吞掉不挡后续)。
   migrate_drop_singbox || rc=1
+  migrate_lan_caddy_reender || true   # 存量机器的反代配置跟上生成器(失败不拖垮更新)
   return $rc
 }
 
@@ -5451,6 +5452,34 @@ LAN_HIJACK_FILE="/etc/mosdns/rules/lan_hijack.txt"
 # 域名"完全一样 —— 抑制 AAAA/HTTPS、A 记录劫持到网关, 剩下的交给 mihomo 按 SNI 分流。
 # 另造一条一模一样的序列只会多一处要同步的地方。
 #
+# 生成器改了、而磁盘上还是旧版渲染出来的 caddy.conf → 重渲一次。
+#
+# 为什么需要它: `pdg update` 只刷新代码, 不碰 /etc/pdg-lan/caddy.conf —— 那是**持久配置**,
+# 由 lanpanel.py 在"加/删面板"时生成。于是生成器修好了 bug, 存量机器却继续用着旧规则,
+# 而且**一切自检都是绿的**(面板表、白名单、证书都对, 错的只是反代的一条改写规则)。
+# v1.10.13 修 Location 端口那次就是这样: 两台线上是我手工跑 `pdg lan render` 才生效的,
+# 按发布包正常升级的机器一个都没修上。
+#
+# 判据取"**生成物里有没有新形态**", 不取版本号 —— 版本号判据下次改生成器就过期, 而且
+# 会漏掉"降级又升级"这类路径。这里认的是 Location 改写那条规则的边界写法。
+#
+# 只在面板已启用、且 caddy.conf 确实存在时动。重渲走 _lan_render(它自带 caddy validate,
+# 不合法就拒绝落盘、现网不动), 之后必须 _lan_apply_proxy —— 只生成不重启等于没改。
+migrate_lan_caddy_reender(){
+  [[ -f "$LAN_CADDYFILE" ]] || return 0                  # 没启用过面板 → 不适用
+  [[ -s "$LAN_TABLE_PATH" ]] || return 0                 # 面板表空 → 没什么可渲
+  # 新形态: Location 改写的边界是 (/|\?|#|$) 四选一。旧版只有一个 `/`。
+  grep -q 'header_down Location "\^https?://.*(/|\\?|#|\$)"' "$LAN_CADDYFILE" && return 0
+  c_g "  [面板迁移] 反代配置是旧版生成器渲染的, 重新生成…"
+  if ! _lan_render; then
+    c_y "  [面板迁移] 重渲失败 —— 现网配置未动, 面板仍可用但 Location 改写还是旧规则。"
+    c_y "             手工补救: sudo pdg lan render"
+    return 0                                             # 不拖垮整次更新: 旧规则只影响个别上游
+  fi
+  _lan_apply_proxy || true
+  c_g "  [面板迁移] 已重新生成并生效。"
+}
+
 # 幂等; 只认本项目的标准形态; 备份 → 生成 → 校验 → 失败还原。$1 可指定文件(供测试)。
 # shellcheck disable=SC2120
 migrate_mosdns_lan(){

--- a/tests/negctl/tailnet-direct-port-drift.py
+++ b/tests/negctl/tailnet-direct-port-drift.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""负控: 放行的 UDP 端口跟 tailscaled 实际监听的端口对不上时, doctor 必须报出来。
+
+`pdg ssh-source tailnet` 会往 input 链插一条
+
+    udp dport 41641 accept comment "pdg-tailnet-direct"
+
+41641 是 Tailscale 的官方默认端口, 但**它是可配的**。Debian 12 上端口来自
+`/etc/default/tailscaled` 的 `PORT=`, unit 经 `EnvironmentFile` 把它传给
+`tailscaled --port=${PORT}`。项目里 41641 是**硬编码常量, 从不读那个文件**。
+
+用户改了 `PORT=` 之后, 这条放行就静默地双向失效:
+
+    41641 那条  → 没有监听者, 成了一个永远不会有人应答的陈旧洞;
+    真正的端口  → 被 input 链的 policy drop 挡住。
+
+后果是 `pdg ssh-source` 当初要消除的**冷启动窗口原样回来** —— 几小时没用 tailnet,
+出事了想连进去, 第一次 SSH 必超时。而配置上完全看不出这两件事有关系: nft 里那条规则
+好端端地写着 accept, `/etc/default/tailscaled` 里也好端端地写着另一个端口。
+
+这支负控盯的是"两份配置的一致性", 不是"端口能不能连" —— 后者要发包, 而且**探不到证明
+不了任何事**(见 lan-acl-false-green.py 的同类教训)。读文件是确定的, 发包不是。
+"""
+import importlib.util
+import io
+import os
+import sys
+import builtins
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
+C = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(C)
+
+PASS, FAIL = [0], [0]
+def ok(m):  PASS[0] += 1; print("  ✓ %s" % m)
+def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
+
+_open, _exists = builtins.open, os.path.exists
+
+NFT_WITH = 'table inet pdg {\n chain input {\n  udp dport %d accept comment "pdg-tailnet-direct"\n }\n}\n'
+NFT_NONE = 'table inet pdg {\n chain input {\n  tcp dport { 22 } accept\n }\n}\n'
+
+
+def run(nft, defaults):
+    """nft: /etc/nftables.conf 的内容; defaults: /etc/default/tailscaled 的内容(None=不存在)"""
+    def fo(p, *a, **k):
+        p = str(p)
+        if p == C.NFT_CONF:
+            if nft is None:
+                raise OSError(2, "No such file")
+            return io.StringIO(nft)
+        if p == getattr(C, "TAILSCALED_DEFAULTS", "/etc/default/tailscaled"):
+            if defaults is None:
+                raise OSError(2, "No such file")
+            return io.StringIO(defaults)
+        return _open(p, *a, **k)
+
+    def fe(p):
+        p = str(p)
+        if p == getattr(C, "TAILSCALED_DEFAULTS", "/etc/default/tailscaled"):
+            return defaults is not None
+        return _exists(p)
+
+    builtins.open, os.path.exists = fo, fe
+    try:
+        fn = getattr(C, "check_tailnet_direct_port", None)
+        if fn is None:
+            return ("__MISSING__", "", "判据函数不存在")
+        # 返回 None = "整项不适用"。统一成三元组, 免得每个断言都要先判空。
+        return fn() or (None, "", "(不适用)")
+    finally:
+        builtins.open, os.path.exists = _open, _exists
+
+
+# ── ① 判据得先存在, 而且接进 doctor ─────────────────────────────────────────
+fn = getattr(C, "check_tailnet_direct_port", None)
+if fn is None:
+    bad("checks.py 里没有 check_tailnet_direct_port —— 整支负控无从谈起")
+else:
+    ok("判据函数存在")
+    if fn in getattr(C, "ALL", []):
+        ok("已接进 checks.ALL(doctor 会真的跑它)")
+    else:
+        bad("没接进 checks.ALL —— 写了也不会被执行")
+
+# ── ② 端口一致 → ok ────────────────────────────────────────────────────────
+r = run(NFT_WITH % 41641, 'PORT="41641"\nFLAGS=""\n')
+if r[0] == "ok":
+    ok("nft 41641 + PORT=41641 → ok")
+else:
+    bad("两边一致却判成了 %r: %s" % (r[0], r[2][:80]))
+
+# ── ③ 端口漂移 → 必须报出来, 而且要把两个数字都说出来 ──────────────────────
+r = run(NFT_WITH % 41641, 'PORT="45678"\n')
+if r[0] in ("warn", "fail"):
+    ok("nft 41641 + PORT=45678 → %s" % r[0])
+else:
+    bad("端口对不上却判成了 %r —— 冷启动窗口会静默回来" % (r[0],))
+if "41641" in r[2] and "45678" in r[2]:
+    ok("文案里两个端口都点了名")
+else:
+    bad("文案没同时给出两个端口, 用户不知道该改哪个: %r" % r[2][:100])
+
+# ── ④ 没收紧 SSH(nft 里没那条放行) → 整项不适用, 不能报警 ───────────────────
+r = run(NFT_NONE, 'PORT="45678"\n')
+if r[0] is None or r[0] == "ok":
+    ok("没放行 41641(SSH 未收紧) → 不适用/ok, 不平白报警")
+else:
+    bad("SSH 没收紧却报了 %r —— 每台没用这功能的机器都会多一条灯" % (r[0],))
+
+# ── ⑤ 读不到 /etc/default/tailscaled → 无结论, 不许猜 ──────────────────────
+r = run(NFT_WITH % 41641, None)
+if r[0] in ("ok", "warn", None):
+    ok("读不到 tailscaled 默认值 → %r(不猜)" % (r[0],))
+else:
+    bad("读不到配置却下了结论: %r" % (r[0],))
+if r[0] == "fail":
+    bad("读不到就判 fail —— 那会让没装 Tailscale 的机器升级失败")
+
+# ── ⑥ PORT 有空格/单引号等写法也要认 ───────────────────────────────────────
+for txt, label in (("PORT=45678\n", "无引号"),
+                   ("PORT='45678'\n", "单引号"),
+                   ("  PORT = \"45678\"  \n", "带空格")):
+    r = run(NFT_WITH % 41641, txt)
+    if r[0] in ("warn", "fail"):
+        ok("%s 写法也认得出漂移" % label)
+    else:
+        bad("%s 写法没认出来(判成 %r) —— 解析太脆" % (label, r[0]))
+
+print("─" * 60)
+print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-lan-location-live.sh
+++ b/tests/test-lan-location-live.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 反代对 Location 头的改写 —— **真 Caddy、真 HTTP 响应头**。
+#
+# 为什么要有这一支: 原来只有静态测试(检查生成出来的 Caddyfile 文本)加 `caddy adapt`。
+# 前者只证明"字符串长这样", 后者只证明"配置能解析" —— **两者都不证明响应头真的被改了**。
+# 代价是实打实的: v1.10.13 那条规则要求主机名后必须跟 `/`, 于是
+#     http://HOST:30035        (无路径)
+#     http://HOST:30035?x=1    (直接跟 query)
+#     http://HOST:30035#frag   (直接跟 fragment)
+# 三种合法形态全部漏掉 —— 而静态测试对此一路绿灯。RFC 3986 里 authority 之后可以直接是
+# `?`、`#` 或字符串结尾, "Location 总是带路径"是当初拍脑袋写进注释的断言, 不是事实。
+#
+# 判据的取样方式也是刻意的: **从 lanpanel.py 现场生成的配置里抠出那一行**, 不手抄。
+# 手抄的那份迟早跟生成器分家, 而分家的方向恰恰是"测试还绿着、线上已经不对"。
+#
+# caddy 不在就地下载(版本与 SHA256 沿用 lib/versions.sh 那一套, 不另立信任链)。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+ok(){  echo "[OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+WD="$(mktemp -d -t pdg-loclive-XXXXXX)"
+CADDY=""
+cleanup(){
+  [[ -n "${STUB_PID:-}" ]] && kill "$STUB_PID" 2>/dev/null
+  [[ -n "${CADDY_PID:-}" ]] && kill "$CADDY_PID" 2>/dev/null
+  rm -rf "$WD"
+}
+trap cleanup EXIT
+
+# ── 取 caddy ────────────────────────────────────────────────────────────────
+if [[ -x /usr/local/bin/caddy ]]; then
+  CADDY=/usr/local/bin/caddy
+elif command -v caddy >/dev/null 2>&1; then
+  CADDY="$(command -v caddy)"
+else
+  # shellcheck source=lib/versions.sh
+  source "$ROOT/lib/versions.sh" 2>/dev/null || { bad "读不到 lib/versions.sh"; exit 1; }
+  arch="$(uname -m)"; case "$arch" in x86_64) arch=amd64;; aarch64) arch=arm64;; esac
+  url="https://github.com/caddyserver/caddy/releases/download/${CADDY_VER}/caddy_${CADDY_VER#v}_linux_${arch}.tar.gz"
+  if curl -fsSL --max-time 120 -o "$WD/caddy.tgz" "$url" 2>/dev/null \
+     && pdg_verify_sha256 "$WD/caddy.tgz" "${PDG_SHA256[caddy-$arch]:-}" "caddy $CADDY_VER" >/dev/null 2>&1 \
+     && tar -xzf "$WD/caddy.tgz" -C "$WD" caddy 2>/dev/null; then
+    CADDY="$WD/caddy"; chmod +x "$CADDY"
+  else
+    bad "拿不到 caddy(下载或校验失败) —— 这支测的就是真 Caddy 的行为, 不能跳过"
+    exit 1
+  fi
+fi
+ok "caddy 可用: $($CADDY version 2>/dev/null | head -1)"
+
+# ── 从生成器现场取那条指令 ──────────────────────────────────────────────────
+HOST="nas.example.test"
+DIRECTIVE="$(python3 - "$ROOT" "$HOST" <<'PY'
+import importlib.util, json, sys
+root, host = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("lp", root + "/deploy/bot/lanpanel.py")
+lp = importlib.util.module_from_spec(spec); spec.loader.exec_module(lp)
+cfg = {"panels": [{"name": "nas", "host": host,
+                   "target": "http://192.168.77.9:30035"}]}
+for line in lp.render_caddy(cfg, "/etc/pdg-lan/certs").splitlines():
+    if "header_down Location" in line and host in line:
+        print(line.strip()); break
+PY
+)"
+if [[ -z "$DIRECTIVE" ]]; then
+  bad "lanpanel.py 没有为本域名生成 header_down Location —— 判据取样失败"
+  exit 1
+fi
+ok "取到生成器的指令: $DIRECTIVE"
+
+# ── 桩上游: 按 query 回不同的 Location ──────────────────────────────────────
+cat > "$WD/stub.py" <<'PY'
+import http.server, urllib.parse
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        q = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+        self.send_response(301)
+        self.send_header("Location", q.get("loc", [""])[0])
+        self.send_header("Content-Length", "0"); self.end_headers()
+    def log_message(self, *a): pass
+http.server.HTTPServer(("127.0.0.1", 18901), H).serve_forever()
+PY
+cat > "$WD/Caddyfile" <<EOF
+{
+	admin off
+	auto_https off
+}
+http://127.0.0.1:18900 {
+	reverse_proxy http://127.0.0.1:18901 {
+		$DIRECTIVE
+	}
+}
+EOF
+python3 "$WD/stub.py" >/dev/null 2>&1 & STUB_PID=$!
+"$CADDY" run --config "$WD/Caddyfile" --adapter caddyfile >"$WD/caddy.log" 2>&1 & CADDY_PID=$!
+for _ in $(seq 1 40); do
+  ss -ltn 2>/dev/null | grep -q 18900 && ss -ltn 2>/dev/null | grep -q 18901 && break
+  sleep 0.25
+done
+if ! ss -ltn 2>/dev/null | grep -q 18900; then
+  bad "caddy 没起来:"; tail -3 "$WD/caddy.log" | sed 's/^/    /'; exit 1
+fi
+ok "测试台起来了(桩 18901 ← caddy 18900)"
+
+probe(){   # $1=上游发的 Location  → stdout: 反代给出的 Location
+  local q; q="$(python3 -c 'import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1")"
+  curl -s -o /dev/null -D - --max-time 8 "http://127.0.0.1:18900/?loc=$q" 2>/dev/null \
+    | grep -i '^location:' | tr -d '\r' | sed 's/^[Ll]ocation: //'
+}
+
+# ── 该被改写的: 指向本域名, 但 scheme/端口不对 ─────────────────────────────
+while IFS='|' read -r src want label; do
+  [[ -z "$src" ]] && continue
+  got="$(probe "$src")"
+  if [[ "$got" == "$want" ]]; then ok "$label: $src → $got"
+  else bad "$label: $src → 得到 '${got:-（空）}', 期望 '$want'"; fi
+done <<EOF
+http://$HOST:30035/dir/|https://$HOST/dir/|带路径
+http://$HOST:30035|https://$HOST|无路径
+http://$HOST:30035?x=1|https://$HOST?x=1|直接跟 query
+http://$HOST:30035#frag|https://$HOST#frag|直接跟 fragment
+http://$HOST/dir/|https://$HOST/dir/|只是 scheme 不对
+http://$HOST|https://$HOST|无路径且无端口
+EOF
+
+# ── 不该被碰的 ─────────────────────────────────────────────────────────────
+while IFS='|' read -r src label; do
+  [[ -z "$src" ]] && continue
+  got="$(probe "$src")"
+  if [[ "$got" == "$src" ]]; then ok "$label 原样放行: $src"
+  else bad "$label 被误改: $src → $got"; fi
+done <<EOF
+http://$HOST.evil.test/x|同前缀的别的域名
+https://$HOST/ok|本来就正确的
+http://other.example.test:30035/x|别的域名
+EOF
+
+echo "─────────────────────────────────────────────"
+echo "通过 $PASS, 失败 $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test-lan-proxy-reload-chokepoint.sh
+++ b/tests/test-lan-proxy-reload-chokepoint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 反代(pdg-lan)的重新加载必须只走 _lan_apply_proxy 这**一个入口**, 而且必须是
+# `systemctl restart`, 不能是 `reload`。
+#
+# 为什么不能 reload: 生成的 caddy.conf 全局块里是 `admin off`(刻意的 —— 不该为了重载
+# 去开 2019 端口), 而 unit 的 ExecReload 是 `caddy reload --config …`, 那条命令**走
+# admin API**。于是 reload 必然失败:
+#     Post "http://localhost:2019/load": connect: connection refused
+# 而出站白名单又是靠 unit 的 ExecStartPre 加载进内核的, reload 根本不跑它。
+#
+# 两次真机事故都出在这条上:
+#   ① acme 的 --reloadcmd 写的是 `systemctl reload pdg-lan 2>/dev/null || true` ——
+#      `|| true` 把失败吞了, acme.sh 照样打印 "Reload successful"。后果不在当天:
+#      **续期时新证书落盘、Caddy 内存里还是旧的**, 一直用到过期那天所有面板一起报错,
+#      全程零告警。
+#   ② `pdg lan render` 重新生成了配置却不重启 —— 2026-08-24 撞上: 文件是新的、
+#      pdg-lan 还停在 9 小时前, 新规则没进内存, 手工重启才生效。
+#
+# 这两处的共同形态是"磁盘对了、进程没跟上"。守卫盯的就是这个形态。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+F="$ROOT/deploy/bot/pdg.sh"
+PASS=0; FAIL=0
+ok(){  echo "[OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# ── ① 入口存在, 且用的是 restart ─────────────────────────────────────────────
+if grep -q '^_lan_apply_proxy(){' "$F"; then
+  ok "入口函数 _lan_apply_proxy 存在"
+else
+  bad "找不到 _lan_apply_proxy —— 守卫失效(没写? 被改名?)"
+fi
+
+if sed -n '/^_lan_apply_proxy()/,/^}/p' "$F" | grep -q 'systemctl restart pdg-lan'; then
+  ok "入口里是 restart(白名单靠 ExecStartPre 进内核, reload 不跑它)"
+else
+  bad "入口里没有 systemctl restart pdg-lan"
+fi
+
+# ── ② 全文不许出现 reload pdg-lan ────────────────────────────────────────────
+# admin off + ExecReload 走 admin API = reload 必败。写了就是错的, 不分场合。
+hits="$(grep -nE 'systemctl +reload +pdg-lan' "$F" || true)"
+if [[ -z "$hits" ]]; then
+  ok "全文没有 systemctl reload pdg-lan"
+else
+  bad "这些地方还在 reload(admin off 下必败):"
+  printf '%s\n' "$hits" | sed 's/^/    /'
+fi
+
+# ── ③ acme 的 reloadcmd: 必须 restart, 且不许吞失败 ──────────────────────────
+rc="$(grep -n -- '--reloadcmd' "$F" || true)"
+if [[ -z "$rc" ]]; then
+  bad "找不到 --reloadcmd —— 判据失效"
+else
+  if grep -q -- '--reloadcmd "systemctl restart pdg-lan"' "$F"; then
+    ok "acme reloadcmd 是 restart 且没有额外修饰"
+  else
+    bad "acme reloadcmd 形态不对:"; printf '%s\n' "$rc" | sed 's/^/    /'
+  fi
+  if printf '%s' "$rc" | grep -q '|| *true'; then
+    bad "acme reloadcmd 里还有 \`|| true\` —— 它会把失败吞成成功"
+  else
+    ok "acme reloadcmd 没有 \`|| true\`"
+  fi
+fi
+
+# ── ④ 写 caddy.conf 的路径都要接上入口 ───────────────────────────────────────
+# _lan_render 只负责生成; 调它的每个地方都必须跟一次 _lan_apply_proxy。
+callers="$(grep -nE '(^|[^_a-zA-Z])_lan_render' "$F" | grep -v '^\s*[0-9]*:_lan_render()' || true)"
+n_call="$(printf '%s' "$callers" | grep -c . || true)"
+n_apply="$(grep -cE '(^|[^_a-zA-Z])_lan_apply_proxy' "$F" || true)"
+if [[ "$n_apply" -ge 2 ]]; then
+  ok "_lan_apply_proxy 有定义之外的调用点($n_apply 处引用)"
+else
+  bad "_lan_apply_proxy 没有被任何地方调用($n_apply 处引用) —— 写了等于没写"
+fi
+echo "       (参考: _lan_render 的调用点 $n_call 处)"
+
+# ── ⑤ 空测: 判据要认得出坏形态, 否则它永远绿 ─────────────────────────────────
+if grep -qE 'systemctl +reload +pdg-lan' <<<'  systemctl reload pdg-lan 2>/dev/null || true'; then
+  ok "反向对照: 判据认得出 reload 这一形态"
+else
+  bad "判据本身失效 —— 连一行明显的 reload 都匹配不到"
+fi
+
+echo "─────────────────────────────────────────────"
+echo "通过 $PASS, 失败 $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test-lanpanel.py
+++ b/tests/test-lanpanel.py
@@ -103,9 +103,17 @@ for _src in (plain, lp.render_caddy(cfg(P(rewrite_location=True)), "/c")):
     assert _pat.startswith("^https?://"), "要同时覆盖 http 与 https, 且锚在头部: " + _pat
     assert "(:[0-9]+)?" in _pat, "要覆盖'带不带端口': " + _pat
     assert r"\." in _pat, "域名里的点要转义, 否则匹配范围过大: " + _pat
-    assert _pat.rstrip("/").endswith("(:[0-9]+)?"), \
-        "端口段之后要跟 / 收口, 否则 nas.example.com.evil.com 也会被吃进来: " + _pat
-    assert _rep.startswith("https://") and ":" not in _rep[8:].rstrip("/"), \
+    # 端口段之后必须有边界, 否则 nas.example.com.evil.com 会被前缀吃进来。
+    # 但边界不能只认 `/` —— RFC 3986 里 authority 之后可以直接跟 `?`、`#`, 或到此为止,
+    # `http://HOST:30035` 是完全合法的 Location。只认 `/` 会漏掉那三种形态, 而这条静态
+    # 断言当初就是这么写的、一路绿灯。真正的判据在 tests/test-lan-location-live.sh:
+    # 起真 Caddy 打真响应头 —— "文本长这样"和"头真的被改了"是两回事。
+    _bound = r"(/|\?|#|$)"
+    assert _pat.endswith(_bound), "端口段之后的边界要覆盖 / ? # 与字符串结尾四种: " + _pat
+    assert "(:[0-9]+)?" + _bound in _pat, "边界要紧跟在端口段之后: " + _pat
+    # 边界那一段要原样带回替换结果, 否则 `?x=1` 会被吃掉。
+    assert _rep.endswith("$2"), "替换目标要用 $2 把边界带回来: " + _rep
+    assert _rep.startswith("https://") and ":" not in _rep[8:-2], \
         "替换目标必须是不带端口的 https 形式: " + _rep
 
 loc = lp.render_caddy(cfg(P(rewrite_location=True)), "/c")


### PR DESCRIPTION
两处「磁盘对了、进程没跟上」，外加一条防止同类问题静默发生的对账判据。都是这两天真机
上撞出来的，不是读代码想出来的。

## ① 反代重载：`reload` 在这套配置下永远失败

`systemctl reload pdg-lan` 必败，两个原因叠在一起：

- 生成的 `caddy.conf` 里是 `admin off`（刻意的——不该为了重载去开 2019 端口），而 unit 的
  `ExecReload` 是 `caddy reload --config …`，那条命令**走 admin API**：
  `Post "http://localhost:2019/load": connect: connection refused`
- 出站白名单（门三）是靠 unit 的 `ExecStartPre` 加载进内核的，`reload` 根本不跑它

两次事故：

**acme 的 `--reloadcmd`** 写的是 `systemctl reload pdg-lan 2>/dev/null || true`。那个
`|| true` 把失败吞成成功，acme.sh 照样打印 `Reload successful`。平时不发作，是因为
`pdg lan add/rm` 会顺手重启；**只有「纯续期、没人改面板」这条路径中招——而那正是它无人
值守跑的常态**。后果是新证书落盘、Caddy 内存里还是旧的，一直用到过期那天所有面板一起
报证书错误，全程零告警。jp2 的 ARI 窗口把下次续期定在 2026-10-23 前后。

**`pdg lan render`** 重新生成配置却不重启。2026-08-24 撞上：`caddy.conf` 是 00:48 的、
`pdg-lan` 还停在 9 小时前，v1.10.13 刚发的 Location 改写规则没进内存，手工重启才生效。

修法是把重启收成 `_lan_apply_proxy` 一个入口（与 `_nft_apply_main` 同一思路），三处调用
点都接上，acme 的 reloadcmd 换成 `systemctl restart pdg-lan` 并去掉 `|| true`。

守卫盯四件事：入口存在且用 restart、全文不许出现 `reload pdg-lan`、acme 的 reloadcmd
形态、入口要有真实调用点；外加一条空测——判据得认得出 `reload` 这一形态，否则它永远绿。

## ② tailnet 直连端口对账

`pdg ssh-source tailnet` 会插一条 `udp dport 41641 accept comment "pdg-tailnet-direct"`。
41641 是官方默认值，但**它是可配的**：Debian 12 上端口来自 `/etc/default/tailscaled` 的
`PORT=`，unit 经 `EnvironmentFile` 传给 `tailscaled --port=${PORT}`。而项目里那个数字是
硬编码常量，12 处写死，从不读那份文件。

用户改了 `PORT=` 之后，这条放行**静默地双向失效**：41641 那条没有监听者，成了永远不会
有人应答的陈旧放行；真正在用的端口被 input 链的 policy drop 挡住。后果是
`pdg ssh-source` 当初要消除的冷启动窗口原样回来——几小时没用 tailnet，出事了想连进去，
第一次 SSH 必超时，而那正是最需要它的时刻。

判据只做**两份配置的对账，不发探测包**。端口通不通要发包才知道，而「探不到」证明不了
任何事——那是 `check_deep_lan_acl` 那条假绿的同款教训，不再犯第二次。读文件是确定的。

三条边界：

- nft 里没有那条放行 → 整项不适用（返回 `None`），不给没用这功能的机器平白加一条灯
- 读不到 `/etc/default/tailscaled` 或没有 `PORT=` → `ok` + 说明无从对账，**绝不判 fail**
  （fail 会让 `pdg update` 的自检门整次回滚，而这只是「没装 Tailscale」而已）
- `PORT=` 的三种写法（裸值 / 单引号 / 双引号，带不带空格）都要认

## 验证

- 两支判据**先红后绿**：守卫红 6 项、负控红 9 项，修完各自全绿
- **牙齿**：reloadcmd 改回 `reload + || true` → 守卫转红；端口漂移改判 `ok` → 负控转红
- `test-ci-coverage` 因为「新测试没进 CI」判红，已接进 workflow 后转绿——**那条判据这次
  真的抓到了东西**
- 相关面全绿：`test-lan-doctor` 29、`test-doctor-conflict-creator` 14、`test-ssh-source-persist` 18、
  `test-lan-nft-chokepoint` 4、`test-lanpanel`/`test-lan-wire`/`test-lanroute`/`test-file-sets`
- 四支负控全绿：`lan-acl-false-green`、`link-note-contradiction`、`tailscale-residue-misdiagnosis`、
  `tailnet-direct-port-drift`
- 静态门：ShellCheck（CI 原样）退出 0、`py_compile`、`bash -n`、`git diff --check`、
  workflow YAML 真解析（8 jobs / 232 steps）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
