### PR TITLE
test: make three fixtures honest on a host that runs Tailscale

### DIFF
--- a/tests/test-cidr-input.py
+++ b/tests/test-cidr-input.py
@@ -40,13 +40,40 @@ def bad(msg):
 
 
 def fake_tcpdump(delay):
-    """假 tcpdump: delay 秒后吐一个私网源包(控制'多久才抓到')。"""
+    """假 tcpdump: delay 秒后吐几个私网入站包(控制"多久才抓到")。
+
+    **必须模仿 tcpdump ≥4.99 的 `-i any` 格式**, 也就是带上时刻 / 接口名 / 方向:
+
+        <时刻> <接口> In  IP <源>.<端口> > <目的>.<端口>: …
+
+    原来的桩吐的是老格式(整行只有 `IP a.b.c.d.p > …`)。后果不是"少测一条路径", 而是
+    **这支测试在装了 Tailscale 的机器上恒红**:
+      · lib/detect-internal-range.sh 会先用 `tcpdump -ni any -c 1` 探一次"这台的 tcpdump
+        打不打接口名"; 打不出来就 ifname_ok=0;
+      · 宿主有 tailscale0 且 ifname_ok=0 时, 产品**有意拒绝猜测**(宁可让人手输, 也不冒险
+        把 tailnet 地址当成内网卡来源)—— 于是 RESULT 为空, 断言失败。
+    产品那个分支是对的; 错的是桩没把现代 tcpdump 的样子演出来。
+
+    另一半同样要紧: **探测调用要立刻应答**。探测那句外面套着 `timeout 3`, 而桩原来对所有
+    调用一律先 sleep delay ——  delay=60 的那一格必然把探测拖超时, 于是又回到 ifname_ok=0。
+    真机上这两次调用本来就不同: 探测只要一个包, 抓取要等够样本。按 `-c 1` 区分即可。
+    """
     os.makedirs(BIN, exist_ok=True)
     p = os.path.join(BIN, "tcpdump")
+    line = "12:34:56.789012 enp1s0 In  IP 172.22.0.5.55000 > 10.0.0.1.853: tcp"
     with open(p, "w") as f:
-        f.write("#!/bin/sh\nsleep %s\n"
-                "printf 'IP 172.22.0.5.55000 > 10.0.0.1.853: tcp\\n172.22.0.5\\n172.22.0.5\\n'\n"
-                "exit 0\n" % delay)
+        f.write(
+            "#!/bin/sh\n"
+            "# 探测调用(-c 1, 无 BPF 过滤): 立刻给一行现代格式, 让 ifname_ok=1\n"
+            "for a in \"$@\"; do\n"
+            "  if [ \"$a\" = \"1\" ] && [ \"$prev\" = \"-c\" ]; then\n"
+            "    printf '%s\\n'; exit 0\n"
+            "  fi\n"
+            "  prev=$a\n"
+            "done\n"
+            "sleep %s\n"
+            "printf '%s\\n%s\\n%s\\n'\n"
+            "exit 0\n" % (line, delay, line, line, line))
     os.chmod(p, 0o755)
 
 

--- a/tests/test-tailscale-ingress-isolation.py
+++ b/tests/test-tailscale-ingress-isolation.py
@@ -88,6 +88,12 @@ def have_env():
 SUDO = "" if os.geteuid() == 0 else "sudo -n"
 
 BOX, TSC, PHY = "pdgts_box", "pdgts_tsc", "pdgts_phy"
+# veth 的**临时**名字: 建的时候用它们, 移进 netns 之后再改成 tailscale0 / wan0 / eth0。
+# 直接用目标名建会在宿主 netns 里短暂占用 "tailscale0", 与真机上跑着的 Tailscale 撞车。
+# 名字里带 PID: 同一台机器上并发跑两份时互不干扰(netns 名本身不带 PID, 所以并发本来就
+# 不支持 —— 这里只保证"上一次残留的链不会顶掉这一次")。
+V_TS_A, V_TS_B = "pdgts_t%da" % os.getpid(), "pdgts_t%db" % os.getpid()
+V_PHY_A, V_PHY_B = "pdgts_p%da" % os.getpid(), "pdgts_p%db" % os.getpid()
 # 配置给 PDG 的内网段。**两个客户端地址都落在它里面** —— 这是这支测试的全部要害:
 # 判据若只看源地址, 两侧完全不可区分, 必须靠入口接口才能分开。
 CIDR = "100.64.0.0/16"
