### PR TITLE
test(functional): make redir conntrack precondition deterministic

### DIFF
--- a/tests/functional-test.sh
+++ b/tests/functional-test.sh
@@ -23,7 +23,23 @@ source "$ROOT/lib/versions.sh"
 
 WORK="$(mktemp -d)"
 PIDS=()
-cleanup(){ for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done; rm -rf "$WORK"; }
+NFT_TABLE=""                    # 非空 = 本次运行**确实建过**临时 conntrack 表, 清理要负责删掉
+# 只删本轮自己建的那一张(名字带 PID, 唯一), 不动任何既有表, 更不 flush。
+# 幂等: 没建过是 no-op; 删掉并确认不存在后注销登记, 重复调用第二次同样是 no-op。
+drop_conntrack_table(){
+  [[ -n "$NFT_TABLE" ]] || return 0
+  sudo -n nft delete table inet "$NFT_TABLE" 2>/dev/null
+  if sudo -n nft list table inet "$NFT_TABLE" >/dev/null 2>&1; then
+    echo "[FAIL] 临时 conntrack 表 inet $NFT_TABLE 没删掉, 给现场留了残留" >&2
+  else
+    NFT_TABLE=""
+  fi
+}
+cleanup(){
+  for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done
+  rm -rf "$WORK"
+  drop_conntrack_table
+}
 trap cleanup EXIT
 fail(){ echo "[FAIL] $*" >&2; exit 1; }
 note(){ echo "[*] $*"; }
@@ -32,6 +48,58 @@ case "$(uname -m)" in
   x86_64) ARCH=amd64 ;; aarch64|arm64) ARCH=arm64 ;;
   *) fail "不支持的架构: $(uname -m)" ;;
 esac
+
+# ── 0. redir 入站的前提: 本 netns 的 conntrack 必须在跟踪 ───────────────────────
+# mihomo 的 redir 入站在 accept 之后立刻 getsockopt(SOL_IP, SO_ORIGINAL_DST) 取回原始目的地
+# (理由见 deploy/firewall/nftables-mihomo.conf 开头)。那个 sockopt 由 conntrack 提供 ——
+# 本 netns 没启用 conntrack hook 时它返回 ENOENT, mihomo 于是**静默丢掉**这条连接。症状是
+# 三个出口日志全空、第一个用例卡满轮询后失败, 而 mihomo 自己一个字都不打, 完全看不出真因。
+#
+# 生产上这个前提恒成立(nft 模板自带 nat prerouting 与 ct state 两类规则), 测试里却一直靠
+# 宿主碰巧激活过 conntrack 白捡 —— runner 上捡不到就是一次假红: main 的 32722985743 与
+# 32579827324 都是这么来的, 同一份代码在别的 run 上全绿。所以这里先探, 缺了就自己建。
+#
+# 与启动时那两行 `IP_TRANSPARENT … operation not permitted` 无关: 那是 Redir **UDP** 监听器
+# 要 CAP_NET_ADMIN, TCP 那半照常 listen 成功, 而本测试只走 TCP。非 root 跑必然有那两行,
+# 它不是失败条件 —— 别去压它, 压了就再也看不见真的权限问题了。
+probe_origdst(){ python3 "$HERE/origdst_probe.py" 2>&1; }
+
+ensure_conntrack(){
+  local out rc t
+  out="$(probe_origdst)"; rc=$?
+  case "$rc" in
+    0) note "conntrack 前提已满足($out), 不建任何临时规则" ; return 0 ;;
+    3) : ;;                       # 未激活 → 往下自己建一张只属于本次运行的表
+    *) fail "conntrack 前提探不出结论($out) —— 不猜, 也不跳过" ;;
+  esac
+  note "本 netns 的 conntrack 未激活($out), 建一张只属于本次运行的临时表"
+  # 缺工具时**判失败而不是跳过**: 跳过等于零覆盖, 而零覆盖会以绿灯的样子出现, 正是本项目
+  # 最怕的那种假绿 —— 真出问题时它一声不吭。
+  sudo -n true 2>/dev/null \
+    || fail "本 netns 缺 conntrack 且没有免密 sudo, 建不起前提(不跳过: 跳过等于零覆盖)"
+  # 探 nft 用 `sudo -n nft --version`, 不用 `command -v nft`: nft 装在 /usr/sbin, 非 root 的
+  # PATH 通常不含那一段 —— 按 command -v 判会把"其实有 nft 的机器"误判成没有, 平白把一次本
+  # 可以自愈的运行变成硬失败。要问的是"待会那条命令跑不跑得起来", 那就照原样问一次。
+  sudo -n nft --version >/dev/null 2>&1 \
+    || fail "本 netns 缺 conntrack 且 sudo 下也调不到 nft, 建不起前提(不跳过: 跳过等于零覆盖)"
+  t="pdgfunc$$"
+  # 只**新建**一张名字唯一的表, 不 flush、不碰任何既有表。规则本身什么都不做(policy accept
+  # 加一条 ct state 匹配), 它唯一的作用是让内核为本 netns 注册 conntrack hook —— 这正是
+  # 定性实验里唯一改动的那一条: 改之前 5/5 红, 加上之后 5/5 绿。
+  sudo -n nft add table inet "$t" || fail "建临时 conntrack 表失败: inet $t"
+  NFT_TABLE="$t"                  # 建成即登记 —— 后面任何一步失败, 清理都能把它删掉
+  sudo -n nft add chain inet "$t" input '{ type filter hook input priority 0; policy accept; }' \
+    || fail "建临时 conntrack 链失败: inet $t"
+  sudo -n nft add rule inet "$t" input ct state established,related accept \
+    || fail "加 ct 规则失败: inet $t"
+  # 建完必须**再探一次**: 三条 nft 命令全都返回 0, 不等于 conntrack 真的被激活了。
+  # 少了这一步, 一个"成功但不生效"的 setup 就会冒充已准备好, 把假绿换成假红而已。
+  out="$(probe_origdst)"; rc=$?
+  [[ "$rc" == 0 ]] \
+    || fail "临时表建好了但 SO_ORIGINAL_DST 仍拿不到($out) —— 前提不成立, 不继续碰运气"
+  note "临时 conntrack 表 inet $t 已生效($out)"
+}
+ensure_conntrack
 
 # ── 1. 取 mihomo ────────────────────────────────────────────────────────────
 # PATH 上那个未必可信: 可能是别的测试留下的**桩**(只会回一句版本号), 拿它跑功能测试等于

