### PR TITLE
fix(doctor): make Tailscale direct-port evidence truthful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: "doctor: 冲突制造者定位 + Tailscale 卸载残留"
         run: python3 tests/test-doctor-conflict-creator.py
 
+      - name: "tailnet 直连端口: 证据等级与 PORT= 解析语义(无结论不得染绿)"
+        run: python3 tests/test-tailnet-port-evidence.py
+
       - name: "内网面板门一: 子网路由重叠拒绝(含每条判据的空测)"
         run: python3 tests/test-lanroute.py
 

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -720,24 +720,66 @@ def check_tailscale_residue():
     return ("ok", name, "没有 tailscale0, 也没有留下 src_valid_mark / 残留二进制")
 
 
+def _tailscaled_port(txt):
+    """从 /etc/default/tailscaled 的内容里取 PORT= 的**最终生效值**。
+
+    返回 (port, reason)。port 为 None 时 reason 说明取不到的原因。
+
+    按 systemd EnvironmentFile 的语义来: 逐行解析, 空行与 `#` 开头的注释跳过, **后面的
+    赋值覆盖前面的**。用 re.search 取第一个是错的 —— 那正好取到被覆盖掉的那个值, 而且
+    错得很安静(两边"对上了", 实际用的是另一个端口)。
+
+    最后一条赋值解析不出合法端口时, **不退回前一个值**。退回去等于拿一个已经被覆盖的旧值
+    冒充现状, 而那正是这条判据要防的事; 宁可说不知道。
+
+    只做这一件事: 不展开变量、不处理续行、不解释引号内的转义 —— 那是 shell 解释器的活,
+    这里不需要, 多写一分就多一分猜错的机会。
+    """
+    port, reason = None, "%s 里没有 PORT= 赋值" % TAILSCALED_DEFAULTS
+    for raw in txt.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^PORT\s*=\s*(.*)$", line)
+        if not m:
+            continue
+        val = m.group(1).strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in "\"'":
+            val = val[1:-1].strip()
+        if not val.isdigit():
+            port, reason = None, "最后一条 PORT= 赋值解析不出端口(%r)" % raw.strip()[:40]
+            continue
+        n = int(val)
+        if not (1 <= n <= 65535):
+            port, reason = None, "最后一条 PORT= 赋值不是合法端口(%d)" % n
+            continue
+        port, reason = n, ""
+    return port, reason
+
+
 def check_tailnet_direct_port():
-    """放行的 UDP 端口与 tailscaled 实际监听的端口是否还对得上。
+    """放行的 UDP 端口与 tailscaled 配置里声明的端口是否还对得上。
 
     `pdg ssh-source tailnet` 会插一条 `udp dport 41641 accept comment "pdg-tailnet-direct"`。
     41641 是官方默认值, 但**它是可配的** —— Debian 12 上来自 /etc/default/tailscaled 的
-    `PORT=`。项目里那个数字是硬编码常量, 从不读那份文件。
+    `PORT=`, unit 经 EnvironmentFile 传给 `tailscaled --port=${PORT}`。项目里那个数字是
+    硬编码常量, 从不读那份文件。
 
     用户改了 PORT 之后, 这条放行**静默地双向失效**:
-      · 41641 那条没有监听者, 成了一个永远不会有人应答的陈旧洞;
-      · 真正的端口被 input 链的 policy drop 挡住。
+      · 41641 那条没有监听者, 成了一个永远不会有人应答的陈旧放行;
+      · 真正在用的端口被 input 链的 policy drop 挡住。
     于是 `pdg ssh-source` 当初要消除的冷启动窗口原样回来 —— 几小时没用 tailnet, 出事了
     想连进去, 第一次 SSH 必超时。而从配置上完全看不出两者有关系。
 
-    判据只做**两份配置的对账**, 不发探测包: 端口通不通要发包才知道, 而"探不到"证明不了
-    任何事(同 check_deep_lan_acl 那条教训)。读文件是确定的。
+    **这是配置对账, 不是监听探测。**判据只比两份配置, 不发探测包: 端口通不通要发包才知道,
+    而"探不到"证明不了任何事(同 check_deep_lan_acl 那条假绿的教训)。读文件是确定的。
+    所以文案里不能把 /etc/default/tailscaled 说成"实际监听端口" —— 它只是 Debian 包的
+    端口配置来源, 进程有没有按它跑, 这条判据管不着。
 