@@ -102,6 +108,11 @@ TS_ADDR6, BOX_TS6 = "fd00:64::2", "fd00:64::1"
 def cleanup():
     for ns in (BOX, TSC, PHY):
         run("%s ip netns del %s" % (SUDO, ns))
+    # 删 netns 会带走里面的链, 但**建链与移入 netns 之间**失败时那一对还留在宿主里 ——
+    # 那正是本文件唯一会往宿主 netns 写东西的窗口, 不清就是给下一次留脏现场。
+    # 只删本进程用的那四个临时名, 不按前缀扫(别人的并发跑不该被我们删掉)。
+    for link in (V_TS_A, V_TS_B, V_PHY_A, V_PHY_B):
+        run("%s ip link del %s" % (SUDO, link))
 
 
 def build_lab():
@@ -111,9 +122,24 @@ def build_lab():
         # netns
         "ip netns add %s" % BOX, "ip netns add %s" % TSC, "ip netns add %s" % PHY,
         # veth: box.tailscale0 <-> tsclient.eth0
-        "ip link add tailscale0 netns %s type veth peer name eth0 netns %s" % (BOX, TSC),
-        # veth: box.wan0 <-> phyclient.eth0
-        "ip link add wan0 netns %s type veth peer name eth0 netns %s" % (BOX, PHY),
+        #
+        # ⚠️ **先用临时名建、再移进 netns 里改名**, 不能直接 `ip link add tailscale0 netns …`。
+        # `ip link add` 是**先在当前(宿主)netns 建出这一对, 再移过去** —— 于是那个瞬间宿主
+        # 里就有了一个叫 tailscale0 的接口。在**真的跑着 Tailscale 的机器上**(开发机就是),
+        # 这一步必然 `RTNETLINK answers: File exists`, 整个实验床建不起来, 而报错指向的是
+        # "建实验床失败", 看不出跟宿主的 tailscale0 有关。
+        # 临时名带 pdgts_ 前缀 + PID, 与 cleanup() 的清理范围一致, 不会撞到任何真实接口。
+        "ip link add %s type veth peer name %s" % (V_TS_A, V_TS_B),
+        "ip link set %s netns %s" % (V_TS_A, BOX),
+        "ip link set %s netns %s" % (V_TS_B, TSC),
+        "ip -n %s link set %s name tailscale0" % (BOX, V_TS_A),
+        "ip -n %s link set %s name eth0" % (TSC, V_TS_B),
+        # veth: box.wan0 <-> phyclient.eth0(同样的道理, 统一走临时名)
+        "ip link add %s type veth peer name %s" % (V_PHY_A, V_PHY_B),
+        "ip link set %s netns %s" % (V_PHY_A, BOX),
+        "ip link set %s netns %s" % (V_PHY_B, PHY),
+        "ip -n %s link set %s name wan0" % (BOX, V_PHY_A),
+        "ip -n %s link set %s name eth0" % (PHY, V_PHY_B),
         # 地址与启用
         "ip -n %s addr add %s/30 dev tailscale0" % (BOX, BOX_TS),
         "ip -n %s addr add %s/30 dev wan0" % (BOX, BOX_PHY),

--- a/tests/test-update-rollback.sh
+++ b/tests/test-update-rollback.sh
@@ -41,6 +41,19 @@ HEAD_REF=$(git -C "$REPO" rev-parse HEAD)
 
 # ── 抽取 cmd_rollback + 打桩 ──────────────────────────────────────────────────
 sed -n '/^cmd_rollback(){/,/^}/p' "$ROOT/deploy/bot/pdg.sh" > "$WORK/rollback.sh"