--- a/tests/negctl/functional-conntrack-fixture.py
+++ b/tests/negctl/functional-conntrack-fixture.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""负控: functional 测试的 conntrack 前提夹具有没有牙。
+
+夹具本身在 tests/functional-test.sh 的第 0 节 —— 那段说"跑之前要先把前提摆好"。
+这一支回答另一个问题: **如果那段退化了, 我们会不会知道?**
+
+为什么需要它: mihomo 的 redir 入站靠 getsockopt(SOL_IP, SO_ORIGINAL_DST) 取原始目的地,
+那个 sockopt 由 conntrack 提供。本 netns 没启用 conntrack hook 时它返回 ENOENT, mihomo
+**静默丢掉**连接 —— 三个出口日志全空, 而 mihomo 一个字都不打。main 的 32722985743 与
+32579827324 就是这么红的, 同一份代码在别的 run 上全绿。这种"看不出真因的偶发红"最容易被
+一句"重跑一下就好了"糊过去, 所以夹具的每一环都要有负控盯着。
+
+做法是逐格把夹具改坏, 然后在一个**干净 netns**(名字唯一的 named netns, 里面没有任何
+conntrack hook)里跑 functional 测试, 看两件事有没有变化:
+
+  1. 具名失败集合相对基线有没有**新增**(基线 = 官方夹具在同样的干净 netns 里跑, 必须全绿);
+  2. 跑完那个 netns 里有没有**残留**的临时表。
+
+每格五步, 缺一不算有效:
+  · 锚点在整份文件里**恰好命中**预期次数(多了少了都说明改坏器没打在预期位置);
+  · 替换后锚点恰好被消费掉一次, 且替换内容确实落进了文件;
+  · 改坏后 `bash -n` 仍通过(语法错造成的红不算"判据抓住了");
+  · 失败集合有具名新增, 或残留守卫报出残留;
+  · 恢复后正式树 sha256 与 before-image 逐字节一致。
+
+改坏落在**工作副本**里, 正式树一个字节都不动 —— 跑完会核对。
+
+盯的六件事:
+  ① 摘掉前提建立     —— 回到偶发红那天的状态, 三格全空;
+  ② setup 成功但不生效 —— nft 三条命令都返回 0, conntrack 却没被激活;
+  ③ 摘掉二次探针     —— 让 ② 那种无效 setup 冒充"已准备好", 精确诊断消失、只剩三格空;
+  ④ 摘掉清理         —— 临时表留在 netns 里, 下一个用它的人接手一个脏现场;
+  ⑤ 建不起来就 return 0 —— 把"建不起前提"悄悄降级成跳过, 零覆盖披着绿灯出场;
+  ⑥ 只加无关注释     —— 反向对照: 不该产生任何新失败, 否则说明判据在看噪声。
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402 - 一次性临时目录: 建了就登记, 退出即清
+
+ROOT = Path(__file__).resolve().parents[2]
+TOUCHED = [ROOT / "tests/functional-test.sh", ROOT / "tests/origdst_probe.py"]
+
+PASS, FAIL = [0], [0]
+def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
+def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def sudo_ok():
+    return subprocess.run(["sudo", "-n", "true"], capture_output=True).returncode == 0
+
+
+def run(cmd, timeout=300):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+# ── 干净 netns: 名字唯一, 建了就一定删 ────────────────────────────────────────
+# 用 named netns 而不是 `unshare -n`: 残留判据要在**脚本退出之后**看那个 netns 里还剩什么,
+# unshare 的匿名 netns 随进程一起消失, 残留会被环境自动抹掉 —— 那样 ④ 就永远抓不到东西。
+class Netns:
+    def __init__(self, name):
+        self.name = name
+
+    def __enter__(self):
+        run(["sudo", "-n", "ip", "netns", "add", self.name])
+        run(["sudo", "-n", "ip", "netns", "exec", self.name, "ip", "link", "set", "lo", "up"])
+        return self
+
+    def __exit__(self, *a):
+        run(["sudo", "-n", "ip", "netns", "del", self.name])
+        return False
+
+    def exec(self, argv, env_path=None, timeout=300):
+        pre = ["sudo", "-n", "ip", "netns", "exec", self.name]
+        if env_path:
+            pre += ["env", "PATH=%s" % env_path]
+        return run(pre + argv, timeout=timeout)
+
+    def stray_tables(self):
+        """本 netns 里还剩几张 pdgfunc* 表 —— 夹具清理干净的话应当一张都没有。"""
+        r = self.exec(["nft", "list", "tables"])
+        return [l.strip() for l in r.stdout.splitlines() if "pdgfunc" in l]
+
+
+def failures(out):
+    return {l.strip() for l in out.splitlines() if l.startswith("[FAIL]")}
+
+
+# 每格 = (标签, [(锚点, 替换, 预期命中数), …])。
+# ③ 和 ⑤ 各带两条编辑: 它们盯的那一环, 只有先让 setup 变成"成功但不生效"才走得到。
+CALL = "\nensure_conntrack\n"
+CT_RULE = ('  sudo -n nft add rule inet "$t" input ct state established,related accept \\\n'
+           '    || fail "加 ct 规则失败: inet $t"')
+CT_NOOP = ('  sudo -n nft list table inet "$t" >/dev/null \\\n'
+           '    || fail "加 ct 规则失败: inet $t"')
+REPROBE = ('  out="$(probe_origdst)"; rc=$?\n'
+           '  [[ "$rc" == 0 ]] \\\n'
+           '    || fail "临时表建好了但 SO_ORIGINAL_DST 仍拿不到($out) —— 前提不成立, 不继续碰运气"')
+
+MUTATIONS = [
+    ("① 摘掉前提建立(回到偶发红那天)", [(CALL, "\n", 1)]),
+    ("② setup 成功但不生效(nft 全返回 0, conntrack 没激活)", [(CT_RULE, CT_NOOP, 1)]),
+    ("③ ② 之上再摘掉二次探针(让无效 setup 冒充已准备好)",
+     [(CT_RULE, CT_NOOP, 1), (REPROBE, '  rc=0', 1)]),
+    ("④ 摘掉清理(临时表留在 netns 里)", [("\n  drop_conntrack_table\n", "\n", 1)]),
+    ("⑤ 建不起来就 return 0(把前提失败降级成跳过)",
+     [("    3) : ;;", '    3) note "conntrack 未激活, 那就算了"; return 0 ;;', 1)]),
+    ("⑥ 只加一行无关注释(反向对照, 不该有新失败)",
+     [("ensure_conntrack(){", "# (负控的空转对照, 不改变任何行为)\nensure_conntrack(){", 1)]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+
+if not sudo_ok():
+    bad("需要免密 sudo —— 这支要真建 netns、真加载 nft 才有判据, 没有就等于没跑")
+    print("-" * 62)
+    print("functional-conntrack-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+    sys.exit(1)
+if run(["sudo", "-n", "nft", "--version"]).returncode != 0:
+    bad("sudo 下调不到 nft —— 这支要真加载 nft 才有判据, 没有就等于没跑")
+    print("-" * 62)
+    print("functional-conntrack-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+    sys.exit(1)
+
+wd = tmpguard.mkdtemp(prefix="pdg-fnct-negctl.")
+try:
+    for sub in ("tests", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)
+    script = Path(wd) / "tests/functional-test.sh"
+    pristine = script.read_text(encoding="utf-8")
+
+    # 钉死版 mihomo 备到工作副本里(不落正式树: prepare-mihomo.sh 认 PDG_TEST_BIN_DIR)。
+    # 干净 netns 里只有 lo, 下不了东西 —— 必须在进 netns **之前**备好, 并放到 PATH 上,
+    # 让 functional-test.sh 的 mihomo_usable() 认出它, 走"用现有 mihomo"那条路。
+    bindir = Path(wd) / "bin"
+    prep = subprocess.run(["bash", str(ROOT / "tests/prepare-mihomo.sh")],
+                          cwd=str(ROOT), capture_output=True, text=True, timeout=600,
+                          env={**os.environ, "PDG_TEST_BIN_DIR": str(bindir)})
+    if not (bindir / "mihomo").exists():
+        bad("备不出钉死版 mihomo, 后面每一格都无从判断: %s"
+            % (prep.stderr.strip()[-200:] or prep.stdout.strip()[-200:]))
+        raise SystemExit(1)
+    path = "%s:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" % bindir
+
+    def one(tag):
+        """在一个专属的干净 netns 里跑一遍, 返回 (失败集合, 残留表, 退出码)。"""
+        ns = "pdgfnct%d%s" % (os.getpid(), tag)
+        with Netns(ns) as n:
+            r = n.exec(["bash", str(script)], env_path=path)
+            return failures(r.stdout + r.stderr), n.stray_tables(), r.returncode
+
+    base_fs, base_stray, base_rc = one("b")
+    if base_rc == 0 and not base_fs and not base_stray:
+        ok("基线绿: 官方夹具在干净 netns 里自建前提并通过, 且没留下临时表")
+    else:
+        bad("基线就不绿(rc=%s, %d 条失败, %d 张残留表), 后面每一格都无从判断:"
+            % (base_rc, len(base_fs), len(base_stray)))
+        for f in sorted(base_fs)[:5]:
+            print("       " + f[:130])
+        for s in base_stray[:3]:
+            print("       残留: " + s[:110])
+        raise SystemExit(1)
+
+    for i, (label, edits) in enumerate(MUTATIONS):
+        mutated, aborted = pristine, False
+        for old, new, want_hits in edits:
+            hits = mutated.count(old)
+            if hits != want_hits:
+                bad("%s → 锚点 %r 命中 %d 次, 预期 %d(改坏器没打在预期位置)"
+                    % (label, re.sub(r"\s+", " ", old)[:40], hits, want_hits))
+                aborted = True
+                break
+            mutated = mutated.replace(old, new, 1)
+            # 校验"锚点被恰好消费掉一次", 不去数新内容出现几次: 删除型的改坏(① ④)替换成的
+            # 就是一个换行符, 全文有两百多个 —— 按新内容计数会把有效负控判成改坏器打偏。
+            # ⑥ 那种前缀插入, 替换内容里本来就含着锚点, 所以要把它带回来一起算。
+            want_left = want_hits - 1 + new.count(old)
+            left = mutated.count(old)
+            if left != want_left:
+                bad("%s → 替换后锚点还剩 %d 处, 预期 %d(没被吃掉或吃多了)"
+                    % (label, left, want_left))
+                aborted = True
+                break
+            if new and new not in mutated:
+                bad("%s → 替换内容没落进文件里" % label)
+                aborted = True
+                break
+        if aborted:
+            continue
+        script.write_text(mutated, encoding="utf-8")
+        if run(["bash", "-n", str(script)]).returncode != 0:
+            bad("%s → 改坏后语法不合法, 这条不算有效负控" % label)
+            script.write_text(pristine, encoding="utf-8")
+            continue
+        fs, stray, _rc = one(str(i))
+        script.write_text(pristine, encoding="utf-8")
+        added = fs - base_fs
+
+        if label.startswith("⑥"):
+            if added or stray:
+                bad("%s → 竟然新增了 %d 条失败 / %d 张残留表, 判据在看噪声"
+                    % (label, len(added), len(stray)))
+            else:
+                ok("%s → 0 条新增(判据不看噪声)" % label)
+            continue
+
+        if label.startswith("④"):
+            # 这一格的牙不在失败集合上: 摘掉清理并不影响用例通过, 变化只体现在现场。
+            if stray:
+                ok("%s → 残留守卫具名报出 %d 张表: %s" % (label, len(stray), stray[0][:60]))
+            else:
+                bad("%s → 清理都摘了却**没留下残留**, 残留守卫无效" % label)
+            continue
+
+        if not added:
+            bad("%s → 锚点命中但**0 条转红**, 负控无效" % label)
+            continue
+        ok("%s → 锚点 %d 条全命中, 新增 %d 条具名失败" % (label, len(edits), len(added)))
+        for f in sorted(added)[:2]:
+            print("       " + f[:128])
+        if label.startswith("③"):
+            # ③ 的重点不只是"红了", 而是**红的理由退化了**: 精确的前提诊断消失,
+            # 只剩下"三个格子都是空的"这种要靠猜的症状 —— 正是二次探针在挡的那件事。
+            precise = [f for f in added if "SO_ORIGINAL_DST 仍拿不到" in f]
+            if precise:
+                bad("③ → 摘了二次探针却仍报出精确诊断, 说明这格没打中那一环")
+            else:
+                ok("③ → 精确前提诊断消失, 只剩三格空的模糊症状(正是二次探针在挡的)")
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+clean = True
+for p in TOUCHED:
+    if sha(p) != before[p]:
+        bad("正式树被改动了! %s: %s → %s" % (p.name, before[p][:16], sha(p)[:16]))
+        clean = False
+    if os.stat(p).st_mode != modes[p]:
+        bad("正式树权限位变了! %s" % p.name)
+        clean = False
+if clean:
+    ok("正式树未被污染: functional-test.sh / origdst_probe.py sha256 与 mode 均一致")
+
+print("-" * 62)
+print("functional-conntrack-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/origdst_probe.py
+++ b/tests/origdst_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""探针: 本 netns 的 conntrack 在不在跟踪 —— 也就是 redir 入站能不能拿回原始目的地。
+
+mihomo 的 redir 入站在 accept 之后立刻 getsockopt(SOL_IP, SO_ORIGINAL_DST) 取原始目的地
+(deploy/firewall/nftables-mihomo.conf 开头就是这么写的)。那个 sockopt 由 conntrack 提供:
+本 netns 没启用 conntrack hook 时它返回 ENOENT —— mihomo 会**静默丢掉**这条连接, 于是三个
+出口日志全空, 表面上完全看不出真因(mihomo 自己在 warning 级别一个字都不打)。
+
+这支把那一个系统调用单独拿出来问一遍, 让前提失败在启动 mihomo **之前**就显形, 并且报出的
+是 errno, 而不是"三个格子都是空的"这种只能靠猜的症状。
+
+做法: 自己起一个只绑 127.0.0.1 的临时监听(端口交给内核挑, 不写死 —— 写死就会和并跑的
+测试撞), 连自己一次, 在 accept 出来的那个 fd 上问一次 SO_ORIGINAL_DST。不改任何系统状态。
+
+退出码(三档分明, 调用方据此决定建不建前提, 不允许把"问不出来"当成"可用"):
+  0  可用(conntrack 在跟踪)      stdout: ORIGDST=ok <ip:port>
+  3  ENOENT —— conntrack 未激活   stdout: ORIGDST=enoent …
+  4  其它错误(含探针自身起不来)   stdout: ORIGDST=error …
+"""
+import errno
+import socket
+import struct
+import sys
+import threading
+
+SO_ORIGINAL_DST = 80          # include/uapi/linux/netfilter_ipv4.h
+
+
+def main():
+    result = {}
+
+    def serve(srv):
+        try:
+            conn, _ = srv.accept()
+        except OSError as e:
+            result["rc"], result["msg"] = 4, "error accept 拿不到连接: %s" % e
+            return
+        try:
+            raw = conn.getsockopt(socket.SOL_IP, SO_ORIGINAL_DST, 16)
+            _fam, port, ip = struct.unpack_from("!HH4s", raw)
+            result["rc"] = 0
+            result["msg"] = "ok %s:%d" % (socket.inet_ntoa(ip), port)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                # 不是"没这个文件": conntrack 查不到本连接的条目就返回它。
+                result["rc"] = 3
+                result["msg"] = "enoent errno=2(ENOENT) 本 netns 的 conntrack 没在跟踪"
+            else:
+                result["rc"] = 4
+                result["msg"] = "error errno=%s(%s) %s" % (
+                    e.errno, errno.errorcode.get(e.errno, "?"), e.strerror)
+        finally:
+            conn.close()
+
+    try:
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.settimeout(5)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+    except OSError as e:
+        print("ORIGDST=error 探针自己起不来: %s" % e)
+        return 4
+
+    t = threading.Thread(target=serve, args=(srv,))
+    t.start()
+    try:
+        c = socket.create_connection(("127.0.0.1", port), timeout=5)
+        c.close()
+    except OSError as e:
+        print("ORIGDST=error 连不上探针自己的监听: %s" % e)
+        t.join(10)
+        srv.close()
+        return 4
+    t.join(10)
+    srv.close()
+    if not result:
+        print("ORIGDST=error 探针没拿到结果(accept 超时)")
+        return 4
+    print("ORIGDST=%s" % result["msg"])
+    return result["rc"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 先说结论: 产品没有缺陷

这一笔只修测试夹具。`deploy/`、`lib/`、install/uninstall、nft 生产模板、systemd unit、CI workflow 一个字节都没动 —— 相对 `main` 的生产 diff 为 **0**。

## 红灯与第一失败点

main 的 push run [32722985743](https://github.com/misaka-cpu/privdns-gateway/actions/runs/32722985743) 与更早的 [32579827324](https://github.com/misaka-cpu/privdns-gateway/actions/runs/32579827324) 都红在 `functional` job 的 `#4 流量层`，签名一模一样：

```
level=warning msg="Failed to start Redir UDP Listener: operation not permitted"
level=error   msg="Start Redir server error: operation not permitted"
[FAIL] SNI=alpha.test 未按预期到达 exitA(域名规则) (A='' B='' D='')
```

**那两行 `operation not permitted` 是良性的，不是失败原因。** strace 钉死它来自：

```
listen(3, 4096)                                                    = 0      ← TCP redir 入口正常
setsockopt(6, SOL_IP, IP_TRANSPARENT, [1], 4) = -1 EPERM (Operation not permitted)
```

那是 Redir **UDP** 监听器要 `CAP_NET_ADMIN`，TCP 那半照常 `listen` 成功，而本测试只走 TCP。非 root 跑必然有这两行 —— 本机实测非 root、零 caps 连跑 5 次，每次都打这两行，5/5 全过。

之前会误以为它相关，是因为 `functional-test.sh` **只在失败路径 `cat mh.out`**，三个绿 run 从头到尾没打印过 mihomo 日志。

真正的第一失败点在同一份 trace 里（该 trace 的 EPERM 条数为 0）：

```
accept4(3, {AF_INET, htons(53628), 127.0.0.1}, …)                  = 8
getsockopt(8, SOL_IP, 0x50 /* SO_ORIGINAL_DST */, …, [16]) = -1 ENOENT
```

mihomo 接下连接后立刻取原始目的地，拿到 ENOENT 就**静默丢弃**（warning 级别不打日志），于是三个出口一条都不写。

## 根因

`SO_ORIGINAL_DST` 由 conntrack 提供 —— 本 netns 没启用 conntrack hook 时返回 ENOENT。这个依赖是项目自己写在 `deploy/firewall/nftables-mihomo.conf:5` 的：「mihomo 靠 SO_ORIGINAL_DST 拿回原始 443/80/5228 再嗅 SNI 分流」。

生产上前提恒成立（nft 模板自带 `nat prerouting … redirect` 与 `ct state established,related accept` 两类规则）。**测试里却从未声明过这个前提**，一直靠宿主碰巧激活过 conntrack 白捡 —— runner 上捡不到就是一次假红。

单变量对照（同一 netns，只切换 conntrack 是否激活，其余逐字一致）：

| 条件 | `SO_ORIGINAL_DST` | 结果 |
|---|---|---|
| conntrack 未激活 | ENOENT | **5/5 红**，`A='' B='' D=''` |
| 加一条 `ct state` 规则 | 成功 | **5/5 绿**，4/4 用例命中 |

五个 run 的 runner image 完全相同（`ubuntu-24.04` / `20260816.277.1`），排除 runner 差异。

## 改动

**`tests/origdst_probe.py`**（新增，单用途 helper）：把那一个系统调用单独问一遍，三档退出 —— `0` 可用 / `3` ENOENT / `4` 其它 errno。自己绑 `127.0.0.1:0`（端口交给内核，不写死），不改任何系统状态。

**`tests/functional-test.sh`**（新增第 0 节，在启动 mihomo 之前）：

- 探针成功 → **完全 no-op**，不建任何规则
- `ENOENT` → 用 `sudo -n nft` 建一张本次运行独占、名字带 PID 的临时表（`pdgfunc$$`）。**只新建，不 flush、不碰任何既有表**；规则本身什么都不做，唯一作用是让内核为本 netns 注册 conntrack hook
- 建完**再探一次**：三条 nft 命令都返回 0，不等于 conntrack 真被激活。少了这一步，一个「成功但不生效」的 setup 就会冒充已准备好
- 其它 errno、缺 sudo、缺 nft → **具名硬失败，不是 SKIP**。跳过等于零覆盖，而零覆盖会以绿灯的样子出现
- 清理挂 EXIT trap：只删本轮自己建的那一张，删后确认不存在才注销登记，幂等；正常、断言失败、启动失败三条路径都执行

探 nft 用 `sudo -n nft --version` 而不是 `command -v nft`：nft 装在 `/usr/sbin`，非 root 的 PATH 通常不含那一段。

**测试仍以非 root 运行** —— 没有 `sudo bash tests/functional-test.sh`，没给 mihomo 设 file capability，没压那两行良性 EPERM，SNI A/B/final 三格一格没动。

## 判据

**`tests/negctl/functional-conntrack-fixture.py`**（新增）：六格变异，每格在一个**专属的干净 netns**（named netns，无任何 conntrack hook）里真跑一遍 functional 测试，比较具名失败集合与跑后残留表。

| 格 | 结果 |
|---|---|
| ① 摘掉前提建立 | 三格全空（回到偶发红那天） |
| ② setup 成功但不生效 | 二次探针具名报出 `SO_ORIGINAL_DST 仍拿不到` |
| ③ ② 之上再摘二次探针 | 精确诊断消失，只剩三格空的模糊症状 |
| ④ 摘掉清理 | 残留守卫报出 `table inet pdgfunc…` |
| ⑤ 建不起来就 `return 0` | 零覆盖没能披着绿灯出场 |
| ⑥ 只加无关注释 | 0 条新增（反向对照） |

**9 通过 / 0 失败**，跑后正式树 sha256 与 mode 均一致。用 named netns 而不是 `unshare -n`：残留判据要在脚本退出之后看那个 netns 里还剩什么，匿名 netns 随进程消失，④ 就永远抓不到东西。

## 本地验证

| 环境 | 结果 |
|---|---|
| conntrack 已激活、非 root、零 caps | **5/5 通过**，夹具 no-op |
| conntrack 未激活、sudo 可用 | **5/5 通过**，自动建表，跑后 0 残留 |
| conntrack 未激活、nft 建立改成 no-op | 二次探针具名失败（负控 ②） |
| conntrack 未激活、`sudo -u nobody` | 具名硬失败，**0 处 SKIP** |
| 清理注入失败 | 残留守卫转红（负控 ④） |

全量回归：250+ 支 × 两棵树逐条对照具名失败集合，归一化时间戳与随机临时目录名后 **分支引入失败 0**，256 支共有文件退出码全部一致。全量 `py_compile` / `bash -n` / CI 原样 ShellCheck / `git diff --check` 均干净。

## CI

`workflow_dispatch` run [32736198478](https://github.com/misaka-cpu/privdns-gateway/actions/runs/32736198478)，head 精确等于本分支 HEAD `f6b41e4`，attempt 1：**29/29 jobs、461/461 steps 全 success**，`functional #4` success。job 与 `(job, 序号, step 名)` 集合与既有基线完全一致。该 runner 上 conntrack 本就激活，夹具正确地走了 no-op 分支。

main 的红 run `32722985743` **未 rerun**（仍 attempt=1）。
