### PR TITLE
fix(doctor): 限流判据认得模板与迁移两种形态

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,6 +785,9 @@ jobs:
         run: bash tests/test-explicit-proxy-nc.sh
       - name: DNS 限流 (rate_limiter 迁移幂等 + 真起 mosdns 验证超限 REFUSED + doctor)
         run: bash tests/test-mosdns-ratelimit.sh
+
+      - name: "限流判据必须认得模板与迁移两种形态(行尾注释不该被当成缺失)"
+        run: python3 tests/test-ratelimit-judgement.py
       - name: 出站 schema (锁定版 sing-box check 各协议 parse_link 输出)
         run: bash tests/test-outbound-schema.sh
       - name: 劫持形态 (真起 mosdns 验证 all=排除式劫持 / gfw=白名单放行)

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1153,7 +1153,15 @@ def check_mosdns_ratelimit():
     # 判据会把一段说明当成缓存的位置 —— 同 HANDOFF §14 那个 grep 命中注释行的形态。
     # 两个位置必须在**同一个坐标系**里比 —— 一个在剥注释后的文本里找、另一个在原文里找,
     # 得到的下标根本不可比(这一版就是这么错过一次)。故两者都用 blk_nc。
+    # 只剥整行注释是不够的。`!$client_limiter` 那一行有**两个生产者**, 形态不同:
+    #     模板 config.yaml       - matches: "!$client_limiter"     # 单客户端超 QPS → REFUSED, …
+    #     migrate_mosdns_ratelimit  - matches: "!$client_limiter"
+    # 上一版改成在剥过注释的文本上匹配时, 顺手去掉了原来对行尾注释的容忍 —— 而剥法只管整行,
+    # 于是**模板形态**(= 全新装机的形态)一律被判成"缺失或参数异常": 一条假警告, 还建议用户
+    # 去跑 pdg restart 追一个不存在的问题(线上 jp2 实测到的就是它)。行尾注释一并剥掉:
+    # 位置判断照样不被受管块说明文字里的 `$lazy_cache` 骗过, 两个生产者的形态也都认得。
     blk_nc = re.sub(r"^\s*#.*$", "", blk, flags=re.M)
+    blk_nc = re.sub(r"[ \t]+#[^\n]*$", "", blk_nc, flags=re.M)
     i_cache = blk_nc.find("$lazy_cache")
     step = re.search(r'matches:\s*"?!\$client_limiter"?[ \t]*\n\s*exec:\s*reject\s+5\b', blk_nc)
     if not step or (i_cache >= 0 and step.start() >= i_cache):