+# _snap_meta_commit 也要**抽真的**, 不能靠打桩、更不能不管。
+#
+# 它是 cmd_rollback 在"调用方没点名 --git"时用来取回滚目标提交的那一步。原来两样都没做:
+# 没抽也没打桩, 于是壳里跑到那行是 **127(command not found)**, 输出被 2>/dev/null 吞掉,
+# 命令替换得到空串 —— 恰好和"这份快照没记提交"是同一个结果, 于是判据一路绿着走过去,
+# 而**真函数从来没被执行过**。这条 127 在基线上就存在, 是 v1.10.16 那轮加收敛调用时才
+# 因为退出码变化被顺带暴露出来的。
+#
+# 它只依赖 python3(读 snapshot.json 的 git_commit, 且只认合法哈希 —— 字面量 "unknown"
+# 会被正则挡掉), 抽进来零成本, 比任何桩都忠实。
+sed -n '/^_snap_meta_commit(){/,/^}/p' "$ROOT/deploy/bot/pdg.sh" >> "$WORK/rollback.sh"
+grep -q '^_snap_meta_commit(){' "$WORK/rollback.sh" \
+  || { echo "[FAIL] 抽不到 _snap_meta_commit —— 改名了? 后面的判据全部无效"; exit 1; }
 # 快照里不含 etc/sing-box/config.json 与 etc/nftables.conf → 内核/nft 校验分支被跳过,
 # 无需真 sing-box/mihomo/nft 二进制(也就不必打桩带连字符的函数名)。
 cat > "$WORK/harness.sh" <<EOF
@@ -88,6 +101,31 @@ e2e_git "$REPO" reset --hard -q "$HEAD_REF"
 out=$(run "--dir '$SNAP/A' --git '$GOOD_REF'")
 [[ "$(git -C "$REPO" rev-parse HEAD)" == "$GOOD_REF" ]] \
   && echo "$out" | grep -q '已回滚并重启服务' && ok "--git: REPO_DIR 复位到指定提交 + 报完全回滚" || bad "B: HEAD=$(git -C "$REPO" rev-parse HEAD) out=$out"
+
+# ── B2. 不带 --git 时, 目标从**快照自己记的** git_commit 派生 ────────────────
+# 这一格是补上来的: 本壳原来每个用例都显式传 --git, 于是 _snap_meta_commit 那条路径
+# 一次都没走过 —— 而它当时根本没被抽进壳里, 跑到那行是静默 127, 命令替换得到空串,
+# 恰好与"这份快照没记提交"同一个结果, 所以一路绿着走过去。127 消失了不等于这条路被验了。
+e2e_git "$REPO" reset --hard -q "$HEAD_REF"
+printf '{"id":"A","source":"cli","op":"update","git_commit":"%s"}\n' "$GOOD_REF" > "$SNAP/A/snapshot.json"
+out=$(run "--dir '$SNAP/A'")
+[[ "$(git -C "$REPO" rev-parse HEAD)" == "$GOOD_REF" ]] \
+  && ok "无 --git: 目标取自快照记的 git_commit(仓库已复位)" \
+  || bad "B2: HEAD=$(git -C "$REPO" rev-parse HEAD) 期望=$GOOD_REF out=$out"
+echo "$out" | grep -q '将一并把仓库复位到快照记录的提交' \
+  && ok "  并明说目标是从快照元数据派生的" || bad "B2b: out=$out"
+
+# ── B3. git_commit 是字面量 "unknown" 时不许当成提交 ─────────────────────────
+# _snap_meta_write 读不到仓库时写的就是 "unknown"。把它交给 `git reset --hard` 会拿一个
+# 不存在的 ref 去复位 —— 正则必须把它挡在外面, 表现应与"没记提交"一致。
+e2e_git "$REPO" reset --hard -q "$HEAD_REF"
+printf '{"id":"A","source":"cli","op":"update","git_commit":"unknown"}\n' > "$SNAP/A/snapshot.json"
+out=$(run "--dir '$SNAP/A'")
+[[ "$(git -C "$REPO" rev-parse HEAD)" == "$HEAD_REF" ]] \
+  && ok "git_commit=unknown → 不当成提交, 仓库不动" || bad "B3: HEAD 被改成 $(git -C "$REPO" rev-parse HEAD)"
+echo "$out" | grep -q '没记下仓库提交' \
+  && ok "  并如实说'只还原了一半'而不是静默跳过" || bad "B3b: out=$out"
+rm -f "$SNAP/A/snapshot.json"
 
 # ── C. git ref 不存在 → 不谎报完全回滚, 返回 1 ───────────────────────────────
 rc=0; out=$(run "--dir '$SNAP/A' --git 'deadbeefdeadbeef'") || rc=$?


### PR DESCRIPTION
关掉台账里的 **P3 ①** 与 **P3 ③**。两条根因都在测试夹具,**生产代码一个字节没动**(`deploy/` 与 `lib/` 零改动)。

## ① `test-update-rollback.sh` 的静默 127