-    读不到 /etc/default/tailscaled 就**无结论** —— 那可能是没装 Tailscale、或者不是 deb
-    装的。不猜, 也绝不判 fail: fail 会让 `pdg update` 的自检门整次回滚。
+    取不到证据时判 **warn + 明说无结论**, 不判 ok: 读不到那份文件、或者文件里没有合法的
+    PORT=, 我们对"放行的端口还有没有人监听"一无所知 —— 那不是"没问题", 是"不知道"。
+    也不判 fail: fail 会让 `pdg update` 的自检门整次回滚, 而"这台机器没装 Tailscale"
+    根本不该阻断更新。
     """
     name = "Tailscale 直连端口对账"
     try:
@@ -750,28 +792,31 @@ def check_tailnet_direct_port():
     if not m:
         return None                       # SSH 没收紧为 tailnet, 整项不适用
     allowed = int(m.group(1))
+    unresolved = ("放行了 UDP %d, 但%s —— **本项无结论**: 取不到声明的端口, 就没法判断这条"
+                  "放行是否还指着 tailscaled 在用的那个口。没装 Tailscale、或不是 deb 装的, "
+                  "属于正常情形, 不必处理。" % (allowed, "%s"))
     try:
         with open(TAILSCALED_DEFAULTS, encoding="utf-8") as f:
             txt = f.read()
-    except OSError:
-        return ("ok", name,
-                "放行了 UDP %d; 读不到 %s, 没法跟 tailscaled 的实际端口对账(没装 Tailscale "
-                "或不是 deb 装的?), 本项无结论。" % (allowed, TAILSCALED_DEFAULTS))
-    pm = re.search(r"^\s*PORT\s*=\s*[\"']?(\d+)[\"']?", txt, re.M)
-    if not pm:
-        return ("ok", name,
-                "放行了 UDP %d; %s 里没有 PORT= 这一行, 无从对账。"
-                % (allowed, TAILSCALED_DEFAULTS))
-    actual = int(pm.group(1))
+    except OSError as e:
+        return ("warn", name, unresolved % ("读不到 %s(%s)" % (TAILSCALED_DEFAULTS, e.strerror or e)))
+    actual, why = _tailscaled_port(txt)
+    if actual is None:
+        return ("warn", name, unresolved % why)
     if actual == allowed:
-        return ("ok", name, "放行的 UDP %d 与 tailscaled 的监听端口一致。" % allowed)
+        return ("ok", name,
+                "放行的 UDP %d 与 %s 里声明的端口一致。" % (allowed, TAILSCALED_DEFAULTS))
     return ("warn", name,
-            "防火墙放行的是 UDP %d, 但 %s 里写的是 PORT=%d —— 两边对不上。"
-            "于是 %d 那条成了没有监听者的陈旧放行, 而真正在用的 %d 被 input 链丢掉。"
+            "防火墙放行的是 UDP %d, 而 %s 里声明的是 PORT=%d —— 两边对不上。"
+            "于是 %d 那条成了没有监听者的陈旧放行, 而声明在用的 %d 被 input 链丢掉。"
             "后果是 `pdg ssh-source tailnet` 本来要消除的冷启动窗口又回来了: 空闲一段之后"
-            "第一次 SSH 会超时。要么把 PORT 改回 %d, 要么跑一次 `pdg ssh-source tailnet` "
-            "让放行跟上(它目前只认 %d, 改端口的话需要手工调 /etc/nftables.conf 里那一行)。"
-            % (allowed, TAILSCALED_DEFAULTS, actual, allowed, actual, allowed, allowed))
+            "第一次 SSH 会超时。"
+            "**`pdg ssh-source tailnet` 目前只生成 41641, 跟不了自定义端口。**"
+            "要恢复默认: 先把 %s 改回 PORT=41641, 重启 tailscaled, 再重新应用一次 tailnet "
+            "SSH 来源策略。要坚持用 %d: 得按运维流程人工把 /etc/nftables.conf 里那一行对齐, "
+            "本命令不会替你处理。"
+            % (allowed, TAILSCALED_DEFAULTS, actual, allowed, actual,
+               TAILSCALED_DEFAULTS, actual))
 
 
 def _filesha(path):

--- a/tests/negctl/tailnet-direct-port-drift.py
+++ b/tests/negctl/tailnet-direct-port-drift.py
@@ -1,135 +1,152 @@
 #!/usr/bin/env python3
-"""负控: 放行的 UDP 端口跟 tailscaled 实际监听的端口对不上时, doctor 必须报出来。
+"""负控: tailnet 直连端口对账的**证据等级与解析语义**有没有牙。
 
-`pdg ssh-source tailnet` 会往 input 链插一条
+契约本身钉在 tests/test-tailnet-port-evidence.py 里 —— 那支说"判据应该说什么"。
+这一支回答另一个问题: **如果判据退化了, 我们会不会知道?**
 
-    udp dport 41641 accept comment "pdg-tailnet-direct"
+做法是逐格把生产代码改坏, 然后看契约测试是否**新增具名失败**。每格五步, 缺一不算有效:
 
-41641 是 Tailscale 的官方默认端口, 但**它是可配的**。Debian 12 上端口来自
-`/etc/default/tailscaled` 的 `PORT=`, unit 经 `EnvironmentFile` 把它传给
-`tailscaled --port=${PORT}`。项目里 41641 是**硬编码常量, 从不读那个文件**。
+  1. 锚点在整份文件里**恰好命中一次**(多了少了都说明改坏器没打在预期位置);
+  2. 替换后原锚点消失、新内容恰好出现一次;
+  3. 改坏后 `py_compile` 仍通过(语法错导致的红不算"测试抓住了");
+  4. 契约测试的失败集合相对基线**有新增**, 并报出新增了哪几条;
+  5. 恢复后 sha256 与 before-image 逐字节一致。
 
-用户改了 `PORT=` 之后, 这条放行就静默地双向失效:
+改坏落在**工作副本**里, 正式树一个字节都不动 —— 跑完会核对。
 
-    41641 那条  → 没有监听者, 成了一个永远不会有人应答的陈旧洞;
-    真正的端口  → 被 input 链的 policy drop 挡住。
-
-后果是 `pdg ssh-source` 当初要消除的**冷启动窗口原样回来** —— 几小时没用 tailnet,
-出事了想连进去, 第一次 SSH 必超时。而配置上完全看不出这两件事有关系: nft 里那条规则
-好端端地写着 accept, `/etc/default/tailscaled` 里也好端端地写着另一个端口。
-
-这支负控盯的是"两份配置的一致性", 不是"端口能不能连" —— 后者要发包, 而且**探不到证明
-不了任何事**(见 lan-acl-false-green.py 的同类教训)。读文件是确定的, 发包不是。
+盯的六件事, 每一件都是真机上出过或差点出的:
+  ① 读不到 defaults 判绿   —— "没证据"染成"没问题";
+  ② 没有 PORT= 判绿        —— 同上, 另一条入口;
+  ③ 多重赋值取第一个       —— 正好取到被覆盖掉的那个值, 而且错得很安静;
+  ④ 注释里的 PORT= 算数    —— 把一行被注释掉的配置当成现行配置;
+  ⑤ 误导文案回潮           —— 让用户以为跑个命令就能跟上自定义端口, 而那条命令做不到;
+  ⑥ 只加无关注释           —— 反向对照: 不该产生任何新失败, 否则说明判据在看噪声。
 """