--- a/tests/test-ratelimit-judgement.py
+++ b/tests/test-ratelimit-judgement.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""限流判据必须认得**两个生产者写出来的两种形态**。
+
+线上实测(jp2, v1.11.1)doctor 报:
+
+    🟡 限流: mosdns 单客户端 QPS 兜底(rate_limiter)缺失或参数/动作异常
+
+而那台机器的限流器完全正确 —— 插件在位、qps200/burst400/mask4-32/mask6-128 逐个对、
+`!$client_limiter → reject 5` 也确实排在缓存之前。假警告。
+
+根因: `!$client_limiter` 这一行有**两个生产者**, 写出来的形态不同 ——
+
+    模板 deploy/mosdns/config.yaml:133
+        - matches: "!$client_limiter"     # 单客户端超 QPS → REFUSED, 抢在缓存/上游之前拦掉
+    migrate_mosdns_ratelimit 写出来的
+        - matches: "!$client_limiter"
+
+判据原本用 `(?:#[^\n]*)?` 容忍行尾注释, 两种都认。去广告那一轮为了不让新加的受管块注释骗过
+`$lazy_cache` 的位置判断, 把判据改成在**剥过注释**的文本上匹配, 顺手把那段容忍去掉了 ——
+可是剥注释用的是 `^\s*#.*$`, 只剥**整行**注释, 行尾注释原样留着。于是模板形态不再命中。
+
+影响面: 全新装机走的就是模板渲染, **每一台新装的机器都会看到这条假警告**, 还被建议去跑
+`pdg restart` 触发迁移 —— 追一个不存在的问题。功能没坏(限流由 mosdns 执行, doctor 只是
+旁观者), 坏的是诚实性。
+
+这一支把两种形态都钉死, 并且**保住当初那次修复要护的性质**: 受管块的注释不许骗过位置判断。
+"""
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "deploy/bot"))
+TMPL = (ROOT / "deploy/mosdns/config.yaml").read_text(encoding="utf-8")
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+import checks          # noqa: E402
+
+
+def verdict(conf_text):
+    """真跑生产判据 check_mosdns_ratelimit, 返回 (等级, 文案)。"""
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        f.write(conf_text)
+        path = f.name
+    old = checks.MOSDNS_CONF
+    try:
+        checks.MOSDNS_CONF = path
+        r = checks.check_mosdns_ratelimit()
+    finally:
+        checks.MOSDNS_CONF = old
+        Path(path).unlink(missing_ok=True)
+    return (r[0], r[2]) if r else ("none", "")
+
+
+LINE_RE = re.compile(r'^(\s*- matches: "!\$client_limiter")(.*)$', re.M)
+
+print("══ 0. 前提: 模板与迁移确实写出两种形态 ══")
+m = LINE_RE.search(TMPL)
+(ok if m else bad)("模板里找得到 `!$client_limiter` 那一行")
+(ok if m and m.group(2).strip().startswith("#") else bad)(
+    "模板那一行**带行尾注释**(实得 %r)" % (m.group(2).strip()[:40] if m else None))
+mig = (ROOT / "deploy/bot/pdg.sh").read_text(encoding="utf-8")
+mm = re.search(r"step='''(.*?)'''", mig, re.S)
+(ok if mm and "#" not in mm.group(1) else bad)(
+    "migrate_mosdns_ratelimit 写出来的**不带**行尾注释")
+
+# 两种形态: 模板原样 / 把行尾注释去掉(= 迁移写出来的样子)
+TEMPLATE_SHAPE = TMPL
+MIGRATED_SHAPE = LINE_RE.sub(lambda x: x.group(1), TMPL)
+
+print()
+print("══ 1. 两种形态都必须判绿 ══")
+for label, conf in (("模板形态(带行尾注释, 全新装机)", TEMPLATE_SHAPE),
+                    ("迁移形态(不带注释)", MIGRATED_SHAPE)):
+    lvl, msg = verdict(conf)
+    (ok if lvl == "ok" else bad)("%s → %s(%s)" % (label, lvl, msg[:52]))
+
+print()
+print("══ 2. 真有问题时仍要报 ══")
+cases = [
+    ("整段 limiter 缺失", re.sub(r"  - tag: client_limiter\n.*?\n.*?\n", "", TMPL, count=1, flags=re.S)),
+    ("qps 被改坏", TMPL.replace("qps: 200", "qps: 20", 1)),
+    ("burst 被改坏", TMPL.replace("burst: 400", "burst: 40", 1)),
+    ("动作不是 reject 5", TMPL.replace("exec: reject 5", "exec: accept", 1)),
+    ("判据整行被删", LINE_RE.sub("", TMPL)),
+]
+for label, conf in cases:
+    lvl, _ = verdict(conf)
+    (ok if lvl == "warn" else bad)("%s → 应 warn, 实得 %s" % (label, lvl))
+
+print()
+print("══ 3. 位置: 限流必须在缓存之前 ══")
+# 把限流那两行搬到 $lazy_cache 之后
+mv = LINE_RE.search(TMPL)
+if mv:
+    two = TMPL[mv.start():TMPL.index("\n", TMPL.index("exec: reject 5", mv.start())) + 1]
+    moved = TMPL.replace(two, "", 1).replace("      - exec: $lazy_cache\n",
+                                             "      - exec: $lazy_cache\n" + two, 1)
+    lvl, _ = verdict(moved)
+    (ok if lvl == "warn" else bad)("限流搬到缓存之后 → 应 warn, 实得 %s" % lvl)
+else:
+    bad("抽不出限流那两行, 位置这一格无从谈起")
+
+print()
+print("══ 4. 受管块的注释不许骗过位置判断(当初那次修复要护的性质)══")
+# 去广告受管块里含 `$lazy_cache` 字样的注释, 曾让位置判断把注释当成真的 cache 位置。
+poisoned = TMPL.replace("      - exec: $lazy_cache\n",
+                        "      # 这一段排在 $lazy_cache 之前(注释里也提到了 $lazy_cache)\n"
+                        "      - exec: $lazy_cache\n", 1)
+lvl, _ = verdict(poisoned)
+(ok if lvl == "ok" else bad)("注释里提到 $lazy_cache 不影响判绿(实得 %s)" % lvl)
+# 反面: 真把限流搬到 cache 之后, 即使注释里怎么写也要报
+poisoned_bad = LINE_RE.sub("", poisoned)
+lvl2, _ = verdict(poisoned_bad)
+(ok if lvl2 == "warn" else bad)("同样有注释但判据真缺失时仍然 warn(实得 %s)" % lvl2)
+
+print("-" * 62)
+print("test-ratelimit-judgement.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
## 症状

线上实测(jp2, v1.11.1)`pdg doctor` 报:

```
🟡 限流: mosdns 单客户端 QPS 兜底(rate_limiter)缺失或参数/动作异常
```

而那台机器的限流器完全正确 —— 插件在位、qps200/burst400/mask4-32/mask6-128 逐个对、`!$client_limiter → reject 5` 也确实排在缓存之前。**假警告。**

## 根因

`!$client_limiter` 这一行有**两个生产者**,写出来的形态不同:

| 生产者 | 形态 |
|---|---|
| 模板 `deploy/mosdns/config.yaml` | `- matches: "!$client_limiter"     # 单客户端超 QPS → REFUSED, …` |
| `migrate_mosdns_ratelimit` | `- matches: "!$client_limiter"` |

判据原本用 `(?:#[^\n]*)?` 容忍行尾注释,两种都认。去广告那一轮为了不让新加的受管块注释骗过 `$lazy_cache` 的位置判断,把判据改成在**剥过注释**的文本上匹配,顺手把那段容忍去掉了 —— 可剥注释用的是 `^\s*#.*$`,只剥**整行**注释,行尾注释原样留着。于是模板形态不再命中。

## 影响面

全新装机走的就是模板渲染,**每一台新装的机器都会看到这条假警告**,还被建议去跑 `pdg restart` 追一个不存在的问题。功能没坏(限流由 mosdns 执行,doctor 只是旁观者),坏的是诚实性。

## 修法

行尾注释一并剥掉。位置判断照样不被受管块说明文字里的 `$lazy_cache` 骗过,两个生产者的形态也都认得。

## 验证

新增 `tests/test-ratelimit-judgement.py`(13 格),**全部落在真跑生产判据 `check_mosdns_ratelimit` 上**,不是对着正则做字符串比对:

- 两种形态都判绿
- 真有问题时仍报 warn:整段 limiter 缺失 / qps 被改坏 / burst 被改坏 / 动作不是 `reject 5` / 判据整行被删
- 位置:限流搬到 `$lazy_cache` 之后 → warn
- **保住当初那次修复要护的性质**:注释里提到 `$lazy_cache` 不影响判绿;同样有注释但判据真缺失时仍然 warn

exact-head CI(workflow_dispatch @ `7a61fef4`):**29/29 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)