该壳只抽了 `cmd_rollback`,而 `_snap_meta_commit` **既没抽也没打桩** —— 跑到那行是 127,输出被 `2>/dev/null` 吞掉,命令替换得到空串。而空串**恰好**与「这份快照没记提交」是同一个结果,于是判据一路绿着走过去,**真函数从来没被执行过**。

这条 127 在基线上就存在,是 v1.10.16 那轮加回滚收敛调用、退出码变化后才被顺带暴露出来的。

改法:抽真函数(它只依赖 `python3`,比任何桩都忠实),并加一条「抽不到就整支作废」的完整性断言。

**光去掉 127 不算修好** —— 本壳每个用例都显式传 `--git`,那条路径本来就走不到。补两格钉住它:

- 不带 `--git` 时,目标必须取自快照记的 `git_commit`(仓库真的被复位,且明说目标是派生来的);
- `git_commit` 是字面量 `"unknown"` 时**不许**当成提交 —— 那是 `_snap_meta_write` 读不到仓库时写的值,拿去 `git reset --hard` 会指向一个不存在的 ref,表现须与「没记提交」一致。

负控:撤掉抽取那一句,B2/B2b 立刻转红,而且失败信息**直接点名 `_snap_meta_commit: command not found`** —— 静默 127 变成具名失败。

## ③ 开发机跑着 Tailscale 时三支恒红

**`test-tailscale-ingress-isolation.py`** —— `ip link add tailscale0 netns BOX …` 是**先在当前(宿主)netns 建出这一对再移过去**,那个瞬间宿主里就有了一个 `tailscale0`。在真的跑着 Tailscale 的机器上必然 `RTNETLINK answers: File exists`,而报错只说「建实验床失败」,看不出与宿主的 `tailscale0` 有关。改成用带 PID 的临时名建、移进 netns 之后再改名。

同时补 `cleanup`:建链与移入 netns **之间**失败时,那一对会留在**宿主**里,删 netns 带不走它 —— 那是本文件唯一会往宿主 netns 写东西的窗口。

**`test-cidr-input.py`** —— 假 tcpdump 吐的是老格式(没有接口名与方向),而且对探测调用(`-c 1`,外面套着 `timeout 3`)也一律先 `sleep delay`。两者都让 `lib/detect-internal-range.sh` 判定「这台的 tcpdump 不打接口名」;宿主有 `tailscale0` 且判定如此时,产品**有意拒绝猜测**(宁可让人手输,也不冒险把 tailnet 地址当成内网卡来源)→ 结果为空 → 断言失败。

**产品那个分支是对的,错的是桩没把现代 tcpdump 演出来。**改成吐 `<时刻> <接口> In IP <源>.<端口> > <目的>.<端口>: …`,并按 `-c 1` 区分探测与抓取。

**`test-tmp-hygiene.py`** 是上一条的级联(它自己写明「cidr-input 没通过,卫生结论无从谈起」),自动跟着好。

## 验证(本机确实跑着 Tailscale)

| | 修前 | 修后 |
|---|---|---|
| `test-update-rollback.sh` | 15/0,含 1 条静默 127 | **19/0**,`command not found` 计数 **0** |
| `test-cidr-input.py` | rc=1 | **7/7** |
| `test-tailscale-ingress-isolation.py` | 建不起实验床 | **13/0/0** |
| `test-tmp-hygiene.py` | rc=1(级联) | **18/0** |
| `negctl/tailscale-isolation-*` | 17 有效 / 1 失败(脏工作区) | **18 有效 / 0** |

**全量宿主回归 182 支全绿** —— 这台开发机第一次跑出零非零 rc。与上一基线比:新增非零 **0**、新增具名失败 **0 条**,修好的正是那三支。

静态门:CI 原样 ShellCheck rc=0、`py_compile`、`bash -n`、`git diff --check`、CI coverage 22/0。

## 顺带的价值

③ 修好之前,那三支恒红会淹掉真信号(§9.10「本地绿不算数」的反面:本地红也未必是真的)。修好之后本机全量回归重新具备判别力。

## 不在本 PR 范围

台账里 **P3 ②**(enabled 态收敛每次都 `restart pdg-lan`;产物层幂等已钉死,服务层未优化,且至今未在真机触发过)与 **P3 ④**(`_RL_WANT` 与其唯一消费者约 80 行组织间隔)按要求**未处理**,仍记为未解决。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