-import importlib.util
-import io
-import os
+import hashlib
+import re
+import shutil
+import subprocess
 import sys
-import builtins
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
-C = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-spec.loader.exec_module(C)
+TOUCHED = ROOT / "deploy/bot/checks.py"
+CONTRACT = "tests/test-tailnet-port-evidence.py"
 
 PASS, FAIL = [0], [0]
-def ok(m):  PASS[0] += 1; print("  ✓ %s" % m)
-def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
-
-_open, _exists = builtins.open, os.path.exists
-
-NFT_WITH = 'table inet pdg {\n chain input {\n  udp dport %d accept comment "pdg-tailnet-direct"\n }\n}\n'
-NFT_NONE = 'table inet pdg {\n chain input {\n  tcp dport { 22 } accept\n }\n}\n'
+def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
+def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
 
 
-def run(nft, defaults):
-    """nft: /etc/nftables.conf 的内容; defaults: /etc/default/tailscaled 的内容(None=不存在)"""
-    def fo(p, *a, **k):
-        p = str(p)
-        if p == C.NFT_CONF:
-            if nft is None:
-                raise OSError(2, "No such file")
-            return io.StringIO(nft)
-        if p == getattr(C, "TAILSCALED_DEFAULTS", "/etc/default/tailscaled"):
-            if defaults is None:
-                raise OSError(2, "No such file")
-            return io.StringIO(defaults)
-        return _open(p, *a, **k)
-
-    def fe(p):
-        p = str(p)
-        if p == getattr(C, "TAILSCALED_DEFAULTS", "/etc/default/tailscaled"):
-            return defaults is not None
-        return _exists(p)
-
-    builtins.open, os.path.exists = fo, fe
-    try:
-        fn = getattr(C, "check_tailnet_direct_port", None)
-        if fn is None:
-            return ("__MISSING__", "", "判据函数不存在")
-        # 返回 None = "整项不适用"。统一成三元组, 免得每个断言都要先判空。
-        return fn() or (None, "", "(不适用)")
-    finally:
-        builtins.open, os.path.exists = _open, _exists
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
 
 
-# ── ① 判据得先存在, 而且接进 doctor ─────────────────────────────────────────
-fn = getattr(C, "check_tailnet_direct_port", None)
-if fn is None:
-    bad("checks.py 里没有 check_tailnet_direct_port —— 整支负控无从谈起")
-else:
-    ok("判据函数存在")
-    if fn in getattr(C, "ALL", []):
-        ok("已接进 checks.ALL(doctor 会真的跑它)")
+def failures(wd):
+    """跑契约测试, 返回 (失败行集合, 退出码)。"""
+    r = subprocess.run([sys.executable, CONTRACT], cwd=wd,
+                       capture_output=True, text=True, timeout=180)
+    fs = {l.strip() for l in r.stdout.splitlines() if l.startswith("[FAIL]")}
+    return fs, r.returncode
+
+
+def syntax_ok(wd):
+    r = subprocess.run([sys.executable, "-m", "py_compile", "deploy/bot/checks.py"],
+                       cwd=wd, capture_output=True, text=True, timeout=60)
+    return r.returncode == 0
+
+
+# 每格 = (标签, [(锚点, 替换, 预期命中数), …])。
+# 多数格只需一条编辑; ④ 需要两条 —— 注释是**双层防御**: 先 startswith("#") 跳过,
+# 再 re.match 行首锚定。两层互为冗余, 单摘一层行为不变(各自实测 0 条转红), 所以要证明
+# "注释保护有牙", 必须两层一起摘。冗余本身是好事, 只是它让单锚点负控失效。
+MUTATIONS = [
+    ("① 读不到 defaults 改回判绿", [
+        ('return ("warn", name, unresolved % ("读不到 %s(%s)"',
+         'return ("ok", name, unresolved % ("读不到 %s(%s)"', 1)]),
+    ("② 没有 PORT= 改回判绿", [
+        ('if actual is None:\n        return ("warn", name, unresolved % why)',
+         'if actual is None:\n        return ("ok", name, unresolved % why)', 1)]),
+    ("③ 多重赋值改成取第一个", [
+        ('        port, reason = n, ""',
+         '        port, reason = n, ""\n        break', 1)]),
+    ("④ 摘掉注释的两层防御(注释里的 PORT= 会被当赋值)", [
+        ('if not line or line.startswith("#"):', 'if not line:', 1),
+        ('m = re.match(r"^PORT\\s*=\\s*(.*)$", line)',
+         'm = re.search(r"PORT\\s*=\\s*(.*)$", line)', 1)]),
+    ("⑤ 误导文案回潮", [
+        ('"**`pdg ssh-source tailnet` 目前只生成 41641, 跟不了自定义端口。**"',
+         '"要么跑一次 `pdg ssh-source tailnet` 让放行跟上。"', 1)]),
+    ("⑥ 只加一行无关注释(反向对照, 不该有新失败)", [
+        ('def check_tailnet_direct_port():',
+         '# (负控的空转对照, 不改变任何行为)\ndef check_tailnet_direct_port():', 1)]),
+]
+
+before = sha(TOUCHED)
+wd = tempfile.mkdtemp(prefix="pdg-tnp-negctl.")
+try:
+    for sub in ("deploy/bot", "tests"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)
+    pristine = (Path(wd) / "deploy/bot/checks.py").read_text(encoding="utf-8")
+
+    base_fs, base_rc = failures(wd)
+    if base_rc == 0 and not base_fs:
+        ok("基线绿: 契约测试 0 失败")
     else:
-        bad("没接进 checks.ALL —— 写了也不会被执行")
+        bad("基线就不绿(rc=%s, %d 条失败), 后面每一格都无从判断:" % (base_rc, len(base_fs)))
+        for f in sorted(base_fs)[:5]:
+            print("       " + f[:120])
+        raise SystemExit(1)
 
-# ── ② 端口一致 → ok ────────────────────────────────────────────────────────
-r = run(NFT_WITH % 41641, 'PORT="41641"\nFLAGS=""\n')
-if r[0] == "ok":
-    ok("nft 41641 + PORT=41641 → ok")
+    for label, edits in MUTATIONS:
+        target = Path(wd) / "deploy/bot/checks.py"
+        target.write_text(pristine, encoding="utf-8")
+        mutated, aborted = pristine, False
+        for old, new, want_hits in edits:
+            hits = mutated.count(old)
+            if hits != want_hits:
+                bad("%s → 锚点 %r 命中 %d 次, 预期 %d(改坏器没打在预期位置)"
+                    % (label, old[:34], hits, want_hits))
+                aborted = True
+                break
+            mutated = mutated.replace(old, new, 1)
+            if mutated.count(new) != 1:
+                bad("%s → 替换后新内容出现 %d 处, 预期 1" % (label, mutated.count(new)))
+                aborted = True
+                break
+        if aborted:
+            continue
+        target.write_text(mutated, encoding="utf-8")
+        if not syntax_ok(wd):
+            bad("%s → 改坏后语法不合法, 这条不算有效负控" % label)
+            continue
+        fs, _rc = failures(wd)
+        added = fs - base_fs
+        noop = label.startswith("⑥")
+        if noop:
+            if added:
+                bad("%s → 竟然新增了 %d 条失败, 判据在看噪声:" % (label, len(added)))
+                for f in sorted(added)[:3]:
+                    print("       " + f[:120])
+            else:
+                ok("%s → 0 条新增(判据不看噪声)" % label)
+        elif added:
+            ok("%s → 锚点 %d 条全命中, 新增 %d 条具名失败" % (label, len(edits), len(added)))
+            for f in sorted(added)[:2]:
+                print("       " + f[:118])
+        else:
+            bad("%s → 锚点命中但**0 条转红**, 负控无效" % label)
+    Path(wd, "deploy/bot/checks.py").write_text(pristine, encoding="utf-8")
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+after = sha(TOUCHED)
+if before == after:
+    ok("正式树未被污染: deploy/bot/checks.py sha256 一致 (%s…)" % before[:16])
 else:
-    bad("两边一致却判成了 %r: %s" % (r[0], r[2][:80]))
+    bad("正式树被改动了! %s → %s" % (before[:16], after[:16]))
 
-# ── ③ 端口漂移 → 必须报出来, 而且要把两个数字都说出来 ──────────────────────
-r = run(NFT_WITH % 41641, 'PORT="45678"\n')
-if r[0] in ("warn", "fail"):
-    ok("nft 41641 + PORT=45678 → %s" % r[0])
-else:
-    bad("端口对不上却判成了 %r —— 冷启动窗口会静默回来" % (r[0],))
-if "41641" in r[2] and "45678" in r[2]:
-    ok("文案里两个端口都点了名")
-else:
-    bad("文案没同时给出两个端口, 用户不知道该改哪个: %r" % r[2][:100])
-
-# ── ④ 没收紧 SSH(nft 里没那条放行) → 整项不适用, 不能报警 ───────────────────
-r = run(NFT_NONE, 'PORT="45678"\n')
-if r[0] is None or r[0] == "ok":
-    ok("没放行 41641(SSH 未收紧) → 不适用/ok, 不平白报警")
-else:
-    bad("SSH 没收紧却报了 %r —— 每台没用这功能的机器都会多一条灯" % (r[0],))
-
-# ── ⑤ 读不到 /etc/default/tailscaled → 无结论, 不许猜 ──────────────────────
-r = run(NFT_WITH % 41641, None)
-if r[0] in ("ok", "warn", None):
-    ok("读不到 tailscaled 默认值 → %r(不猜)" % (r[0],))
-else:
-    bad("读不到配置却下了结论: %r" % (r[0],))
-if r[0] == "fail":
-    bad("读不到就判 fail —— 那会让没装 Tailscale 的机器升级失败")
-
-# ── ⑥ PORT 有空格/单引号等写法也要认 ───────────────────────────────────────
-for txt, label in (("PORT=45678\n", "无引号"),
-                   ("PORT='45678'\n", "单引号"),
-                   ("  PORT = \"45678\"  \n", "带空格")):
-    r = run(NFT_WITH % 41641, txt)
-    if r[0] in ("warn", "fail"):
-        ok("%s 写法也认得出漂移" % label)
-    else:
-        bad("%s 写法没认出来(判成 %r) —— 解析太脆" % (label, r[0]))
-
-print("─" * 60)
-print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+print("-" * 62)
+print("tailnet-direct-port-drift.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
 sys.exit(1 if FAIL[0] else 0)

--- a/tests/negctl/tailnet-direct-port-drift.py
+++ b/tests/negctl/tailnet-direct-port-drift.py
@@ -27,8 +27,10 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402 - 一次性临时目录: 建了就登记, 退出即清
 
 ROOT = Path(__file__).resolve().parents[2]
 TOUCHED = ROOT / "deploy/bot/checks.py"
@@ -84,7 +86,10 @@ MUTATIONS = [
 ]
 
 before = sha(TOUCHED)
-wd = tempfile.mkdtemp(prefix="pdg-tnp-negctl.")
+# 顶层沙箱必须走 tmpguard: 它建了就登记, 正常退出、抛异常、被 SIGTERM 杀都会清掉。
+# 裸 tempfile.mkdtemp 绕过登记 —— test-tmp-hygiene 第 4 节盯的就是这个, 而它盯得对:
+# 这支负控中途会 raise SystemExit(基线不绿时), 那条路径正是最容易漏清的。
+wd = tmpguard.mkdtemp(prefix="pdg-tnp-negctl.")
 try:
     for sub in ("deploy/bot", "tests"):
         shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)

