### PR TITLE
fix(lan): converge generated state after rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,12 @@ jobs:
       - name: "Location 改写: 真 Caddy 打真响应头(静态测试证明不了头被改了)"
         run: bash tests/test-lan-location-live.sh
 
+      - name: "内网面板门四: 受管反代路由与面板表双向对账(回滚后的静默漂移)"
+        run: python3 tests/test-lan-proxy-drift.py
+
+      - name: "内网面板回滚收敛: 派生产物跟随已恢复的模型, 且 render/apply 不假成功"
+        run: bash tests/test-lan-rollback-convergence.sh
+
       - name: "链路诊断采集器 (证书正常/临期/过期/错域名/损坏/误放私钥; 零写入零写锁)"
         run: python3 tests/test-link-status.py
 

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -927,6 +927,85 @@ _RL_WARN = ("warn", "限流", "mosdns 单客户端 QPS 兜底(rate_limiter)缺�
                             "'!$client_limiter → reject 5'。")
 _RL_WANT = {"qps": "200", "burst": "400", "mask4": "32", "mask6": "128"}
 
+def _lan_route_projection(text):
+    """把一份 Caddyfile 投影成 {host: 上游}。
+
+    **正反两侧共用这一个抽取器** —— 期望值那边也用它。抽取器自己有偏差时两边同样偏,
+    于是它不可能凭空造出"漂移"; 能造出漂移的只有真正的内容差异。
+    """
+    out, host = {}, None
+    for line in (text or "").splitlines():
+        m = re.match(r"^(\S+):443\s*\{", line)
+        if m:
+            host = m.group(1)
+            continue
+        m = re.match(r"^\s*reverse_proxy\s+(\S+)", line)
+        if m and host:
+            out[host] = m.group(1)
+            host = None
+    return out
+
+
+def check_lan_proxy_routes():
+    """门四: 受管的反代路由必须与面板表**双向一致**。
+
+    门三(check_lan_whitelist)看的是内核里的出站白名单, 这一条看的是**反代自己的配置**。
+    两者都由面板表派生, 但只有门三有人对账 —— 于是这种状态可以长期存在且零告警:
+
+        模型里已经没有 c 面板了, 而 caddy.conf 还在为 c 转发。
+
+    最典型的来源是回滚: /etc/privdns-gateway(面板表 + 启用意图)在全局快照内, 跟着回去了;
+    /etc/pdg-lan/caddy.conf 在快照之外, 留在原地。两个方向的危险不对称:
+      · 反代多出模型没有的站点 = 仍在服务一个**已经被移除**的面板;
+      · 反代少了模型有的站点   = 那个面板打不开, 而白名单是按模型放行的, 现场看着正常。
+
+    期望值用**真渲染器**(lanpanel.render_caddy)现渲, 不另写一套宽松版判据 —— 第二实现
+    迟早与真渲染器分叉, 而分叉方向通常是"判据比产品宽", 也就是假绿。
+    读不出来的一律 warn: "判据没跑成"与"判据成立"混成一句, 会让缺文件的机器看着像配置丢了。
+    """
+    name = "内网面板: 反代路由对账"
+    cfg = _lan_cfg()
+    if cfg is None:
+        return None                   # 从来没配过这个功能
+    on, _active = _lan_on()
+    if not on:
+        return ("ok", name, "内网面板已停用 —— 不适用")
+    lp = _lanpanel()
+    if lp is None:
+        return ("warn", name, "取不到 lanpanel 模块, 反代对账本次没跑")
+    try:
+        with open(LAN_CADDYFILE, encoding="utf-8") as f:
+            live_txt = f.read()
+    except OSError as e:
+        return ("warn", name, "读不到受管反代配置 %s(%s), 本项没跑成" % (LAN_CADDYFILE, e.__class__.__name__))
+    try:
+        want_txt = lp.render_caddy(cfg, LAN_CERT_DIR)
+    except Exception as e:  # noqa: BLE001  含 PanelError: 面板表自己就不合法
+        return ("warn", name, "面板表渲不出反代配置(%s), 对账本次没跑" % e)
+
+    live, want = _lan_route_projection(live_txt), _lan_route_projection(want_txt)
+    if want and not live:
+        return ("fail", name,
+                "面板表有 %d 个站点, 而受管反代配置里一个都解析不到 —— 反代此刻不按面板表工作。"
+                "跑 sudo pdg lan render 后重启 pdg-lan。" % len(want))
+    missing = sorted(h for h in want if h not in live)
+    extra = sorted(h for h in live if h not in want)
+    drift = sorted(h for h in want if h in live and live[h] != want[h])
+    if not (missing or extra or drift):
+        return ("ok", name, "反代路由与面板表逐条一致(%d 个站点)" % len(want))
+    parts = []
+    if extra:
+        parts.append("反代仍在服务面板表里没有的 %s —— 那些面板已经被移除, 而反代还在转发"
+                     % ", ".join(extra[:3]))
+    if missing:
+        parts.append("反代缺少面板表里的 %s —— 那些面板打不开, 而白名单是按表放行的, 看着一切正常"
+                     % ", ".join(missing[:3]))
+    if drift:
+        parts.append("上游对不上: %s" % ", ".join(
+            "%s(反代→%s, 表→%s)" % (h, live[h], want[h]) for h in drift[:3]))
+    return ("fail", name, "; ".join(parts) + "。跑 sudo pdg lan render 后重启 pdg-lan。")
+
+
 def check_mosdns_ratelimit():
     """单客户端 QPS 兜底(rate_limiter)是否就位且参数/动作正确:
     插件 client_limiter 是 rate_limiter 且 qps200/burst400/mask4-32/mask6-128;
@@ -1845,6 +1924,7 @@ def check_transactions():
 
 # ── 内网面板(方案 B) ─────────────────────────────────────────────────────────
 LAN_TABLE = "/etc/privdns-gateway/lan-panels.json"
+LAN_CADDYFILE = "/etc/pdg-lan/caddy.conf"
 LAN_CERT_DIR = "/etc/pdg-lan/certs"
 LAN_NFT_TABLE = "pdglan"
 LAN_USER = "pdg-lan"
@@ -2197,7 +2277,7 @@ def check_deep_lan_acl():
 ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue, check_tailnet_direct_port,
-       check_lan_routes, check_lan_whitelist, check_lan_cert,
+       check_lan_routes, check_lan_whitelist, check_lan_proxy_routes, check_lan_cert,
        check_mosdns_ratelimit, check_mosdns_explicit_proxy, check_ruleset_hijack,
        check_nft_extra, check_rescue_firewall, check_geosite_db, check_mem,
        check_cert, check_cert_dir_sync, check_dns, check_core_config, check_rulesets, check_rule_precedence,

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1452,6 +1452,11 @@ cmd_rollback(){
       c_y "     配置与服务已回滚; 代码仍是当前版本。要对齐就跑一次 pdg update, 或手工 git reset。"
     fi
   fi
+  # 内网面板的派生产物在全局快照之外, 得从**刚恢复的**模型现渲一遍才算回滚完整。
+  # 位置有讲究: 必须在上面的 git reset 之后 —— 生成器来自 REPO_DIR, 那一步才刚复位。
+  if ! _lan_rollback_converge; then
+    unrestored+=("内网面板派生产物")
+  fi
   if [[ ${#unrestored[@]} -eq 0 ]]; then
     echo "✅ 已回滚并重启服务"
   else
@@ -5237,38 +5242,126 @@ _lan_migrate_certs(){
   return 0
 }
 
+# 把面板表渲染成三个派生产物, **一笔局部事务**: 一起生成、一起校验、一起落盘,
+# 任一步不成立就整笔退回本次调用的前像。
+#
+# 为什么必须是一笔: 三个产物是同一个模型的三个投影。落一半 = 反代、防火墙、systemd
+# 各自看着不同版本的面板表, 而这种状态没有任何一条自检会报。旧实现有三个各自独立的
+# 写点, 而且:
+#   · `pdg_unit_lan_caddy … > "$LAN_UNIT"` —— 重定向**先截断正式文件**再执行, 生成失败
+#     就留下一个空 unit, 失败本身又被 `&&` 短路吞掉;
+#   · 函数最后一条是 `systemctl daemon-reload … || true` —— **恒为真**, 于是上面任何
+#     一步失败, 整个函数照样返回 0。调用方据此打印"已生成并生效"。
+#   · `install -m640 -o root -g "$LAN_USER" … || install -m644 …` —— 属组装不上就静默
+#     降级成 644 root:root, 而那份配置里是面板拓扑。
+#
+# 边界: 只碰这三个产物。凭据(dns.env / 证书 / acme 账户密钥)一个字节都不读不写 ——
+# 它们不是版本产物, 不随模型变化, 也不该出现在任何候选目录里。
 _lan_render(){
   _lan_migrate_certs
-  local mod tmpc tmpn legacy
+  local mod stg pre legacy cbin f base rc=0
   mod="$(_pdg_module lanpanel.py)" || { c_y "❌ 找不到 lanpanel.py"; return 1; }
-  tmpc="$(mktemp)"; tmpn="$(mktemp)"
-  if ! python3 "$mod" render "$LAN_TABLE_PATH" --certs "$LAN_CERT_DIR" > "$tmpc" 2>"$tmpc.err"; then
-    c_y "❌ 生成反代配置失败:"; sed 's/^/    /' "$tmpc.err" "$tmpc" 2>/dev/null | head -10
-    rm -f "$tmpc" "$tmpn" "$tmpc.err"; return 1
+  stg="$(_pdg_mktemp_dir)" || { c_y "❌ 候选目录创建失败(未改动任何文件)"; return 1; }
+  chmod 700 "$stg" 2>/dev/null || true      # 候选里是面板拓扑, 不给旁人看
+  pre="$stg/pre"
+  if ! mkdir -p "$pre"; then
+    c_y "❌ 前像目录创建失败(未改动任何文件)"; rm -rf "$stg"; return 1
   fi
-  if ! python3 "$mod" nft "$LAN_TABLE_PATH" --uid "$LAN_USER" > "$tmpn" 2>"$tmpn.err"; then
-    c_y "❌ 生成出站白名单失败:"; sed 's/^/    /' "$tmpn.err" 2>/dev/null | head -10
-    rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"; return 1
+
+  # ── ① 三个候选一起生成 ────────────────────────────────────────────────────
+  if ! python3 "$mod" render "$LAN_TABLE_PATH" --certs "$LAN_CERT_DIR" > "$stg/caddy.conf" 2>"$stg/err"; then
+    c_y "❌ 生成反代配置失败:"; sed 's/^/    /' "$stg/err" 2>/dev/null | head -10
+    rm -rf "$stg"; return 1
   fi
-  # 反代配置先让 caddy 自己判一遍再落盘。落一份它读不懂的配置, 症状是服务起不来,
-  # 而那时旧配置已经被覆盖 —— 连"退回去"都没得退。
-  if [[ -x /usr/local/bin/caddy ]]; then
-    if ! /usr/local/bin/caddy validate --config "$tmpc" --adapter caddyfile >/dev/null 2>&1; then
-      c_y "❌ 生成出来的反代配置 caddy 自己判为不合法, 拒绝落盘(现有配置未动):"
-      /usr/local/bin/caddy validate --config "$tmpc" --adapter caddyfile 2>&1 | head -6 | sed 's/^/    /'
-      rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"; return 1
-    fi
+  if ! python3 "$mod" nft "$LAN_TABLE_PATH" --uid "$LAN_USER" > "$stg/lan.nft" 2>"$stg/err"; then
+    c_y "❌ 生成出站白名单失败:"; sed 's/^/    /' "$stg/err" 2>/dev/null | head -10
+    rm -rf "$stg"; return 1
   fi
-  install -m640 -o root -g "$LAN_USER" "$tmpc" "$LAN_CADDYFILE" 2>/dev/null || install -m644 "$tmpc" "$LAN_CADDYFILE"
-  install -m644 "$tmpn" "$LAN_NFT_CONF"
-  rm -f "$tmpc" "$tmpn" "$tmpc.err" "$tmpn.err"
   legacy="$(python3 -c 'import importlib.util,sys
 spec=importlib.util.spec_from_file_location("lp",sys.argv[1]); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
 import json; print("1" if m.legacy_tls_panels(json.load(open(sys.argv[2]))) else "")' "$mod" "$LAN_TABLE_PATH" 2>/dev/null)"
   # shellcheck source=lib/units.sh
-  source "$REPO_DIR/lib/units.sh" 2>/dev/null || { c_y "❌ 读不到 lib/units.sh"; return 1; }
-  pdg_unit_lan_caddy "$legacy" > "$LAN_UNIT" && chmod 644 "$LAN_UNIT"
-  systemctl daemon-reload 2>/dev/null || true
+  if ! source "$REPO_DIR/lib/units.sh" 2>/dev/null; then
+    c_y "❌ 读不到 lib/units.sh(未改动任何文件)"; rm -rf "$stg"; return 1
+  fi
+  if ! pdg_unit_lan_caddy "$legacy" > "$stg/pdg-lan.service" || [[ ! -s "$stg/pdg-lan.service" ]]; then
+    c_y "❌ 生成 pdg-lan.service 失败(未改动任何文件)"; rm -rf "$stg"; return 1
+  fi
+
+  # ── ② 落盘前校验 ──────────────────────────────────────────────────────────
+  # 反代配置交给**真 Caddy**, 防火墙候选交给 nft -c。两者都只在工具可用时做 ——
+  # 拿"工具不在"当判据就是假红(§9.10)。caddy 的取用顺序与 tests/test-lan-location-live.sh
+  # 一致: 装好的那份优先, 否则 PATH。生产上 _lan_install_caddy 保证前者存在, 于是这条
+  # 只可能让校验**多跑**, 不会让它少跑。
+  cbin=""
+  if [[ -x /usr/local/bin/caddy ]]; then cbin=/usr/local/bin/caddy
+  elif command -v caddy >/dev/null 2>&1; then cbin="$(command -v caddy)"; fi
+  if [[ -n "$cbin" ]] && ! "$cbin" validate --config "$stg/caddy.conf" --adapter caddyfile >/dev/null 2>&1; then
+    c_y "❌ 生成出来的反代配置 caddy 自己判为不合法, 拒绝落盘(现有配置未动):"
+    "$cbin" validate --config "$stg/caddy.conf" --adapter caddyfile 2>&1 | head -6 | sed 's/^/    /'
+    rm -rf "$stg"; return 1
+  fi
+  if command -v nft >/dev/null 2>&1 && ! nft -c -f "$stg/lan.nft" >/dev/null 2>&1; then
+    c_y "❌ 生成出来的出站白名单 nft 判为不合法, 拒绝落盘(现有配置未动):"
+    nft -c -f "$stg/lan.nft" 2>&1 | head -6 | sed 's/^/    /'
+    rm -rf "$stg"; return 1
+  fi
+
+  # ── ③ 留前像 ──────────────────────────────────────────────────────────────
+  # 记下"本来存不存在": 本来没有的, 退回时要删掉而不是留一份新的。
+  for f in "$LAN_CADDYFILE" "$LAN_NFT_CONF" "$LAN_UNIT"; do
+    base="$(basename "$f")"
+    if [[ -e "$f" ]]; then
+      cp -a "$f" "$pre/$base" || { c_y "❌ 备份前像失败(未改动任何文件): $f"; rm -rf "$stg"; return 1; }
+    else
+      : > "$pre/$base.absent"
+    fi
+  done
+
+  # ── ④ 落盘 ────────────────────────────────────────────────────────────────
+  _lan_install_managed "$stg/caddy.conf"      "$LAN_CADDYFILE" 640 "$LAN_USER" || rc=1
+  [[ "$rc" == 0 ]] && { _lan_install_managed "$stg/lan.nft"    "$LAN_NFT_CONF"  644 ""          || rc=1; }
+  [[ "$rc" == 0 ]] && { _lan_install_managed "$stg/pdg-lan.service" "$LAN_UNIT" 644 ""          || rc=1; }
+  # daemon-reload 属于这一笔: 新 unit 落了盘而 systemd 不知道, 等于没换。
+  # 旧实现这里是 `|| true` —— 那是整个函数假成功的最后一环。
+  [[ "$rc" == 0 ]] && { systemctl daemon-reload 2>/dev/null || rc=1; }
+
+  if [[ "$rc" != 0 ]]; then
+    c_y "❌ 派生产物落盘失败 → 整笔退回本次调用前的状态。"
+    _lan_restore_pre "$pre"
+    systemctl daemon-reload 2>/dev/null || true
+    rm -rf "$stg"; return 1
+  fi
+  rm -rf "$stg"
+  return 0
+}
+
+# 落一个受管产物。**没有静默降级的退路**: 属组/权限设不成就是失败。
+# 旧实现的 `|| install -m644` 会把一份 640 root:pdg-lan 的配置悄悄变成 644 root:root。
+# 属主设成 root 只在真的是 root 时做 —— 不是 root 就没有这个权力, 而生产上这个函数
+# 只经 need_root 之后才可能被调到。
+_lan_install_managed(){
+  local src="$1" dst="$2" mode="$3" grp="${4:-}"
+  install -m "$mode" "$src" "$dst" 2>/dev/null || { c_y "  落盘失败: $dst"; return 1; }
+  if [[ -n "$grp" ]]; then
+    chgrp "$grp" "$dst" 2>/dev/null || { c_y "  属组设不成 $grp(不静默降级): $dst"; return 1; }
+    [[ $EUID -eq 0 ]] && { chown root "$dst" 2>/dev/null || { c_y "  属主设不成 root: $dst"; return 1; }; }
+  fi
+  return 0
+}
+
+# 把三个受管产物退回前像。本来不存在的删掉 —— 留一份"回滚前没有过"的新文件
+# 同样是半套状态, 只是方向相反。
+_lan_restore_pre(){
+  local pre="$1" f base
+  for f in "$LAN_CADDYFILE" "$LAN_NFT_CONF" "$LAN_UNIT"; do
+    base="$(basename "$f")"
+    if [[ -e "$pre/$base.absent" ]]; then
+      rm -f "$f" 2>/dev/null || true
+    elif [[ -e "$pre/$base" ]]; then
+      cp -a "$pre/$base" "$f" 2>/dev/null || c_y "  ⚠️ 前像退回失败: $f"
+    fi
+  done
 }
 
 # 现有证书的 SAN 没覆盖到的面板(空 = 都覆盖了)。preflight 与 add/rm 共用这一份判据 ——
@@ -5314,6 +5407,53 @@ _lan_apply_proxy(){
   return 1
 }
 
+# 回滚收尾: 让三个派生产物跟上**刚恢复的**模型。
+#
+# 现场是这样出现的: /etc/privdns-gateway/{lan-panels.json, profile.env} 在全局快照内,
+# 回滚把它们带回去了; 而 caddy.conf / nftables-pdg-lan.conf / pdg-lan.service 都在快照
+# 之外, 回滚一个字节都不碰。于是模型是旧的、产物是新的 —— 白名单那半有 doctor 逐条对账,
+# 反代那半在门四之前根本没人看。
+#
+# ⚠️ 调用点必须在 **git reset 之后**: _lan_render 会 source "$REPO_DIR/lib/units.sh"
+# 并经 _pdg_module 取 lanpanel.py, 而仓库在 cmd_rollback 的最后一步才复位。插在它之前
+# 等于拿**新版**生成器去渲**旧版**模型, 那正是要消除的那类半新半旧。
+#
+# 边界(三条都不许放宽):
+#   · 只碰那三个派生产物。凭据(dns.env / 证书 / acme 账户密钥)不读不写;
+#   · 绝不签证书、不下载、不读 tailnet —— 回滚是把现场退回去, 不是重建一遍;
+#   · **不碰 mosdns 劫持集与 mihomo 分流**: /etc/mosdns 与 /etc/mihomo 本来就在快照里,
+#     已经跟着回滚了。在这里再 _lan_wire 一次, 等于拿当前状态覆盖掉刚恢复的那一份。
+_lan_rollback_converge(){
+  local intent active=0
+  intent="$(_lan_intent)"
+  systemctl is-active --quiet pdg-lan 2>/dev/null && active=1
+
+  if [[ "$intent" == 1 ]]; then
+    if ! _lan_render; then
+      c_y "⚠️ LAN 回滚不完整: 派生产物没能按恢复出来的面板表重新生成(第一失败点: 渲染/落盘)。"
+      c_y "   面板表与 profile 已经回滚到位; 反代仍在用回滚前的配置。手工补: sudo pdg lan render"
+      return 1
+    fi
+    if ! _lan_apply_proxy; then
+      c_y "⚠️ LAN 回滚不完整: 产物已按面板表更新, 但反代没能重启(第一失败点: 重启 pdg-lan)。"
+      c_y "   此刻磁盘是新的、进程还用着旧的。手工补: sudo systemctl restart pdg-lan"
+      return 1
+    fi
+    return 0
+  fi
+
+  # 意图是"停用"。**只有确实还有东西在跑或在盘上时**才收敛: 从未启用过面板的机器上
+  # _lan_disable 会往 profile.env 写一个快照里根本没有的 PDG_LAN_ENABLED=0 ——
+  # 那是在改写刚刚恢复出来的状态, 方向虽小, 性质与漂移相同。
+  if (( active == 1 )) || [[ -e "$LAN_UNIT" || -s "$LAN_NFT_CONF" ]]; then
+    if ! _lan_disable >/dev/null; then
+      c_y "⚠️ LAN 回滚不完整: 面板已回到停用态, 但反代没能停下来(第一失败点: 停用 pdg-lan)。"
+      return 1
+    fi
+  fi
+  return 0
+}
+
 _lan_sync_after_change(){
   local on active
   on="$(_lan_intent)"; active=0
@@ -5324,7 +5464,9 @@ _lan_sync_after_change(){
   fi
   _lan_render || { c_y "⚠️ 反代配置/白名单没能重新生成 —— 新面板还不会生效。"; return 1; }
   _lan_wire   || { c_y "⚠️ DNS 劫持集/分流没能同步 —— 新面板还不会生效。"; return 1; }
-  _lan_apply_proxy || true   # 已经自己报过原因了, 不因此中断后面的证书提示
+  # 失败必须向上传播: 这里曾是 `|| true` —— 反代没重启起来, 而调用方照旧打印"已同步"。
+  # "磁盘对了、进程没跟上"是本项目反复出事的那个形态, 不能由一句成功文案盖过去。
+  _lan_apply_proxy || return 1
   c_g "✅ 反代配置、出站白名单、DNS 劫持集与分流已同步。"
   local miss; miss="$(_lan_cert_missing)"
   if [[ -n "$miss" ]]; then
@@ -5476,7 +5618,10 @@ migrate_lan_caddy_reender(){
     c_y "             手工补救: sudo pdg lan render"
     return 0                                             # 不拖垮整次更新: 旧规则只影响个别上游
   fi
-  _lan_apply_proxy || true
+  if ! _lan_apply_proxy; then
+    c_y "  [面板迁移] 配置已重新生成, 但反代没能重启 —— 进程仍用着旧规则。"
+    return 1                                   # 调用侧(cmd_update)自带 `|| true`, 不拖垮整次更新
+  fi
   c_g "  [面板迁移] 已重新生成并生效。"
 }
 
@@ -5636,7 +5781,7 @@ cmd_lan(){
     render)    need_root lan
                _lan_render || return 1
                # 只生成不重启 = 文件是新的、进程还用着旧的。撞过一次, 见 _lan_apply_proxy。
-               _lan_apply_proxy || true
+               _lan_apply_proxy || return 1
                c_g "✅ 反代配置与出站白名单已按面板表重新生成并生效。"
                _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;
     wire)      need_root lan; _lan_wire && c_g "✅ DNS 劫持集与 mihomo 分流已同步。";;

--- a/tests/lan-fixture.sh
+++ b/tests/lan-fixture.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 内网面板这一组测试的共用夹具: 把 pdg.sh 里的**生产函数原样**抽进沙箱跑, 不复制实现。
+#
+# 为什么单独一份: test-lan-rollback-convergence.sh 与 negctl 那支要抽同一批函数, 两边
+# 各写一遍迟早不一致 —— 而不一致的方向是"负控抽到了、正控没抽到", 于是负控看起来有牙,
+# 实际上两边测的根本不是同一个闭包。
+#
+# ⚠️ 抽取有两个已知陷阱, 这里各堵一个:
+#
+#   ① **单行函数会被范围抽取吃穿**(§9.7)。`_lan_intent(){ …; }` 写在一行上, 而
+#      `sed -n '/^_lan_intent()/,/^}/p'` 会一路吃到**下一个**函数的收尾花括号, 于是
+#      沙箱里凭空多出半个函数定义。lan_fx_extract 先判形态再决定取一行还是取范围。
+#
+#   ② **漏抽依赖 = 静默 127**(§10.7)。被测函数新增一个内部调用而抽取清单没跟上时,
+#      那次调用返回 127, 而报错指向别处("形态认不出""nft 动作不对")。lan_fx_guard127
+#      把 command not found 提成**具名失败**, 不许它伪装成被测行为。
+# ─────────────────────────────────────────────────────────────────────────────
+
+LAN_FX_SRC="${LAN_FX_SRC:?lan-fixture.sh 需要 LAN_FX_SRC 指向 deploy/bot/pdg.sh}"
+
+# 抽一个函数。单行形态只取那一行, 多行形态取到第一个顶格 `}`。
+lan_fx_extract(){
+  local fn="$1" ln
+  ln="$(grep -n "^${fn}()" "$LAN_FX_SRC" | head -1 | cut -d: -f1)"
+  [[ -n "$ln" ]] || { echo "lan-fixture: 抽不到函数 $fn(改名了?)" >&2; return 1; }
+  if sed -n "${ln}p" "$LAN_FX_SRC" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*\(\)\{.*\}[[:space:]]*$'; then
+    sed -n "${ln}p" "$LAN_FX_SRC"
+  else
+    sed -n "${ln},/^}/p" "$LAN_FX_SRC"
+  fi
+}
+
+# 本组测试要用到的生产函数闭包。**新增内部调用时这张表要跟着改** —— 漏了会被
+# lan_fx_guard127 抓成具名失败, 而不是变成一条看不懂的断言。
+LAN_FX_FUNCS=(
+  c_g c_y
+  _pdg_mktemp_dir _pdg_module
+  _lan_hosts _lan_intent _lan_migrate_certs _lan_cert_missing
+  _lan_render _lan_apply_proxy _lan_sync_after_change _lan_disable
+)
+
+# 把闭包写成一个可 source 的文件。缺哪个就整体失败, 不半截交付。
+lan_fx_emit(){
+  local out="$1" fn extra
+  : > "$out"
+  for fn in "${LAN_FX_FUNCS[@]}" "${@:2}"; do
+    lan_fx_extract "$fn" >> "$out" || return 1
+    echo >> "$out"
+  done
+  # 可选函数: 存在才抽(本轮新增的收敛入口在基线上还不存在, 缺席要能被具名报出来)
+  for extra in "${LAN_FX_OPTIONAL[@]:-}"; do
+    [[ -n "$extra" ]] || continue
+    grep -q "^${extra}()" "$LAN_FX_SRC" && { lan_fx_extract "$extra" >> "$out"; echo >> "$out"; }
+  done
+  return 0
+}
+
+# 沙箱假根: 造出 LAN 那几条路径, 并把生产变量指过去。
+# 凭据(dns.env / certs)一并造出来 —— 收敛路径**不许碰它们**, 没有它们就证明不了这一条。
+lan_fx_sandbox(){
+  local w="$1"
+  mkdir -p "$w/etc/pdg-lan/certs" "$w/etc/privdns-gateway" "$w/etc/systemd/system" \
+           "$w/var/lib/pdg-lan" "$w/bin" "$w/state"
+  # 证书必须是**真 PEM**: 生成物要交给真 Caddy 校验, 假证书会让校验在到达注入点之前就失败,
+  # 于是每一格都"红得很像样"而其实什么都没测到 —— 这支测试第一版就栽在这里。
+  if [[ -n "${LAN_FX_PEM_DIR:-}" && -s "$LAN_FX_PEM_DIR/panel.crt" ]]; then
+    cp "$LAN_FX_PEM_DIR/panel.crt" "$LAN_FX_PEM_DIR/panel.key" "$w/etc/pdg-lan/certs/"
+  else
+    echo "lan-fixture: 需要 LAN_FX_PEM_DIR 指向一对真 PEM" >&2; return 1
+  fi
+  echo "CF_Token=must-not-be-touched" > "$w/etc/pdg-lan/dns.env"
+  chmod 600 "$w/etc/pdg-lan/dns.env"
+}
+
+# 沙箱里的 PATH 桩。systemctl/nft/caddy 都按**状态派生**回答, 不返回恒定的"健康"(§9.1)。
+# 每个桩把自己的调用记进 $w/calls.log —— 断言要能指认是哪一步做的, 不能只看最终文件。
+lan_fx_stubs(){
+  local w="$1"
+  cat > "$w/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+echo "systemctl $*" >> "$FX_CALLS"
+case "$1" in
+  is-active)
+    shift; [[ "${1:-}" == "--quiet" ]] && shift
+    [[ -e "$FX_ROOT/state/active" ]] || exit 3
+    echo active; exit 0;;
+  daemon-reload) [[ -e "$FX_ROOT/state/reload-fails" ]] && exit 1; exit 0;;
+  restart)
+    [[ -e "$FX_ROOT/state/restart-fails" ]] && exit 1
+    touch "$FX_ROOT/state/active"; exit 0;;
+  disable) rm -f "$FX_ROOT/state/active"; exit 0;;
+  *) exit 0;;
+esac
+STUB
+  cat > "$w/bin/nft" <<'STUB'
+#!/usr/bin/env bash
+echo "nft $*" >> "$FX_CALLS"
+# -c 是"只校验": 候选文件语法坏了要说不。故障注入用 state/nft-check-fails。
+if [[ "${1:-}" == "-c" ]]; then
+  [[ -e "$FX_ROOT/state/nft-check-fails" ]] && { echo "nft: syntax error" >&2; exit 1; }
+  exit 0
+fi
+if [[ "${1:-}" == "delete" ]]; then rm -f "$FX_ROOT/state/pdglan-table"; exit 0; fi
+if [[ "${1:-}" == "-f" ]]; then touch "$FX_ROOT/state/pdglan-table"; exit 0; fi
+exit 0
+STUB
+  chmod 755 "$w/bin/systemctl" "$w/bin/nft"
+}
+
+# 生产变量绑到沙箱。REPO_DIR 指真仓库 —— lanpanel.py / units.sh 必须是**真的那一份**。
+lan_fx_bind(){
+  local w="$1" repo="$2"
+  export FX_ROOT="$w" FX_CALLS="$w/calls.log"
+  mkdir -p "$w/state"
+  : > "$FX_CALLS"
+  REPO_DIR="$repo"
+  LAN_USER="$(id -un)"                      # 沙箱里不建系统用户: 用当前用户, install -o/-g 才可能成功
+  LAN_ETC="$w/etc/pdg-lan"
+  LAN_CADDYFILE="$LAN_ETC/caddy.conf"
+  LAN_NFT_CONF="$w/etc/nftables-pdg-lan.conf"
+  LAN_CERT_DIR="$LAN_ETC/certs"
+  LAN_DNS_ENV="$LAN_ETC/dns.env"
+  LAN_UNIT="$w/etc/systemd/system/pdg-lan.service"
+  LAN_STATE_DIR="$w/var/lib/pdg-lan"
+  LAN_TABLE_PATH="$w/etc/privdns-gateway/lan-panels.json"
+  PROFILE_ENV="$w/etc/privdns-gateway/profile.env"
+  ACME_HOME="$w/opt/pdg-acme"
+  export REPO_DIR LAN_USER LAN_ETC LAN_CADDYFILE LAN_NFT_CONF LAN_CERT_DIR LAN_DNS_ENV \
+         LAN_UNIT LAN_STATE_DIR LAN_TABLE_PATH PROFILE_ENV ACME_HOME
+  PATH="$w/bin:$PATH"; export PATH
+}
+
+# 写一份面板表。参数: <文件> <name:host:ip:port> …
+lan_fx_model(){
+  local out="$1"; shift
+  python3 - "$out" "$@" <<'PY'
+import json, sys
+out = sys.argv[1]
+panels = []
+for spec in sys.argv[2:]:
+    name, host, ip, port = spec.split(":")
+    panels.append({"name": name, "host": host, "target": "http://%s:%s" % (ip, port)})
+json.dump({"panels": panels}, open(out, "w"), ensure_ascii=False, indent=2)
+PY
+}
+
+# 从**任意** Caddyfile 抽 (host → 上游) 投影。正反两侧共用这一个抽取器 ——
+# 抽取器自己有偏差时两边同样偏, 不会凭空造出"漂移"。
+lan_fx_routes(){
+  python3 - "$1" <<'PY'
+import re, sys
+try:
+    txt = open(sys.argv[1], encoding="utf-8").read()
+except OSError:
+    sys.exit(0)
+host = None
+for line in txt.splitlines():
+    m = re.match(r'^(\S+):443\s*\{', line)
+    if m:
+        host = m.group(1); continue
+    m = re.match(r'^\s*reverse_proxy\s+(\S+)', line)
+    if m and host:
+        print("%s=%s" % (host, m.group(1))); host = None
+PY
+}
+
+# 127 守卫: 漏抽依赖时把它提成具名失败, 不让它伪装成被测行为(§10.7)。
+lan_fx_guard127(){
+  local logf="$1"
+  grep -q 'command not found' "$logf" 2>/dev/null && {
+    echo "夹具漏抽依赖(127): $(grep -o '[A-Za-z_][A-Za-z0-9_]*: command not found' "$logf" | sort -u | tr '\n' ' ')"
+    return 1
+  }
+  return 0
+}
+
+# 一对自签 PEM, 覆盖测试用的面板域名。生成一次, 各沙箱复制。
+lan_fx_make_pem(){
+  local d="$1"; mkdir -p "$d"
+  openssl req -x509 -newkey rsa:2048 -keyout "$d/panel.key" -out "$d/panel.crt" \
+    -days 2 -nodes -subj "/CN=lan.test" \
+    -addext "subjectAltName=DNS:a.lan.test,DNS:b.lan.test,DNS:c.lan.test,DNS:p1.lan.test" \
+    >/dev/null 2>&1 || return 1
+  [[ -s "$d/panel.crt" && -s "$d/panel.key" ]]
+}
+
+# 真 Caddy: 本地 → PATH → 按 lib/versions.sh 钉死的 SHA 下载。拿不到**硬失败**, 不跳过 ——
+# 口径与 tests/test-lan-location-live.sh 一致, 不另立一套信任链。
+lan_fx_caddy(){
+  local root="$1" wd="$2" arch url
+  if [[ -x /usr/local/bin/caddy ]]; then echo /usr/local/bin/caddy; return 0; fi
+  if command -v caddy >/dev/null 2>&1; then command -v caddy; return 0; fi
+  # shellcheck source=lib/versions.sh
+  source "$root/lib/versions.sh" 2>/dev/null || return 1
+  case "$(dpkg --print-architecture 2>/dev/null)" in amd64) arch=amd64;; arm64) arch=arm64;; *) return 1;; esac
+  url="https://github.com/caddyserver/caddy/releases/download/${CADDY_VER}/caddy_${CADDY_VER#v}_linux_${arch}.tar.gz"
+  curl -fsSL --max-time 120 -o "$wd/caddy.tgz" "$url" 2>/dev/null || return 1
+  pdg_verify_sha256 "$wd/caddy.tgz" "${PDG_SHA256[caddy-$arch]:-}" "caddy $CADDY_VER" >/dev/null 2>&1 || return 1
+  tar -xzf "$wd/caddy.tgz" -C "$wd" caddy 2>/dev/null || return 1
+  chmod +x "$wd/caddy"; echo "$wd/caddy"
+}

--- a/tests/lan-fixture.sh
+++ b/tests/lan-fixture.sh
@@ -37,9 +37,16 @@ lan_fx_extract(){
 LAN_FX_FUNCS=(
   c_g c_y
   _pdg_mktemp_dir _pdg_module
+  _profile_set
   _lan_hosts _lan_intent _lan_migrate_certs _lan_cert_missing
-  _lan_render _lan_apply_proxy _lan_sync_after_change _lan_disable
+  _lan_render _lan_install_managed _lan_restore_pre
+  _lan_apply_proxy _lan_sync_after_change _lan_disable
 )
+
+# 沙箱专用的桩(**不是**生产函数): need_root 在非 root 下会 exit 1, 而这一组测的不是
+# 权限门。写在这里而不是各测试里各写一份, 免得两支对"沙箱里什么算已就绪"的假设分叉。
+LAN_FX_STUB_FUNCS='need_root(){ :; }'
+
 
 # 把闭包写成一个可 source 的文件。缺哪个就整体失败, 不半截交付。
 lan_fx_emit(){
@@ -49,6 +56,7 @@ lan_fx_emit(){
     lan_fx_extract "$fn" >> "$out" || return 1
     echo >> "$out"
   done
+  printf '%s\n\n' "$LAN_FX_STUB_FUNCS" >> "$out"
   # 可选函数: 存在才抽(本轮新增的收敛入口在基线上还不存在, 缺席要能被具名报出来)
   for extra in "${LAN_FX_OPTIONAL[@]:-}"; do
     [[ -n "$extra" ]] || continue

--- a/tests/negctl/lan-rollback-convergence-negative-controls.py
+++ b/tests/negctl/lan-rollback-convergence-negative-controls.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""负控: LAN 回滚收敛这一套判据有没有牙。
+
+被盯的东西在两处 —— pdg.sh 的 `_lan_render` / `_lan_rollback_converge` / 三处 apply 调用点,
+以及 checks.py 的门四。这一支回答的是另一个问题: **如果它们退化了, 我们会不会知道?**
+
+做法是逐格把**生产代码**改坏(只改工作副本, 正式树一个字节不动), 再跑那两支聚焦测试,
+看具名失败集合相对基线有没有新增。基线 = 未改坏的同一份副本, 必须全绿 —— 基线不绿的话
+后面每一格的"新增"都算不出来。
+
+每格五步, 缺一不算有效(规矩见 HANDOFF §6):
+  · 锚点在整份文件里**恰好命中**预期次数(多了少了都说明改坏器没打在预期位置);
+  · 替换确实落进了文件, 且锚点恰好被消费掉;
+  · 改坏后语法门仍过(`bash -n` / `py_compile`)—— 语法错造成的红不算"判据抓住了";
+  · 失败集合有**具名新增**(0 条转红 = 这一格无效, 判 FAIL);
+  · 恢复后正式树 sha256 与 before-image 逐字节一致。
+
+九格:
+  ① 摘掉 cmd_rollback 里的收敛调用      —— D 组(按执行顺序判的那条)该转红;
+  ② 收敛函数改成空转 return 0           —— C 组该转红: 模型回去了产物没跟上;
+  ③ _lan_render 落盘失败洗成 return 0   —— A 组该转红, 这正是修掉的那个假成功;
+  ④ 摘掉失败时的前像退回                —— "半套状态"那两条该转红;
+  ⑤ 恢复 `_lan_apply_proxy || true`     —— B 组该转红, 这是被吞掉的失败;
+  ⑥ 摘掉停用方向的收敛分支              —— C3 该转红(只顾启用方向是最容易漏的那半);
+  ⑦ 门四只报"缺少"不报"多出"            —— 漂移里最危险的那个方向该转红;
+  ⑧ 门四把"读不到"判成 fail             —— 假红也是坏判据: 把"没跑成"说成"不一致";
+  ⑨ 只加无关注释                        —— 反向对照, 不该有任何新失败。
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402 - 一次性临时目录: 建了就登记, 退出即清
+
+ROOT = Path(__file__).resolve().parents[2]
+TOUCHED = [ROOT / "deploy/bot/pdg.sh", ROOT / "deploy/bot/checks.py"]
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def run(cmd, cwd=None, timeout=900):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+
+
+def failures(out):
+    """具名失败集合。归一化掉时间戳/随机临时目录/PID —— 否则同一条失败会因为
+    `tmp.a9m4kpkt` vs `tmp.n17y1tpp` 被算成"一增一减"(§9.15)。"""
+    s = set()
+    for line in out.splitlines():
+        if not line.startswith("[FAIL]"):
+            continue
+        t = re.sub(r"/tmp/[^\s,)]+", "/tmp/X", line.strip())
+        t = re.sub(r"\b[0-9a-f]{12,64}\b", "H", t)
+        t = re.sub(r"\b\d{4,}\b", "N", t)
+        s.add(t)
+    return s
+
+
+# ── 两支聚焦测试 ────────────────────────────────────────────────────────────
+SH = "tests/test-lan-rollback-convergence.sh"
+PY_ = "tests/test-lan-proxy-drift.py"
+
+
+def run_suites(wd):
+    """在工作副本里跑两支, 回显 (具名失败集合, 是否有崩溃迹象)。"""
+    out = ""
+    for cmd in (["bash", SH], ["python3", PY_]):
+        r = run(cmd, cwd=wd)
+        out += r.stdout + r.stderr
+    return failures(out), out
+
+
+# 每格 = (标签, 文件, [(锚点, 替换, 预期命中数), …], 期望转红的关键词)
+PDG = "deploy/bot/pdg.sh"
+CHK = "deploy/bot/checks.py"
+
+CONV_CALL = """  if ! _lan_rollback_converge; then
+    unrestored+=("内网面板派生产物")
+  fi
+"""
+CONV_BODY_ANCHOR = """_lan_rollback_converge(){
+  local intent active=0"""
+RENDER_FAIL = """    c_y "❌ 派生产物落盘失败 → 整笔退回本次调用前的状态。"
+    _lan_restore_pre "$pre\""""
+APPLY_SYNC = """  _lan_apply_proxy || return 1
+  c_g "✅ 反代配置、出站白名单、DNS 劫持集与分流已同步。\""""
+DISABLED_BRANCH = """  if (( active == 1 )) || [[ -e "$LAN_UNIT" || -s "$LAN_NFT_CONF" ]]; then
+    if ! _lan_disable >/dev/null; then"""
+EXTRA_DIR = """    if extra:
+        parts.append("反代仍在服务面板表里没有的 %s"""
+WARN_UNREADABLE = """        return ("warn", name, "读不到受管反代配置 %s(%s), 本项没跑成" % (LAN_CADDYFILE, e.__class__.__name__))"""
+
+MUTATIONS = [
+    ("① 摘掉 cmd_rollback 里的收敛调用", PDG, [(CONV_CALL, "", 1)], "D1"),
+    ("② 收敛函数空转(什么都不做就说成功)", PDG,
+     [(CONV_BODY_ANCHOR, "_lan_rollback_converge(){\n  return 0\n  local intent active=0", 1)], "C"),
+    ("③ _lan_render 落盘失败洗成 return 0", PDG,
+     [('    rm -rf "$stg"; return 1\n  fi\n  rm -rf "$stg"\n  return 0',
+       '    rm -rf "$stg"; return 0\n  fi\n  rm -rf "$stg"\n  return 0', 1)], "A"),
+    ("④ 摘掉失败时的前像退回", PDG,
+     [(RENDER_FAIL, '    c_y "❌ 派生产物落盘失败 → 整笔退回本次调用前的状态。"', 1)], "半套状态"),
+    ("⑤ 恢复 `_lan_apply_proxy || true`", PDG,
+     [(APPLY_SYNC, '  _lan_apply_proxy || true\n  c_g "✅ 反代配置、出站白名单、DNS 劫持集与分流已同步。"', 1)], "B"),
+    ("⑥ 摘掉停用方向的收敛分支", PDG,
+     [(DISABLED_BRANCH, '  if false; then\n    if ! _lan_disable >/dev/null; then', 1)], "C3"),
+    ("⑦ 门四只报缺少、不报多出", CHK,
+     [(EXTRA_DIR, '    if False:\n        parts.append("反代仍在服务面板表里没有的 %s', 1)], "③"),
+    ("⑧ 门四把读不到判成 fail(把没跑成说成不一致)", CHK,
+     [(WARN_UNREADABLE, '        return ("fail", name, "读不到受管反代配置 %s(%s)" % (LAN_CADDYFILE, e.__class__.__name__))', 1)], "⑧"),
+    ("⑨ 只加一行无关注释(反向对照)", PDG,
+     [("_lan_rollback_converge(){", "# (负控的空转对照, 不改变任何行为)\n_lan_rollback_converge(){", 1)], None),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+
+wd = tmpguard.mkdtemp(prefix="pdg-lanconv-negctl.")
+try:
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True,
+                        symlinks=True, ignore=shutil.ignore_patterns("__pycache__"))
+    pristine = {rel: (Path(wd) / rel).read_text(encoding="utf-8") for rel in (PDG, CHK)}
+
+    # ── 基线: 未改坏的同一份副本必须全绿 ────────────────────────────────────
+    base_fails, base_out = run_suites(wd)
+    if base_fails:
+        bad("基线(未改坏)就有 %d 条失败 —— 后面每一格的'新增'都算不出来: %s"
+            % (len(base_fails), sorted(base_fails)[:2]))
+        raise SystemExit(1)
+    ok("基线: 两支聚焦测试在工作副本里全绿(具名失败 0 条)")
+
+    for label, rel, edits, want_kw in MUTATIONS:
+        target = Path(wd) / rel
+        text = pristine[rel]
+        anchored = True
+        for anchor, repl, want_hits in edits:
+            hits = text.count(anchor)
+            if hits != want_hits:
+                bad("%s: 锚点命中 %d 次(应为 %d)—— 改坏器没打在预期位置" % (label, hits, want_hits))
+                anchored = False
+                break
+            text = text.replace(anchor, repl, 1)
+        if not anchored:
+            target.write_text(pristine[rel], encoding="utf-8")
+            continue
+        if text == pristine[rel]:
+            bad("%s: 替换没有真的落进文件" % label)
+            continue
+        target.write_text(text, encoding="utf-8")
+
+        # 语法门: 语法错造成的红不算"判据抓住了"
+        if rel.endswith(".sh"):
+            syn = run(["bash", "-n", str(target)])
+        else:
+            syn = run(["python3", "-m", "py_compile", str(target)])
+        if syn.returncode != 0:
+            bad("%s: 改坏后语法门不过 —— 这一格的红不作数(%s)"
+                % (label, (syn.stderr or "").strip()[:80]))
+            target.write_text(pristine[rel], encoding="utf-8")
+            continue
+
+        got, out = run_suites(wd)
+        new = got - base_fails
+        target.write_text(pristine[rel], encoding="utf-8")
+
+        if want_kw is None:                      # 反向对照
+            if new:
+                bad("%s: 不该有新失败, 却新增 %d 条 —— 判据在看噪声: %s"
+                    % (label, len(new), sorted(new)[:2]))
+            else:
+                ok("%s: 新增失败 0 条(判据没在看噪声)" % label)
+            continue
+
+        if not new:
+            bad("%s: **0 条转红** —— 这一格的判据没有牙" % label)
+        elif not any(want_kw in n for n in new):
+            bad("%s: 转红了但没命中预期判据(%s): %s" % (label, want_kw, sorted(new)[:2]))
+        else:
+            hit = sorted(n for n in new if want_kw in n)[0]
+            ok("%s: 新增 %d 条具名失败, 含 → %s" % (label, len(new), hit[:88]))
+finally:
+    # 正式树逐字节核对。不用 git reset/checkout 还原 —— 那会连带冲掉别的改动。
+    drift = [str(p) for p in TOUCHED if sha(p) != before[p]]
+    if drift:
+        bad("正式树被改动了(负控只该改工作副本): %s" % drift)
+    else:
+        ok("正式树 sha256 与 before-image 逐字节一致(%d 个文件)" % len(TOUCHED))
+    for p in TOUCHED:
+        if os.stat(p).st_mode != modes[p]:
+            bad("正式树文件 mode 变了: %s" % p)
+
+print("-" * 62)
+print("lan-rollback-convergence-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-ci-coverage.py
+++ b/tests/test-ci-coverage.py
@@ -34,7 +34,7 @@ def bad(m):
 HELPERS = {
     "rescuebox.py", "rescueform.py", "snapmatrix.py", "txbox.py", "mihomobin.py",
     "mock_dns.py", "mock_socks.py", "sni_client.py", "e2e-lib.sh", "prepare-mihomo.sh",
-    "prepare-mosdns.sh", "update_invariants.py",
+    "prepare-mosdns.sh", "update_invariants.py", "lan-fixture.sh",
 }
 
 if not os.path.exists(CI):

--- a/tests/test-lan-proxy-drift.py
+++ b/tests/test-lan-proxy-drift.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""门四: 受管的反代路由必须与面板表**双向一致**。
+
+为什么需要这一条: 面板表是权威模型, 三个派生产物(caddy.conf / 出站白名单 / unit)
+都由它渲染。白名单那半已经有 check_lan_whitelist 逐条对账了, 而**反代那半一直没人看** ——
+于是这种状态可以长期存在且零告警:
+
+    模型里没有 c 面板了, 而 caddy.conf 还在为 c 转发。
+
+它最典型的来源是**回滚**: /etc/privdns-gateway 在全局快照内(模型跟着回去了),
+/etc/pdg-lan/caddy.conf 在快照外(产物留在原地)。两个方向的危险不对称:
+
+  · Caddy 多出模型没有的站点 = 反代仍在服务一个**已经被移除**的面板;
+  · Caddy 少了模型有的站点   = 那个面板打不开, 而白名单是按模型放行的, 看着一切正常。
+
+判据取**同一个渲染器 + 同一个抽取器**: 拿 lanpanel.render_caddy 现渲一份期望值, 再用
+同一个抽取器把两侧都投影成 {host: 上游} 去比。不另写一套宽松版渲染逻辑 —— 那种"第二实现"
+迟早与真渲染器分叉, 而分叉的方向通常是"判据比产品宽", 也就是假绿。
+"""
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tmpguard          # 一次性临时目录: 建了就登记, 退出即清
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "deploy" / "bot"))
+spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
+C = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(C)
+
+PASS = [0]
+FAILED = []
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAILED.append(m)
+    print("[FAIL] %s" % m)
+
+
+def stub(**kw):
+    old = {k: getattr(C, k, None) for k in kw}
+    for k, v in kw.items():
+        setattr(C, k, v)
+    return old
+
+
+def restore(old):
+    for k, v in old.items():
+        if v is None:
+            try:
+                delattr(C, k)
+            except AttributeError:
+                pass
+        else:
+            setattr(C, k, v)
+
+
+def cfg(*panels):
+    return {"panels": [{"name": n, "host": h, "target": "http://%s:%d" % (ip, port)}
+                       for n, h, ip, port in panels]}
+
+
+P_A = ("a", "a.lan.test", "192.168.100.10", 80)
+P_B = ("b", "b.lan.test", "192.168.100.11", 8080)
+P_C = ("c", "c.lan.test", "192.168.100.12", 80)
+
+WORK = Path(tmpguard.mkdtemp(prefix="lan-drift-"))
+
+sys.path.insert(0, str(ROOT / "deploy" / "bot"))
+import lanpanel          # noqa: E402  真渲染器: "盘上那份"要长得跟真的一样
+
+
+def live_conf(model, name="caddy.conf"):
+    """按某个模型渲染出一份"盘上的 caddy.conf"。"""
+    p = WORK / name
+    p.write_text(lanpanel.render_caddy(model, "/etc/pdg-lan/certs"), encoding="utf-8")
+    return str(p)
+
+
+def run_check(model, live_path, on=(True, True)):
+    """跑门四。判据函数不存在 = 本轮要新增的东西还没有 —— 具名报出来, 不伪装成别的失败。"""
+    fn = getattr(C, "check_lan_proxy_routes", None)
+    if fn is None:
+        return ("MISSING", "check_lan_proxy_routes", "checks.py 里没有这条判据")
+    old = stub(_lan_cfg=lambda: model, _lan_on=lambda: on, LAN_CADDYFILE=live_path)
+    try:
+        return fn()
+    finally:
+        restore(old)
+
+
+def verdict(res):
+    return res[0] if res else None
+
+
+# ══ ① 完全一致 → ok ═════════════════════════════════════════════════════════
+m = cfg(P_A, P_B)
+r = run_check(m, live_conf(m, "same.conf"))
+if verdict(r) == "ok":
+    ok("① 模型与反代逐条一致 → ok(%s)" % r[2])
+else:
+    bad("① 一致时判据没给 ok: %r" % (r,))
+
+# ══ ② 模型有、Caddy 缺 → fail 且点名 ════════════════════════════════════════
+m = cfg(P_A, P_B)
+r = run_check(m, live_conf(cfg(P_A), "missing.conf"))
+if verdict(r) == "fail" and "b.lan.test" in (r[2] if r else ""):
+    ok("② 反代少了模型里的站点 → fail 并点名 b.lan.test")
+else:
+    bad("② 反代缺站点时没判红或没点名: %r" % (r,))
+
+# ══ ③ Caddy 有、模型已删 → fail 且点名 ══════════════════════════════════════
+# 这正是"回滚删了面板、反代还在转发"的形态 —— 最危险的那个方向。
+m = cfg(P_A)
+r = run_check(m, live_conf(cfg(P_A, P_C), "extra.conf"))
+if verdict(r) == "fail" and "c.lan.test" in (r[2] if r else ""):
+    ok("③ 反代多出模型已删的站点 → fail 并点名 c.lan.test")
+else:
+    bad("③ 反代多站点时没判红或没点名: %r" % (r,))
+
+# ══ ④ 上游漂移 → fail ══════════════════════════════════════════════════════
+m = cfg(P_A)
+drift = cfg(("a", "a.lan.test", "192.168.100.99", 80))
+r = run_check(m, live_conf(drift, "upstream.conf"))
+if verdict(r) == "fail" and "a.lan.test" in (r[2] if r else ""):
+    ok("④ 同一站点上游漂移 → fail 并点名")
+else:
+    bad("④ 上游漂移没判红: %r" % (r,))
+
+# ══ ⑤ 域名漂移 → fail(一缺一多, 两个方向都要说出来)══════════════════════
+m = cfg(P_A)
+r = run_check(m, live_conf(cfg(("a", "a2.lan.test", "192.168.100.10", 80)), "host.conf"))
+if verdict(r) == "fail":
+    ok("⑤ 域名漂移 → fail(%s)" % r[2][:60])
+else:
+    bad("⑤ 域名漂移没判红: %r" % (r,))
+
+# ══ ⑥ 未启用 → 按既有语义, 不报红 ══════════════════════════════════════════
+m = cfg(P_A)
+r = run_check(m, live_conf(cfg(P_A, P_C), "off.conf"), on=(False, False))
+if verdict(r) == "ok":
+    ok("⑥ 面板停用时不报红(与其余三条判据同语义)")
+else:
+    bad("⑥ 停用时判据不该报红: %r" % (r,))
+
+# ══ ⑦ 从未配过 → None(整条不出现)═════════════════════════════════════════
+r = run_check(None, live_conf(cfg(P_A), "never.conf"))
+if r is None:
+    ok("⑦ 从未配过面板 → 判据整条不出现")
+else:
+    bad("⑦ 没配过面板时判据不该出现: %r" % (r,))
+
+# ══ ⑧ 读不到 caddy.conf → warn, 不是 fail ══════════════════════════════════
+# "判据没跑成"与"判据成立"必须分开: 混成一句会让一台缺文件的机器看起来像反代丢了配置。
+m = cfg(P_A)
+r = run_check(m, str(WORK / "does-not-exist.conf"))
+if verdict(r) == "warn":
+    ok("⑧ 读不到反代配置 → warn(说明本项没跑成)")
+elif verdict(r) == "fail":
+    bad("⑧ 读不到配置被判成 fail —— 把'没跑成'说成了'不一致'")
+else:
+    bad("⑧ 读不到配置时的判据不对: %r" % (r,))
+
+# ══ ⑨ 模型自己不合法 → warn, 不得崩、不得假绿 ══════════════════════════════
+r = run_check({"panels": [{"name": "x"}]}, live_conf(cfg(P_A), "badmodel.conf"))
+if verdict(r) == "warn":
+    ok("⑨ 模型渲不出来 → warn(不崩、不假绿)")
+else:
+    bad("⑨ 模型不合法时的判据不对: %r" % (r,))
+
+# ══ ⑩ 必须登记进 doctor 的判据表 ═══════════════════════════════════════════
+# 判据写了却没人调 = 永远不会跑的死代码, 而看起来"已经有这条检查了"。
+src = (ROOT / "deploy/bot/checks.py").read_text(encoding="utf-8")
+try:
+    import ast
+    tree = ast.parse(src)
+    called = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    called |= {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    registered = "check_lan_proxy_routes" in called and "def check_lan_proxy_routes" in src
+except SyntaxError as e:
+    registered = False
+    print("    (checks.py 解析失败: %s)" % e)
+if registered:
+    ok("⑩ 判据已在 checks.py 里被登记调用")
+else:
+    bad("⑩ check_lan_proxy_routes 没定义或没被 doctor 调到(死代码)")
+
+print("─────────────────────────────────────────")
+print("通过 %d, 失败 %d" % (PASS[0], len(FAILED)))
+sys.exit(1 if FAILED else 0)

--- a/tests/test-lan-rollback-convergence.sh
+++ b/tests/test-lan-rollback-convergence.sh
@@ -301,6 +301,56 @@ grep -qE 'LAN 回滚不完整|回滚不完整' "$W/out.log" \
   && ok "C6c 收敛失败后恢复本次调用前像" \
   || bad "C6c 收敛失败后留下半套状态"
 
+echo "══ D. 调用点: 收敛必须在仓库复位之后跑 ══"
+
+# 为什么按**执行顺序**判而不是 grep 一行: _lan_render 会 source "$REPO_DIR/lib/units.sh"
+# 并经 _pdg_module 取 lanpanel.py, 而 REPO_DIR 在 cmd_rollback 的最后一步才被 git reset
+# 复位。收敛若排在复位之前, 拿到的是**新版**生成器 + **旧版**模型 —— 半新半旧, 正是这一轮
+# 要消除的东西, 而它在任何静态检查里都看不出来。
+W="$(new_box d1)"
+sed -n '/^cmd_rollback(){/,/^}/p' "$LAN_FX_SRC" > "$W/rollback.sh"
+SNAP="$W/snapdir/20260101-000000"; mkdir -p "$SNAP/etc/privdns-gateway"
+( cd "$W" && mkdir -p snaproot/etc/privdns-gateway && echo x > snaproot/etc/privdns-gateway/keep \
+  && tar czf "$SNAP/snap.tar.gz" -C snaproot etc ) 2>/dev/null
+cat > "$W/d.sh" <<EOF
+SNAP_DIR="$W/snapdir"; REPO_DIR="$W/repo"; ORDER="$W/order.txt"; : > "\$ORDER"
+LAN_UNIT="$W/etc/systemd/system/pdg-lan.service"; LAN_NFT_CONF="$W/etc/nftables-pdg-lan.conf"
+need_root(){ :; }; _lock(){ :; }
+c_g(){ echo "\$*"; }; c_y(){ echo "\$*"; }
+_pdg_mktemp_dir(){ mktemp -d; }
+_snap_meta_commit(){ echo deadbeefdeadbeefdeadbeefdeadbeefdeadbeef; }
+_snap_meta_label(){ echo l; }
+_sb_panel_managed_on(){ return 1; }
+_pdg_ios_verify_tree(){ return 0; }
+_pdg_apply_snapshot_tree(){ echo MODEL >> "\$ORDER"; return 0; }
+_nft_apply_main(){ return 0; }
+_core_kernel_activate(){ return 0; }
+pdg_write_unit(){ return 0; }; pdg_unit_mihomo(){ echo x; }
+_pdg_drop_singbox_files(){ :; }; _pdg_singbox_is_ours(){ return 1; }
+systemctl(){ return 0; }; nft(){ return 0; }
+git(){ [[ "\$*" == *"reset --hard"* ]] && echo GITRESET >> "\$ORDER"; return 0; }
+_lan_rollback_converge(){ echo CONVERGE >> "\$ORDER"; return 0; }
+EOF
+mkdir -p "$W/repo/.git" "$W/etc/privdns-gateway"
+( set +e; source "$W/d.sh"; source "$W/rollback.sh"; cmd_rollback --dir "$SNAP" --git deadbeef ) \
+  > "$W/d.log" 2>&1
+order="$(tr '\n' ' ' < "$W/order.txt")"
+if [[ "$order" != *CONVERGE* ]]; then
+  bad "D1 回滚全程没有调用 LAN 收敛(顺序=[$order])"
+elif [[ "$order" == *GITRESET*CONVERGE* ]]; then
+  ok "D1 收敛排在仓库复位之后(顺序=[$order])"
+else
+  bad "D1 收敛跑在仓库复位**之前** —— 会拿新版生成器渲旧版模型(顺序=[$order])"
+fi
+if [[ "$order" == *MODEL*CONVERGE* ]]; then
+  ok "D2 收敛排在模型恢复之后"
+else
+  bad "D2 收敛没排在模型恢复之后(顺序=[$order])"
+fi
+grep -q '内网面板派生产物' "$W/rollback.sh" \
+  && ok "D3 收敛失败会计入未恢复项(不谎报完全回滚)" \
+  || bad "D3 收敛失败没有计入 unrestored —— 会报成'✅ 已回滚'"
+
 echo "─────────────────────────────────────────"
 echo "通过 $PASS, 失败 $FAIL"
 [[ "$FAIL" == 0 ]]

--- a/tests/test-lan-rollback-convergence.sh
+++ b/tests/test-lan-rollback-convergence.sh
@@ -354,6 +354,41 @@ grep -q '内网面板派生产物' "$W/rollback.sh" \
   && ok "D3 收敛失败会计入未恢复项(不谎报完全回滚)" \
   || bad "D3 收敛失败没有计入 unrestored —— 会报成'✅ 已回滚'"
 
+echo "══ E. 第一次执行 / 二次幂等 / 凭据保全 ══"
+
+# E1: 产物一个都不存在时(第一次执行)必须能从零生成 —— 回滚到"面板刚启用之前"那种快照,
+# 现场就是这样: 模型说启用, 而三个产物还没有。
+W="$(new_box e1)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" a:a.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"
+rm -f "$W/etc/pdg-lan/caddy.conf" "$W/etc/nftables-pdg-lan.conf" "$W/etc/systemd/system/pdg-lan.service"
+rc1="$(run_box "$W" "$CONV; converge")"
+first="$(snap3 "$W")"
+if [[ "$rc1" == 0 && "$first" != *"-"* ]]; then
+  ok "E1 第一次执行(产物全不存在)→ 三个都生成出来了"
+else
+  bad "E1 第一次执行没能生成齐(rc=$rc1, 指纹=[$first])"
+fi
+
+# E2: 再跑一次, 三个产物必须**逐字节相同**。渲染里混进时间戳/随机名之类的东西, 会让
+# "有没有变"这个问题永远答不清楚 —— 而回滚收尾要能反复跑。
+before_creds="$(creds "$W")"
+rc2="$(run_box "$W" "$CONV; converge")"
+second="$(snap3 "$W")"
+[[ "$rc2" == 0 && "$second" == "$first" ]] \
+  && ok "E2 二次幂等: 三个产物逐字节相同" \
+  || bad "E2 二次不幂等(rc=$rc2): 首次=[$first] 二次=[$second]"
+
+# E3: 两次跑完, 凭据的内容 + mode + uid:gid 全都不许动。
+[[ "$(creds "$W")" == "$before_creds" ]] \
+  && ok "E3 两次收敛全程凭据零改动(内容+mode+属主)" \
+  || bad "E3 凭据被改动: 前=[$before_creds] 后=[$(creds "$W")]"
+
+# E4: 收敛不许碰 acme 账户目录 —— 它是不可再生的凭据, 也是"绝不签证书"这条边界的落点。
+[[ ! -e "$W/opt/pdg-acme" ]] \
+  && ok "E4 收敛没有创建/触碰 acme 账户目录(不签证书、不联网)" \
+  || bad "E4 收敛动了 acme 账户目录"
+
 echo "─────────────────────────────────────────"
 echo "通过 $PASS, 失败 $FAIL"
 [[ "$FAIL" == 0 ]]

--- a/tests/test-lan-rollback-convergence.sh
+++ b/tests/test-lan-rollback-convergence.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 内网面板: 回滚后派生产物必须向已恢复的模型收敛, 且 render/apply 不许假成功。
+#
+# 背景(为什么这支测试存在):
+#   /etc/privdns-gateway/{lan-panels.json, profile.env} 是**权威模型**, 两者都在全局
+#   快照内, 回滚会把它们一起带回去。而三个**派生产物** —— /etc/pdg-lan/caddy.conf、
+#   /etc/nftables-pdg-lan.conf、pdg-lan.service —— 都在快照之外, 回滚一个字节都不碰。
+#   于是回滚之后模型是旧的、产物是新的, 两边各说各的:
+#     · 白名单那半有人看着(check_lan_whitelist 逐条对账, 会判红);
+#     · **反代那半没人看** —— Caddy 继续按旧配置服务着模型里已经不存在的面板, 全程零告警。
+#
+#   删面板方向尤其危险: 模型里没有了, 反代还在转发, 而出站白名单会被 doctor 判红 ——
+#   现场看到的是"白名单多出一条", 真正的原因却在反代配置上。
+#
+# 这支测试**跑真的生产函数**(tests/lan-fixture.sh 从 pdg.sh 原样抽取), 不复制实现。
+# 在 v1.10.15 基线上它必须红, 且每条失败都指向单一归因。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export LAN_FX_SRC="$ROOT/deploy/bot/pdg.sh"
+# shellcheck source=tests/lan-fixture.sh
+source "$ROOT/tests/lan-fixture.sh"
+
+PASS=0; FAIL=0
+ok(){  echo "[OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d)" || exit 1
+cleanup(){ [[ -n "${PDG_KEEP_TMP:-}" ]] && { echo "现场保留: $WORK"; return; }; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# 本轮新增的收敛入口: 基线上还不存在, 缺席要能被具名报出来而不是变成 127。
+LAN_FX_OPTIONAL=(_lan_rollback_converge)
+
+# 真 PEM: 生成物要交给**真 Caddy** 校验, 假证书会让校验在到达注入点前就失败(第一版栽过)。
+export LAN_FX_PEM_DIR="$WORK/pem"
+if ! lan_fx_make_pem "$LAN_FX_PEM_DIR"; then
+  echo "[FAIL] 生成测试用 PEM 失败(缺 openssl?) —— 真 Caddy 校验这一条测不了, 不跳过"; exit 1
+fi
+CADDY_BIN="$(lan_fx_caddy "$ROOT" "$WORK")" || CADDY_BIN=""
+if [[ -z "$CADDY_BIN" ]]; then
+  echo "[FAIL] 拿不到 caddy(本地/PATH/按钉死 SHA 下载都不成) —— 这支要验真 Caddy 的行为, 不能跳过"; exit 1
+fi
+
+CLOSURE="$WORK/closure.sh"
+if ! lan_fx_emit "$CLOSURE"; then
+  echo "[FAIL] 生产函数闭包抽取失败 —— 后面的断言全部无效"; exit 1
+fi
+
+# ── 每格一个独立沙箱 ────────────────────────────────────────────────────────
+# 共用现场的顺序测试迟早互相下毒(§8), 所以一格一个假根, 不复用。
+new_box(){
+  local w="$WORK/$1"; mkdir -p "$w"
+  lan_fx_sandbox "$w"; lan_fx_stubs "$w"
+  # 生产函数要 source 真仓库的 lib/units.sh 与 deploy/bot/lanpanel.py —— 用**影子仓库**:
+  # 目录结构照搬, 内容软链到真仓库, 于是故障注入只需要替换其中一个文件。
+  mkdir -p "$w/repo/deploy" "$w/repo/lib"
+  ln -sfn "$ROOT/deploy/bot" "$w/repo/deploy/bot"
+  cp "$ROOT/lib/units.sh" "$w/repo/lib/units.sh"
+  echo "$w"
+}
+
+# 在沙箱里跑一段脚本, 回显退出码; 输出落到 $w/out.log。
+run_box(){
+  local w="$1" body="$2"
+  ( set +e
+    lan_fx_bind "$w" "$w/repo"
+    # shellcheck source=/dev/null
+    source "$CLOSURE"
+    eval "$body"
+  ) > "$w/out.log" 2>&1
+  echo $?
+}
+
+# 三个派生产物的指纹(不存在记为 "-")
+fp(){ [[ -e "$1" ]] && sha256sum "$1" 2>/dev/null | cut -c1-16 || echo "-"; }
+snap3(){ echo "$(fp "$1/etc/pdg-lan/caddy.conf") $(fp "$1/etc/nftables-pdg-lan.conf") $(fp "$1/etc/systemd/system/pdg-lan.service")"; }
+# 凭据保全: 内容 + mode + uid:gid
+credfp(){ local f="$1"; [[ -e "$f" ]] || { echo "-"; return; }; echo "$(sha256sum "$f" | cut -c1-16) $(stat -c '%a %u:%g' "$f")"; }
+creds(){ echo "$(credfp "$1/etc/pdg-lan/dns.env") $(credfp "$1/etc/pdg-lan/certs/panel.crt") $(credfp "$1/etc/pdg-lan/certs/panel.key")"; }
+
+echo "══ A. _lan_render: 三个产物要么一起换, 要么一个都不动 ══"
+
+# ── A1/A2: unit 生成失败 ────────────────────────────────────────────────────
+# 注入: 影子仓库的 units.sh 末尾追加一个恒失败的 pdg_unit_lan_caddy(后定义者胜)。
+# 基线机制: `pdg_unit_lan_caddy … > "$LAN_UNIT" && chmod 644`, 重定向**先截断**再执行,
+# 失败被 && 短路; 而函数最后一条是 `systemctl daemon-reload … || true` —— 恒为真。
+W="$(new_box a1)"
+echo 'pdg_unit_lan_caddy(){ return 1; }' >> "$W/repo/lib/units.sh"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+echo "OLDUNIT" > "$W/etc/systemd/system/pdg-lan.service"
+before="$(fp "$W/etc/systemd/system/pdg-lan.service")"
+rc="$(run_box "$W" '_lan_render')"
+lan_fx_guard127 "$W/out.log" || bad "A 组: $(lan_fx_guard127 "$W/out.log")"
+[[ "$rc" != 0 ]] && ok "A1 unit 生成失败 → _lan_render 返回非零($rc)" \
+                 || bad "A1 unit 生成失败, _lan_render 仍返回 0 —— 假成功"
+[[ "$(fp "$W/etc/systemd/system/pdg-lan.service")" == "$before" ]] \
+  && ok "A2 unit 生成失败 → live unit 未被截断" \
+  || bad "A2 live unit 被截断/改写(重定向直接打在正式文件上)"
+
+# ── A3: nft 配置落盘失败 → 三文件回到前像 ───────────────────────────────────
+W="$(new_box a3)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+echo "OLDCADDY" > "$W/etc/pdg-lan/caddy.conf"
+echo "OLDNFT"   > "$W/etc/nftables-pdg-lan.conf"
+echo "OLDUNIT"  > "$W/etc/systemd/system/pdg-lan.service"
+before="$(snap3 "$W")"
+chmod 444 "$W/etc/nftables-pdg-lan.conf"; chmod 555 "$W/etc"      # 只堵这一个落点
+rc="$(run_box "$W" '_lan_render')"
+chmod 755 "$W/etc"; chmod 644 "$W/etc/nftables-pdg-lan.conf"
+if [[ "$rc" == 0 ]]; then
+  bad "A3 nft 配置落盘失败, _lan_render 仍返回 0 —— 假成功"
+else
+  ok "A3 nft 配置落盘失败 → 返回非零($rc)"
+fi
+[[ "$(snap3 "$W")" == "$before" ]] \
+  && ok "A3b 落盘失败后三个产物都回到前像" \
+  || bad "A3b 落盘失败后留下半套状态: 前=[$before] 后=[$(snap3 "$W")]"
+
+# ── A4: 候选校验失败 → 正式文件零改动 ───────────────────────────────────────
+# 注入走 **nft 校验**而不是 caddy: _lan_render 里的 caddy 路径是写死的
+# /usr/local/bin/caddy, PATH 桩拦不住它, 于是"有没有装 caddy"会让这一格的判据在
+# 本机与 CI 上给出不同结果 —— 那正是 §9.10 那类环境依赖红。nft 走 PATH, 两边一致。
+W="$(new_box a4)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+echo "OLDCADDY" > "$W/etc/pdg-lan/caddy.conf"; echo "OLDNFT" > "$W/etc/nftables-pdg-lan.conf"
+echo "OLDUNIT" > "$W/etc/systemd/system/pdg-lan.service"
+before="$(snap3 "$W")"; touch "$W/state/nft-check-fails"
+rc="$(run_box "$W" '_lan_render')"
+[[ "$rc" != 0 && "$(snap3 "$W")" == "$before" ]] \
+  && ok "A4 候选校验失败 → 返回非零且正式文件零改动" \
+  || bad "A4 候选(nft -c)校验失败后仍落了盘或返回 0(rc=$rc) —— 未做落盘前校验"
+
+# ── A8: 生成物必须能过**真 Caddy** ──────────────────────────────────────────
+W="$(new_box a8)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" \
+  a:a.lan.test:192.168.100.10:80 b:b.lan.test:192.168.100.11:8080
+rc="$(run_box "$W" '_lan_render')"
+if [[ "$rc" == 0 ]] && "$CADDY_BIN" validate --config "$W/etc/pdg-lan/caddy.conf" --adapter caddyfile >"$W/caddyval.log" 2>&1; then
+  ok "A8 生成的 caddy.conf 过真 Caddy 校验($("$CADDY_BIN" version 2>/dev/null | head -1))"
+else
+  bad "A8 生成物没过真 Caddy 校验(rc=$rc): $(tail -2 "$W/caddyval.log" 2>/dev/null | tr '\n' ' ')"
+fi
+
+# ── A5: 属组装不上不得静默降级 ──────────────────────────────────────────────
+# 基线机制: `install -m640 -o root -g "$LAN_USER" … || install -m644 …`
+# —— 属组装不上就悄悄换成 644 root:root, 而那份配置里有面板拓扑。
+W="$(new_box a5)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+rc="$(run_box "$W" 'LAN_USER=pdg-nonexistent-user-for-test; _lan_render')"
+if [[ "$rc" == 0 && -s "$W/etc/pdg-lan/caddy.conf" ]]; then
+  mode="$(stat -c '%a' "$W/etc/pdg-lan/caddy.conf")"
+  bad "A5 属组装不上仍报成功并落盘(mode=$mode) —— 静默降级"
+else
+  ok "A5 属组装不上 → 不静默降级(rc=$rc)"
+fi
+
+# ── A6: daemon-reload 失败必须传播 ──────────────────────────────────────────
+W="$(new_box a6)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+touch "$W/state/reload-fails"
+rc="$(run_box "$W" '_lan_render')"
+[[ "$rc" != 0 ]] && ok "A6 daemon-reload 失败 → 返回非零" \
+                 || bad "A6 daemon-reload 失败被 '|| true' 吞掉, 返回 0"
+
+# ── A7: 失败路径不得留临时物 ────────────────────────────────────────────────
+# 基线机制: 裸 mktemp 造的 $tmpc/$tmpn 与**派生的 $tmpc.err**, 没有 trap 兜底。
+W="$(new_box a7)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+mytmp="$W/tmp"; mkdir -p "$mytmp"
+touch "$W/state/nft-check-fails"
+rc="$(run_box "$W" "export TMPDIR='$mytmp'; _lan_render")"
+left="$(find "$mytmp" -mindepth 1 2>/dev/null | wc -l)"
+# rc 必须非零 —— 否则这一格根本没走到失败路径, "零残留"是空测(§17.2 的空测判定)。
+[[ "$rc" != 0 && "$left" == 0 ]] && ok "A7 失败路径(rc=$rc)临时物零残留" \
+                   || bad "A7 失败路径未成立或有残留(rc=$rc, 残留 $left): $(find "$mytmp" -mindepth 1 2>/dev/null | head -3 | tr '\n' ' ')"
+
+echo "══ B. 应用层诚实性: 只生成不重启 = 磁盘对了进程没跟上 ══"
+
+W="$(new_box b1)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"
+touch "$W/state/active" "$W/state/restart-fails"           # 反代在跑, 但重启会失败
+rc="$(run_box "$W" '_lan_wire(){ return 0; }; _lan_sync_after_change')"
+lan_fx_guard127 "$W/out.log" || bad "B 组: $(lan_fx_guard127 "$W/out.log")"
+[[ "$rc" != 0 ]] && ok "B1 反代重启失败 → _lan_sync_after_change 返回非零" \
+                 || bad "B1 反代重启失败被 '_lan_apply_proxy || true' 吞掉, 返回 0"
+if grep -qE '✅.*(已同步|已生效)' "$W/out.log"; then
+  bad "B2 反代重启失败却仍打印成功文案: $(grep -oE '✅[^"]*' "$W/out.log" | head -1)"
+else
+  ok "B2 反代重启失败时不打印成功文案"
+fi
+
+echo "══ C. 回滚后收敛 ══"
+
+# 收敛入口在基线上不存在 —— 用包装器把"缺席"变成一条具名失败, 而不是 127。
+CONV='converge(){ declare -F _lan_rollback_converge >/dev/null || { echo "缺少收敛入口 _lan_rollback_converge"; return 1; }; _lan_rollback_converge; }'
+
+# ── C1: 删面板方向 ──────────────────────────────────────────────────────────
+# 现场: 模型已被回滚成"两个面板", 而产物还是"三个面板"那一版。
+W="$(new_box c1)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" \
+  a:a.lan.test:192.168.100.10:80 b:b.lan.test:192.168.100.11:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"
+touch "$W/state/active"
+# 产物按"三面板"渲染(模型多一条 c), 渲完把模型换回两条 —— 这就是回滚后的现场
+lan_fx_model "$W/stale.json" a:a.lan.test:192.168.100.10:80 b:b.lan.test:192.168.100.11:80 \
+  c:c.lan.test:192.168.100.12:80
+run_box "$W" "LAN_TABLE_PATH='$W/stale.json'; _lan_render" >/dev/null
+before_creds="$(creds "$W")"
+rc="$(run_box "$W" "$CONV; converge")"
+routes="$(lan_fx_routes "$W/etc/pdg-lan/caddy.conf" | sort | tr '\n' ' ')"
+# "应有"的路由用**同一个渲染器 + 同一个抽取器**现算, 不写死格式:
+# 写死的话渲染器一改这条断言就悄悄失去意义, 而它看起来仍然是绿的。
+WX="$(new_box c1want)"
+lan_fx_model "$WX/etc/privdns-gateway/lan-panels.json" \
+  a:a.lan.test:192.168.100.10:80 b:b.lan.test:192.168.100.11:80
+run_box "$WX" '_lan_render' >/dev/null
+want="$(lan_fx_routes "$WX/etc/pdg-lan/caddy.conf" | sort | tr '\n' ' ')"
+[[ -n "$want" && "$routes" == "$want" ]] \
+  && ok "C1 删面板后 caddy 路由收敛到已恢复的模型($routes)" \
+  || bad "C1 caddy 路由未收敛: 现有=[$routes] 应为=[$want] (rc=$rc)"
+if grep -q 'c.lan.test' "$W/etc/nftables-pdg-lan.conf" 2>/dev/null || grep -q '192.168.100.12' "$W/etc/nftables-pdg-lan.conf" 2>/dev/null; then
+  bad "C1b 出站白名单仍留着已删面板的上游 —— 反代还能连到它"
+else
+  ok "C1b 出站白名单不再含已删面板的上游"
+fi
+[[ "$(creds "$W")" == "$before_creds" ]] \
+  && ok "C1c 收敛全程未碰凭据(dns.env/证书: 内容+mode+属主逐项相同)" \
+  || bad "C1c 凭据被改动: 前=[$before_creds] 后=[$(creds "$W")]"
+
+# ── C2: 改上游方向 ──────────────────────────────────────────────────────────
+W="$(new_box c2)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" a:a.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"
+touch "$W/state/active"
+lan_fx_model "$W/stale.json" a:a.lan.test:192.168.100.99:8080
+run_box "$W" "LAN_TABLE_PATH='$W/stale.json'; _lan_render" >/dev/null
+rc="$(run_box "$W" "$CONV; converge")"
+routes="$(lan_fx_routes "$W/etc/pdg-lan/caddy.conf" | tr '\n' ' ')"
+[[ "$routes" == *"192.168.100.10:80"* && "$routes" != *"192.168.100.99"* ]] \
+  && ok "C2 改上游后三产物回到已恢复的模型" \
+  || bad "C2 上游未收敛: [$routes] (rc=$rc)"
+
+# ── C3: enabled → disabled ──────────────────────────────────────────────────
+W="$(new_box c3)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" a:a.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=0" > "$W/etc/privdns-gateway/profile.env"   # 回滚回到"停用"那一版
+touch "$W/state/active" "$W/state/pdglan-table"
+run_box "$W" "_lan_render" >/dev/null                              # 产物是启用态留下的
+rc="$(run_box "$W" "$CONV; converge")"
+if [[ -e "$W/state/active" ]]; then
+  bad "C3 模型已回到停用态, 反代仍在跑 —— 未走正式停用路径"
+else
+  ok "C3 模型停用 → 反代已停(走既有 _lan_disable 语义)"
+fi
+[[ -e "$W/state/pdglan-table" ]] \
+  && bad "C3b 停用后内核里仍留着 pdglan 表(残留)" \
+  || ok "C3b 停用后 pdglan 表已撤"
+
+# ── C4: disabled → enabled ──────────────────────────────────────────────────
+W="$(new_box c4)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" a:a.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"    # 回滚回到"启用"那一版
+rm -f "$W/state/active"                                            # 但此刻反代没在跑
+rc="$(run_box "$W" "$CONV; converge")"
+if [[ -s "$W/etc/pdg-lan/caddy.conf" ]] && lan_fx_routes "$W/etc/pdg-lan/caddy.conf" | grep -q 'a.lan.test'; then
+  ok "C4 模型启用 → 派生产物已按模型生成"
+else
+  bad "C4 模型启用, 但派生产物没生成(rc=$rc)"
+fi
+
+# ── C5: 从未启用过 → 必须 no-op, 且不得往 profile.env 写新键 ────────────────
+W="$(new_box c5)"
+echo "PDG_INTERNAL_CIDR=172.22.0.0/16" > "$W/etc/privdns-gateway/profile.env"
+before="$(sha256sum "$W/etc/privdns-gateway/profile.env" | cut -c1-16)"
+rc="$(run_box "$W" "$CONV; converge")"
+after="$(sha256sum "$W/etc/privdns-gateway/profile.env" | cut -c1-16)"
+if [[ "$rc" == 0 && "$before" == "$after" && ! -e "$W/etc/pdg-lan/caddy.conf" ]]; then
+  ok "C5 从未启用过 → no-op, profile.env 一个字节没改"
+else
+  bad "C5 从未启用过却动了现场(rc=$rc, profile 变了=$([[ "$before" != "$after" ]] && echo 是 || echo 否))"
+fi
+
+# ── C6: 收敛失败必须说"不完整"并返回非零 ────────────────────────────────────
+W="$(new_box c6)"
+lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" a:a.lan.test:192.168.100.10:80
+echo "PDG_LAN_ENABLED=1" > "$W/etc/privdns-gateway/profile.env"
+touch "$W/state/active"
+run_box "$W" "_lan_render" >/dev/null
+before="$(snap3 "$W")"
+touch "$W/state/nft-check-fails"                                   # 让 render 必败
+rc="$(run_box "$W" "$CONV; converge")"
+[[ "$rc" != 0 ]] && ok "C6 收敛失败 → 返回非零" || bad "C6 收敛失败仍返回 0"
+grep -qE 'LAN 回滚不完整|回滚不完整' "$W/out.log" \
+  && ok "C6b 收敛失败明确报告「LAN 回滚不完整」" \
+  || bad "C6b 收敛失败没有报出「LAN 回滚不完整」(现场只能靠猜)"
+[[ "$(snap3 "$W")" == "$before" ]] \
+  && ok "C6c 收敛失败后恢复本次调用前像" \
+  || bad "C6c 收敛失败后留下半套状态"
+
+echo "─────────────────────────────────────────"
+echo "通过 $PASS, 失败 $FAIL"
+[[ "$FAIL" == 0 ]]

--- a/tests/test-lan-rollback-convergence.sh
+++ b/tests/test-lan-rollback-convergence.sh
@@ -101,23 +101,26 @@ lan_fx_guard127 "$W/out.log" || bad "A 组: $(lan_fx_guard127 "$W/out.log")"
   || bad "A2 live unit 被截断/改写(重定向直接打在正式文件上)"
 
 # ── A3: nft 配置落盘失败 → 三文件回到前像 ───────────────────────────────────
+# 注入用"父目录不存在"而不是权限位: install 不会替你造父目录, 而且 **root 也一样失败**。
+# 第一版用 chmod 444 + 555 堵落点 —— 那在宿主(非 root)有效, 在真 systemd 容器里以 root 跑
+# 时权限位根本拦不住, 于是同一份代码宿主绿、容器红(§9.10 那类环境依赖)。
+# 顺带把"本来不存在的产物"这条路径也覆盖到: 退回时它必须仍然不存在, 而不是留下一份新的。
 W="$(new_box a3)"
 lan_fx_model "$W/etc/privdns-gateway/lan-panels.json" p1:p1.lan.test:192.168.100.10:80
 echo "OLDCADDY" > "$W/etc/pdg-lan/caddy.conf"
-echo "OLDNFT"   > "$W/etc/nftables-pdg-lan.conf"
 echo "OLDUNIT"  > "$W/etc/systemd/system/pdg-lan.service"
-before="$(snap3 "$W")"
-chmod 444 "$W/etc/nftables-pdg-lan.conf"; chmod 555 "$W/etc"      # 只堵这一个落点
-rc="$(run_box "$W" '_lan_render')"
-chmod 755 "$W/etc"; chmod 644 "$W/etc/nftables-pdg-lan.conf"
+NFTDST="$W/etc/nope/nftables-pdg-lan.conf"
+a3fp(){ echo "$(fp "$W/etc/pdg-lan/caddy.conf") $(fp "$NFTDST") $(fp "$W/etc/systemd/system/pdg-lan.service")"; }
+before="$(a3fp)"
+rc="$(run_box "$W" "LAN_NFT_CONF='$NFTDST'; _lan_render")"
 if [[ "$rc" == 0 ]]; then
   bad "A3 nft 配置落盘失败, _lan_render 仍返回 0 —— 假成功"
 else
   ok "A3 nft 配置落盘失败 → 返回非零($rc)"
 fi
-[[ "$(snap3 "$W")" == "$before" ]] \
-  && ok "A3b 落盘失败后三个产物都回到前像" \
-  || bad "A3b 落盘失败后留下半套状态: 前=[$before] 后=[$(snap3 "$W")]"
+[[ "$(a3fp)" == "$before" ]] \
+  && ok "A3b 落盘失败后三个产物都回到前像(含'本来就不存在'那一个)" \
+  || bad "A3b 落盘失败后留下半套状态: 前=[$before] 后=[$(a3fp)]"
 
 # ── A4: 候选校验失败 → 正式文件零改动 ───────────────────────────────────────
 # 注入走 **nft 校验**而不是 caddy: _lan_render 里的 caddy 路径是写死的

--- a/tests/test-update-rollback.sh
+++ b/tests/test-update-rollback.sh
@@ -66,6 +66,9 @@ _pdg_apply_snapshot_tree(){ cat "\$1/etc/privdns-gateway/snapid" > "\$APPLIED" 2
 # 覆盖生产文件之前的 iOS 联合校验(见 pdg.sh _pdg_ios_verify_tree)。这些快照里根本没有
 # iOS 生命周期成员, 生产里它会直接 return 0 —— 这里打桩只是因为本壳没抽那一批函数。
 _pdg_ios_verify_tree(){ return 0; }
+# 内网面板的回滚收敛(见 pdg.sh _lan_rollback_converge)。同样是"本壳没抽那一批函数"才打的桩 ——
+# 收敛本身由 tests/test-lan-rollback-convergence.sh 跑真函数覆盖, 这里只要它不影响本壳的判据。
+_lan_rollback_converge(){ return 0; }
 EOF
 
 run(){ bash -c "source '$WORK/harness.sh'; source '$WORK/rollback.sh'; cmd_rollback $1" 2>&1; }


### PR DESCRIPTION
## 真实缺陷

回滚会把**权威状态**带回去,却不动**派生产物**,而两边没有一条判据对得上账。

LAN 的权威状态由**两样共同组成**,两样都在全局快照内、由同一次落盘一起恢复:

- `/etc/privdns-gateway/profile.env` 的 `PDG_LAN_ENABLED` —— **启用意图**(`_lan_intent` / `checks._lan_on`)
- `/etc/privdns-gateway/lan-panels.json` —— **面板模型**

而三个派生产物 `/etc/pdg-lan/caddy.conf`、`/etc/nftables-pdg-lan.conf`、`pdg-lan.service` 都在快照**之外**,`cmd_rollback` 一个字节都不碰。于是回滚之后权威状态是旧的、产物是新的:

- 白名单那半有人看着 —— `check_lan_whitelist` 与面板表逐条对账,会判红;
- **反代那半没人看** —— Caddy 继续按旧配置服务着模型里已经不存在的面板,全程零告警。

删面板方向最危险:模型里没有了,反代还在转发,而现场看到的是"白名单多出一条",真正的原因却在反代配置上。

## A+ 的边界

模型回滚之后**重新生成**派生产物,而**不**把凭据与运行态塞进全局快照:

- 不扩大 `cmd_snapshot` 的候选清单,不放宽快照路径守卫(两者本 PR 内**逐字节未改**);
- `dns.env`、证书私钥、ACME 账户密钥是持久凭据,不随模型变化,不进闭包也不被读写;
- `/var/lib/pdg-lan`(Caddy 运行态)与 `/usr/local/bin/caddy`(钉死版可重下)同样不进;
- **不碰** mosdns 劫持集与 mihomo 分流 —— `/etc/mosdns` 与 `/etc/mihomo` 本来就在快照里,已经跟着回滚了,再渲一次等于拿当前状态覆盖刚恢复的那份。

## `_lan_render` 收成一笔局部事务

三个产物是同一个模型的三个投影,落一半 = 反代、防火墙、systemd 各看着不同版本的面板表。现在:候选一起生成到 0700 临时目录 → 一起过校验(反代配置交**真 Caddy**,白名单交 `nft -c`)→ 一起落盘 → 任一步失败**整笔退回本次调用前像**(本来存在的按 `cp -a` 退回,本来不存在的删掉)。

三个具体缺陷一并关掉:

- `pdg_unit_lan_caddy … > "$LAN_UNIT"` 的重定向**先截断正式文件**再执行,生成失败留下空 unit,而失败本身被 `&&` 短路吞掉;
- 函数最后一条是 `systemctl daemon-reload … || true`,**恒为真** —— 于是上面任何一步失败,整个函数照样返回 0;
- `install -m640 -o root -g "$LAN_USER" … || install -m644 …` 把 640 root:pdg-lan **静默降级**成 644 root:root。新的 `_lan_install_managed` 没有降级的退路。

**成功路径的产出与改动前归一化后逐字节相同**,mode/属主亦相同 —— 只改了失败处理,没改产出。

## 收敛的三态

调用点在 `cmd_rollback` 的 `git reset` **之后**、未恢复项汇总之前(生成器来自 `REPO_DIR`,仓库在那一步才复位;插在之前等于拿新版生成器渲旧版模型)。实测执行序列 `MODEL → GITRESET → CONVERGE`。

| 恢复出的权威状态 | 收敛动作 |
|---|---|
| intent=1 | `_lan_render` + `_lan_apply_proxy` |
| intent=0 且确有可收敛之物 | 走既有 `_lan_disable` 语义 |
| intent 缺失 / 从未启用 | **no-op**,`profile.env` 一个字节不写 |

第三态是刻意的:对从未启用过面板的机器调 `_lan_disable`,会往 `profile.env` 写一个快照里根本没有的 `PDG_LAN_ENABLED=0` —— 那是在改写刚恢复出来的状态。

收敛失败时明确打印「LAN 回滚不完整」+ 第一失败点,并计入 `unrestored`,整体 rollback 返回非零。

## 三处假成功文案与失败传播

`_lan_apply_proxy` 的三处 `|| true` 全部收口(`_lan_sync_after_change` / `migrate_lan_caddy_reender` / `cmd_lan render`)。"磁盘对了、进程没跟上"是本项目反复出事的形态,不能由一句成功文案盖过去。`migrate_lan_caddy_reender` 向上传播即可 —— 它的调用侧 `cmd_update` 自带 `|| true`,更新不会被拖垮。

## doctor 门四:双向对账

新增 `check_lan_proxy_routes`,与面板表**双向**比:反代多出模型已删的站点 → fail;反代缺少模型里的站点 → fail;上游漂移 → fail。期望值用**真渲染器** `lanpanel.render_caddy` 现渲,再用**同一个抽取器**把两侧投影成 `{host: 上游}` 去比 —— 抽取器有偏差时两边同样偏,造不出假漂移;也不另写一套宽松版渲染逻辑。读不出来一律 warn 不判 fail:把"判据没跑成"说成"不一致",会让缺文件的机器看着像配置丢了。

## 证据

- 聚焦测试:回滚收敛 **29/0**、门四 **10/0**;负控 **11/0**,九格改坏器**逐格转红**,反向对照(只加注释)新增 **0**。
- 真环境:`--privileged` 容器内 PID1=systemd、nft v1.0.6、**真 Caddy v2.11.4**,聚焦测试 root 下同为 29/0。六支 E2E(update / preserve-userdata / upgrade-from-release / cross-version-rollback / rescue-migration-lock / snapshot-meta)分支与基线**同为 6/6 rc=0、FAIL 0、SKIP 11 且 SKIP 集合逐行相同**。
- 全量宿主回归 182 支,与基线比**具名失败集合差集 = 0**,新增 SKIP 0。
- 凭据保全:`dns.env` 与证书的**内容 + mode + uid:gid** 在单次与双次收敛前后逐项相同;`/opt/pdg-acme` 全程未被创建或触碰。

## 六笔提交(以及为什么多出两笔)

1. `0b3fa02` 红灯测试(基线 28 条具名失败)
2. `3216d9e` 回滚收敛实现
3. `3dc57eb` doctor 门四
4. `e8089bb` mutation 负控
5. `0ec2bce` — **计划外**:A3 那格原本用 `chmod 444/555` 注入,在真 systemd 容器里以 root 跑时权限位根本拦不住,同一份代码宿主 25/0、容器 23/2。改成"父目录不存在",root 与非 root 一致。
6. `df5486a` — **计划外**:把「第一次执行 / 二次幂等 / 凭据保全」钉成常驻断言,而不是一次性日志。

## 未解决(不在本 PR 范围)

- **P3** `tests/test-update-rollback.sh` 的壳里 `_snap_meta_commit` 有一处**既有**静默 127(基线抽出的 rollback.sh 同一行同样命中,只因基线绿而没回显)。本 PR 只补了自己新增依赖的桩,没动它。
- **P3** 启用态收敛每次都 `restart pdg-lan`:产物层幂等已钉死(逐字节相同),服务层仍每次重启。白名单靠 `ExecStartPre` 进内核是机制要求,但"产物未变则不重启"值得单独一轮。
- **P3** 开发机存在 `tailscale0`,导致 `test-cidr-input.py` / `test-tailscale-ingress-isolation.py` / `test-tmp-hygiene.py` 三支在本机恒红(基线树同样红,CI 上全绿)。本地全量回归的判别力因此受损。
- **P3** 本 PR 把 `check_lan_proxy_routes` 插在了 `_RL_WANT` 与其唯一消费者 `check_mosdns_ratelimit` 之间,常量与函数被隔开约 80 行。函数体逐字节未变、行为零影响,但属组织性瑕疵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