--- a/tests/test-tailnet-port-evidence.py
+++ b/tests/test-tailnet-port-evidence.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""tailnet 直连端口对账的**证据等级契约**。
+
+这一项做的是"两份配置对不对得上", 不是"端口通不通" —— 它读 nft 里那条放行, 再读
+/etc/default/tailscaled 里的 PORT=, 比一比。所以它能给的结论只有三种:
+
+    对得上        → ok
+    对不上        → warn(且必须把两个端口都说出来, 否则用户不知道改哪个)
+    取不到证据    → warn + 明说无结论
+
+**第三种以前判 ok, 那是把"没证据"染成了绿灯。**读不到配置文件、或者文件里根本没有
+PORT= 时, 我们对"防火墙放行的端口是否还有人监听"一无所知 —— 那不是"没问题", 那是
+"不知道"。判绿的代价是: 用户改过端口、冷启动窗口已经回来了, 而 doctor 一路绿灯。
+
+级别只能是 warn, **不能是 fail**: fail 会让 `pdg update` 的自检门整次回滚, 而"这台机器
+没装 Tailscale"根本不该阻断更新。
+
+PORT= 的取值按 systemd EnvironmentFile 的语义: 逐行解析, 后面的赋值覆盖前面的。取第一个
+是错的 —— 那正好取到被覆盖掉的那个值, 而且错得很安静。
+
+这支是**普通测试**(登记进 CI), 与 tests/negctl/tailnet-direct-port-drift.py 分工不同:
+那支证明"判据有牙", 这支钉死"判据说什么"。
+"""
+import builtins
+import importlib.util
+import io
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
+C = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(C)
+
+PASS, FAIL = [0], [0]
+def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
+def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
+
+_open, _exists = builtins.open, os.path.exists
+DEFAULTS = getattr(C, "TAILSCALED_DEFAULTS", "/etc/default/tailscaled")
+
+NFT_WITH = ('table inet pdg {\n chain input {\n'
+            '  udp dport %d accept comment "pdg-tailnet-direct"\n }\n}\n')
+NFT_NONE = 'table inet pdg {\n chain input {\n  tcp dport { 22 } accept\n }\n}\n'
+
+
+def run(nft, defaults, defaults_err=None):
+    """defaults: 文件内容; None = 文件不存在; defaults_err = 打开时抛的异常(权限等)"""
+    def fo(p, *a, **k):
+        p = str(p)
+        if p == C.NFT_CONF:
+            if nft is None:
+                raise OSError(2, "No such file")
+            return io.StringIO(nft)
+        if p == DEFAULTS:
+            if defaults_err is not None:
+                raise defaults_err
+            if defaults is None:
+                raise OSError(2, "No such file")
+            return io.StringIO(defaults)
+        return _open(p, *a, **k)
+
+    def fe(p):
+        p = str(p)
+        if p == DEFAULTS:
+            return defaults is not None or defaults_err is not None
+        return _exists(p)
+
+    builtins.open, os.path.exists = fo, fe
+    try:
+        return C.check_tailnet_direct_port() or (None, "", "(不适用)")
+    finally:
+        builtins.open, os.path.exists = _open, _exists
+
+
+def expect(label, r, level, must=(), must_not=()):
+    lv, _n, msg = r
+    if lv == level:
+        ok("%s → %s" % (label, level if level else "None(不适用)"))
+    else:
+        bad("%s → 得到 %r, 期望 %r。文案: %s" % (label, lv, level, msg[:90]))
+        return
+    for w in must:
+        if w not in msg:
+            bad("%s 的文案里缺 %r: %s" % (label, w, msg[:110]))
+            return
+    for w in must_not:
+        if w in msg:
+            bad("%s 的文案里不该有 %r: %s" % (label, w, msg[:110]))
+            return
+    if must or must_not:
+        ok("%s 的文案符合要求" % label)
+
+
+print("== 1. 不适用与一致 ==")
+expect("nft 没有 pdg-tailnet-direct", run(NFT_NONE, 'PORT="45678"\n'), None)
+expect("端口一致", run(NFT_WITH % 41641, 'PORT="41641"\n'), "ok")
+
+print()
+print("== 2. 漂移: warn, 且两个端口都要说出来 ==")
+expect("41641 vs 45678", run(NFT_WITH % 41641, 'PORT="45678"\n'), "warn",
+       must=("41641", "45678"))
+
+print()
+print("== 3. 取不到证据 → warn + 无结论(以前这两格判 ok) ==")
+expect("defaults 文件不存在", run(NFT_WITH % 41641, None), "warn", must=("无结论",))
+expect("defaults 读取失败(权限)",
+       run(NFT_WITH % 41641, None, defaults_err=PermissionError(13, "Permission denied")),
+       "warn", must=("无结论",))
+expect("文件在但没有 PORT=", run(NFT_WITH % 41641, 'FLAGS=""\n# nothing here\n'),
+       "warn", must=("无结论",))
+
+print()
+print("== 4. 多重赋值: 取最后一个(systemd EnvironmentFile 语义) ==")
+expect("PORT 两次, 最后一个与 nft 一致 → ok",
+       run(NFT_WITH % 45678, 'PORT="41641"\nFLAGS=""\nPORT="45678"\n'), "ok")
+expect("PORT 两次, 最后一个与 nft 不一致 → warn",
+       run(NFT_WITH % 41641, 'PORT="41641"\nPORT="45678"\n'), "warn",
+       must=("41641", "45678"))
+expect("最后一条非法 → 不退回前一个, 判无结论",
+       run(NFT_WITH % 41641, 'PORT="41641"\nPORT=abc\n'), "warn", must=("无结论",))
+expect("最后一条端口越界 → 无结论",
+       run(NFT_WITH % 41641, 'PORT="41641"\nPORT=70000\n'), "warn", must=("无结论",))
+
+print()
+print("== 5. 行首注释里的 PORT= 不算赋值 ==")
+expect("只有注释里有 PORT=", run(NFT_WITH % 41641, '# PORT="45678"\nFLAGS=""\n'),
+       "warn", must=("无结论",))
+expect("注释在真赋值之后, 不该覆盖",
+       run(NFT_WITH % 41641, 'PORT="41641"\n#PORT="45678"\n'), "ok")
+
+print()
+print("== 6. 引号与空格 ==")
+for txt, label in (('PORT=45678\n', "无引号"),
+                   ("PORT='45678'\n", "单引号"),
+                   ('PORT="45678"\n', "双引号"),
+                   ('  PORT = "45678"  \n', "两侧空格")):
+    expect(label, run(NFT_WITH % 41641, txt), "warn", must=("45678",))
+
+print()
+print("== 7. 文案不得暗示 pdg ssh-source 会跟随自定义端口 ==")
+_lv, _n, _msg = run(NFT_WITH % 41641, 'PORT="45678"\n')
+for phrase in ("让放行跟上", "自动跟随", "会跟着改"):
+    if phrase in _msg:
+        bad("漂移文案里仍有误导措辞 %r —— 该命令只会生成 41641" % phrase)
+        break
+else:
+    ok("漂移文案没有暗示该命令会跟随自定义端口")
+if "41641" in _msg and ("只支持" in _msg or "只生成" in _msg or "只认" in _msg):
+    ok("文案明说了该命令目前只支持默认端口")
+else:
+    bad("文案没说清该命令只支持 41641: " + _msg[:120])
+if "监听" in _msg and "配置" not in _msg:
+    bad("文案把 defaults 说成了运行时监听事实, 而这一项只是配置对账")
+else:
+    ok("文案把自己限定为配置对账, 没冒充监听探测")
+
+print()
+print("== 8. 级别不得升成 fail(会让 update 自检门回滚) ==")
+_bad_fail = []
+for label, r in (("不存在", run(NFT_WITH % 41641, None)),
+                 ("没有 PORT=", run(NFT_WITH % 41641, 'FLAGS=""\n')),
+                 ("漂移", run(NFT_WITH % 41641, 'PORT="45678"\n'))):
+    if r[0] == "fail":
+        _bad_fail.append(label)
+if _bad_fail:
+    bad("这些格判成了 fail, 会让没装 Tailscale 的机器升级回滚: %s" % _bad_fail)
+else:
+    ok("没有任何一格是 fail")
+
+print()
+print("== 9. 判据仍接在 doctor 上 ==")
+if C.check_tailnet_direct_port in C.ALL:
+    ok("check_tailnet_direct_port 在 checks.ALL 里")
+else:
+    bad("判据没接进 checks.ALL —— 写了也不会跑")
+
+print("-" * 62)
+print("test-tailnet-port-evidence.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-tailnet-port-evidence.py
+++ b/tests/test-tailnet-port-evidence.py
@@ -152,8 +152,13 @@ if "41641" in _msg and ("只支持" in _msg or "只生成" in _msg or "只认" i
     ok("文案明说了该命令目前只支持默认端口")
 else:
     bad("文案没说清该命令只支持 41641: " + _msg[:120])
-if "监听" in _msg and "配置" not in _msg:
-    bad("文案把 defaults 说成了运行时监听事实, 而这一项只是配置对账")
+# 盯的是**冒充运行时事实**这一形态, 不是某个字。defaults 只是端口的配置来源, 进程有没有
+# 按它跑, 这条判据管不着 —— 所以不能写"实际监听/监听端口/在监听", 只能写"声明/配置"。
+_claims_runtime = [w for w in ("实际监听", "监听端口", "正在监听", "监听的端口") if w in _msg]
+if _claims_runtime:
+    bad("文案把 defaults 说成了运行时监听事实(%s), 而这一项只是配置对账" % _claims_runtime[0])
+elif not any(w in _msg for w in ("声明", "配置", "对账")):
+    bad("文案没把自己限定为配置对账, 读者会以为它探过端口: " + _msg[:110])
 else:
     ok("文案把自己限定为配置对账, 没冒充监听探测")
 


### PR DESCRIPTION
## 问题

`pdg doctor` 的 Tailscale 直连端口一项存在三处不真实：

1. **读不到 `/etc/default/tailscaled` 时判绿。** 拿不到证据被当成"没问题"，是典型的假绿。
2. **文件里没有任何 `PORT=` 赋值时判绿。** 同上——"无结论"不等于"通过"。
3. **文案把配置说成监听。** `/etc/default/tailscaled` 里的 `PORT=` 只是**声明**给 tailscaled 的启动参数，doctor 并没有去看实际监听的端口；旧文案写成"监听"会让人误以为已经核过 socket。同时旧的修复建议指向 `pdg ssh-source tailnet`，但**那条命令目前只生成 41641，跟不了自定义端口**——照着做修不好，只会来回打转。

## 改动

`deploy/bot/checks.py`：

- 新增 `_tailscaled_port()`，按 **systemd EnvironmentFile 语义**解析：跳过 `#` 注释行、`PORT=` 行**后者覆盖前者**（取最后一条，不是第一条）、去掉成对引号、校验 1–65535。最后一条无效时**不回退**到前面的有效值，直接判为无结论——这与 systemd 实际行为一致。
- `check_tailnet_direct_port()` 的证据等级收口为：
  - nft 里没有 `pdg-tailnet-direct` 规则 → `None`（本项不适用，不出现在报告里）
  - 声明端口与规则端口一致 → `ok`
  - 两者不一致 → `warn`，**两个端口都点名**
  - 文件读不到 / 没有可解析的 `PORT=` → `warn` 且明说「本项无结论」
  - **任何路径都不返回 `fail`** —— 这是审计项，不是阻断项，不该让 `pdg update` 因它回滚
- 文案改为「声明的」，并显式写明 `pdg ssh-source tailnet` 只生成 41641 这一限制。

## 判据

- `tests/test-tailnet-port-evidence.py`（新增，已注册进 CI）：9 节 33 条断言，覆盖四个等级、多重赋值取最后一条、注释行不被当赋值、引号剥离、越界端口、以及文案不得把配置说成监听。刻意**不写** `level in ("ok","warn",None)` 这种放水断言——每条都钉死具体等级。
- `tests/negctl/tailnet-direct-port-drift.py`（重写为变异式负控）：6 个变异，每个带自己的锚点表，逐一验证「锚点命中数正确 → 替换后仍能 `py_compile` → 失败集合相对基线**具名**新增」。结果 2 / 4 / 4 / 2 / 2 / 0（第 6 个是反向对照：只加一行无关注释，不该有新增失败）。跑完校验官方树 sha256 复原。

## 不在本 PR 范围

- **没有**改 `pdg ssh-source tailnet` 的行为——让它支持自定义端口是另一件事，本 PR 只保证 doctor 说的是实话。
- 没有碰 `pdg.sh`、`_lan_render`、`_lan_apply_proxy`、快照/回滚/pdgtx、防火墙规则、README/ROADMAP/CHANGELOG/版本号。
- 没有触碰生产机或 tailnet 配置。

## CI

`workflow_dispatch` run [32708069899](https://github.com/misaka-cpu/privdns-gateway/actions/runs/32708069899)，head 精确等于本分支 HEAD `00449f9`，attempt 1：**29/29 jobs、461/461 steps 全 success**，failure / skipped / cancelled 均为 0。job 名集合与 v1.10.14 成功基线一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
