### PR TITLE
feat(adblock): 第三方规则源可配 + 上游容错 + 条数上限按 512M 实测重定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
       - name: "去广告用户规则事务 CLI: 停用态只改源 / 幂等零重启 / 精确删除 / 失败整份回滚"
         run: bash tests/test-adblock-rule-cli.sh
 
+      - name: "去广告第三方源可配: add 当场校验 / 幂等 / 白名单只跟配置过的源走 / 进快照"
+        run: bash tests/test-adblock-sources.sh
+
       - name: "Telegram 内联按钮管理去广告规则: 闭集 callback / 跨用户隔离 / 只经 argv 调 CLI"
         run: python3 tests/test-bot-adblock-inline.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,9 @@ jobs:
       - name: "去广告第三方源可配: add 当场校验 / 幂等 / 白名单只跟配置过的源走 / 进快照"
         run: bash tests/test-adblock-sources.sh
 
+      - name: "第三方表容错: 下划线主机名放行 / 少量坏行跳过计数 / 超阈值仍整份拒"
+        run: python3 tests/test-adblock-upstream-tolerance.py
+
       - name: "Telegram 内联按钮管理去广告规则: 闭集 callback / 跨用户隔离 / 只经 argv 调 CLI"
         run: python3 tests/test-bot-adblock-inline.py
 

--- a/deploy/bot/adblock.py
+++ b/deploy/bot/adblock.py
@@ -132,9 +132,14 @@ def parse_source_ex(text):
         else:
             return ([], 0, "认不出的行形态")         # 结构性不对
         cand = cand.strip().lower().rstrip(".")
-        if _IPV4_RE.match(cand) or cand in ("localhost", "localhost.localdomain", "local"):
-            return ([], 0, "出现纯 IP / localhost 条目")   # 结构性不对 → 整份拒
-        if not _DOMAIN_RE.match(cand):
+        # 纯 IP / localhost: **跳过计数**, 不整份拒。合并型广告表从多个上游拼起来, 掺进
+        # 几条 IP 是常态(线上那张 215320 行的表里有 57 条, 占 0.026%), 而 domain_set 里放
+        # 一个 IPv4 字面量, mosdns 会拿它当域名匹配 —— 永远匹配不到真实查询, 无害也无用。
+        # 为这点比例废掉 21.5 万条不成比例。真拿错成一份 IP 黑名单时, 比例会接近 100%,
+        # 下面的 max_skip_ratio 照样把它整份拒掉。
+        if (_IPV4_RE.match(cand)
+                or cand in ("localhost", "localhost.localdomain", "local")
+                or not _DOMAIN_RE.match(cand)):
             skipped += 1                            # 逐行的域名不合格: 跳过并计数
             continue
         names.append(cand)

--- a/deploy/bot/adblock.py
+++ b/deploy/bot/adblock.py
@@ -315,9 +315,11 @@ def update_lists(state_dir=None, sources=None, fetch=None):
     os.makedirs(d, exist_ok=True)
     lk = os.path.join(d, "list.lkg")
     prev = read_meta(d).get("count") or None
-    fetch = fetch or (lambda u: _safe_fetch(u, LIMITS["max_bytes"]))
+    src = list(sources or DEFAULT_SOURCES)
+    hosts = allowed_fetch_hosts(src)          # 白名单跟着**这一次真正要取的源**算
+    fetch = fetch or (lambda u: _safe_fetch(u, LIMITS["max_bytes"], allowed_hosts=hosts))
     errs = []
-    for url in (sources or DEFAULT_SOURCES):
+    for url in src:
         try:
             got = fetch(url)
             text, ctype = (got[0], got[1]) if isinstance(got, (tuple, list)) else (got, "")
@@ -472,8 +474,67 @@ def infra_closure(acme_home=None, user_allow=None):
 # 所以这里**不用任何会自己解析域名或自己跟随重定向的 HTTP 客户端**: 自己解析、自己校验、
 # 自己连、自己发一个最小请求。多写几十行, 换的是"校验过的地址就是真正连上去的地址"。
 
-# 允许连接的主机名 = 从 DEFAULT_SOURCES **算出来**的精确集合。不是通配、不是后缀匹配,
-# 也不是"URL 里写了什么就信什么" —— 换源不在首版范围内, 这个集合就该是封闭的。
+SOURCES_FILE = "/etc/privdns-gateway/adblock-sources.txt"     # 用户源, 一行一个; 是用户数据
+
+
+def check_source_url(url):
+    """(ok, reason)。URL 形态的**单一真源** —— `source add` 与 `_safe_fetch` 用同一套。
+
+    分开写是为了让 `source add` 能在**落盘之前**当场拒:等到 update 才报"这个源不合规",
+    用户已经把它记进配置里了, 排查起来还得先想起来是什么时候加的。
+    这里只判 URL 本身, 不做任何网络动作。
+    """
+    p = urllib.parse.urlsplit(url or "")
+    if p.scheme != "https":
+        return (False, "只允许 https(实得 scheme=%s)" % (p.scheme or "空",))
+    if p.username or p.password:
+        return (False, "URL 里带 userinfo")
+    try:
+        port = p.port
+    except ValueError:
+        return (False, "URL 的端口部分非法")
+    if port not in (None, 443):
+        return (False, "只允许默认 443 端口(实得 %s)" % port)
+    host = p.hostname or ""
+    if not host:
+        return (False, "URL 里没有主机名")
+    try:
+        ipaddress.ip_address(host)
+        return (False, "主机名是 IP 字面量(证书与白名单都无从谈起)")
+    except ValueError:
+        pass
+    if not _DOMAIN_RE.match(host.lower()):
+        return (False, "主机名不是合法域名")
+    return (True, "")
+
+
+def read_sources(path=None):
+    """用户配置的源; 没配就返回内置默认。允许 # 注释与空行。
+
+    "没配 = 用默认"这条让老机器升上来行为一个字节不变 —— 升级不该顺手改掉别人在用的源。
+    """
+    try:
+        with open(path or SOURCES_FILE, encoding="utf-8") as f:
+            urls = [l.strip() for l in f if l.strip() and not l.strip().startswith("#")]
+    except OSError:
+        urls = []
+    return urls or list(DEFAULT_SOURCES)
+
+
+def allowed_fetch_hosts(sources=None):
+    """允许连接的主机名 = 从**生效的源**算出来的精确集合。不是通配、不是后缀匹配,
+    也不是"URL 里写了什么就信什么"。
+
+    用户 `source add` 一个主机, 它才进这个集合 —— 那一步本身就是显式授权, 且 add 时已经
+    过了 check_source_url。**没被配置过的主机照样连不上**: 这道门挡的是"URL 被改成任意
+    地方", 而真正的安全价值在它后面几道(零重定向 / 非公网地址拒绝 / DNS 与连接地址绑定 /
+    TLS 用原始主机名校验)—— 那几道一条都没有因为源可配而松动。
+    """
+    src = sources if sources is not None else read_sources()
+    return frozenset(h for h in (urllib.parse.urlsplit(u).hostname for u in src) if h)
+
+
+# 内置默认算出来的那份, 保留给不传 sources 的老调用点(行为与首版一致)。
 ALLOWED_FETCH_HOSTS = frozenset(
     h for h in (urllib.parse.urlsplit(u).hostname for u in DEFAULT_SOURCES) if h)
 
@@ -516,7 +577,8 @@ def _default_connect(addr, port, timeout):
     return socket.create_connection((addr, port), timeout=timeout)
 
 
-def _safe_fetch(url, max_bytes, resolve=None, connect=None, ssl_context=None):
+def _safe_fetch(url, max_bytes, resolve=None, connect=None, ssl_context=None,
+                allowed_hosts=None):
     """按固定白名单取一份规则表。返回 (text, content_type, status)。
 
     每一道都在**连接之前**判完, 判不过就一个字节都不发。
@@ -540,8 +602,8 @@ def _safe_fetch(url, max_bytes, resolve=None, connect=None, ssl_context=None):
         raise FetchRefused("主机名是 IP 字面量 —— 拒绝(证书与白名单都无从谈起)")
     except ValueError:
         pass
-    if host not in ALLOWED_FETCH_HOSTS:
-        raise FetchRefused("主机名不在固定白名单内: %s" % host)
+    if host not in (allowed_hosts if allowed_hosts is not None else ALLOWED_FETCH_HOSTS):
+        raise FetchRefused("主机名不在允许集合内: %s" % host)
 
     addrs = (resolve or _default_resolve)(host)
     if not addrs:
@@ -671,6 +733,15 @@ if __name__ == "__main__":
                                       sys.argv[3] if len(sys.argv) > 3 else None,
                                       sys.argv[4] if len(sys.argv) > 4 else None),
                          ensure_ascii=False))
+    elif len(sys.argv) >= 3 and sys.argv[1] == "check-source":
+        good, why = check_source_url(sys.argv[2])
+        print(json.dumps({"ok": good, "why": why}, ensure_ascii=False))
+        sys.exit(0 if good else 2)
+    elif len(sys.argv) >= 2 and sys.argv[1] == "list-sources":
+        print(json.dumps({
+            "sources": read_sources(sys.argv[2] if len(sys.argv) > 2 else None),
+            "defaults": list(DEFAULT_SOURCES),
+        }, ensure_ascii=False))
     elif len(sys.argv) >= 3 and sys.argv[1] in ("rule-add", "rule-del"):
         # 只吐 JSON, 不吐文案 —— 调用方(pdg.sh → Bot)认字段不认措辞。
         # 与 check 同一条规矩: **非法输入不回显原文**, 只说是哪一类不合法。
@@ -682,7 +753,11 @@ if __name__ == "__main__":
             sys.exit(2)
         print(json.dumps({"change": change, "normalized": norm}, ensure_ascii=False))
     elif len(sys.argv) >= 2 and sys.argv[1] == "update":
-        print(json.dumps(update_lists(sys.argv[2] if len(sys.argv) > 2 else None), ensure_ascii=False))
+        # argv[3] 可选: 用户源文件路径。调用方(pdg.sh)手里就有这个真源, 传进来比在这里
+        # 再写死一次好, 也让沙箱测试能指到假根。
+        _srcs = read_sources(sys.argv[3]) if len(sys.argv) > 3 else None
+        print(json.dumps(update_lists(sys.argv[2] if len(sys.argv) > 2 else None, _srcs),
+                         ensure_ascii=False))
     elif len(sys.argv) >= 3 and sys.argv[1] == "compile":
         # 第 4 个参数是用户 block 源的路径, 可选。调用方(pdg.sh)手里本来就有 ADB_USER_BLOCK
         # 这个真源, 让它传进来比在这里再写死一次好 —— 也让沙箱测试能指到假根, 而不必去

--- a/deploy/bot/adblock.py
+++ b/deploy/bot/adblock.py
@@ -45,23 +45,42 @@ DEFAULT_SOURCES = (
 
 # ── 阈值 ─────────────────────────────────────────────────────────────────────
 # 每个数字都能解释, 不是"看着合理":
-#   max_entries 150000 —— Phase 0 在 MemoryMax=96M、禁 swap 下实测过 15 万条:
-#                         RSS 45.1 MiB、200 QPS p99 1.56ms、oom_kill=0。上限取到实测过的
-#                         那个点为止, 再高就没有证据了。
-#   max_bytes   8 MiB  —— 实测 anti-AD 2.0 MiB / AdGuard 4.1 MiB; 8 MiB 留一倍余量,
+#   max_entries 500000 —— 见下面 LIMITS 里那段实测。(旧值 150000 出自更早的 Phase 0, 那次
+#                         的约束是 MemoryMax=96M —— 一个测试时人为加的上限, 产品并不设它;
+#                         按"整机 512M 可用"重测之后, 那个数不再是决策依据。)
+#   max_skip_ratio 1%  —— 第三方表逐行域名不合格时跳过的比例上限, 见 LIMITS 里的说明。
+#   max_bytes   8 MiB  —— 实测 anti-AD 2.0 MiB / AdGuard 4.1 MiB / adblockfilters 4.2 MiB;
+#                         8 MiB 留了余量,
 #                         同时给下载一个硬边界(防的是"对方返回了一个巨大的东西")。
 #   min_entries 1000   —— 真实广告表都在万条以上; 1000 挡的是截断、半截下载与错页。
 #   max_drop_ratio 0.5 —— 新表不足上一份 LKG 的一半就拒。源被投毒或半截发布时, 条目数是
 #                         最先塌下来的那个量。
 LIMITS = {
     "min_entries": 1000,
-    "max_entries": 150000,
+    # 512M 整机实测重定(旧值 150000 是更早在 MemoryMax=96M 那个更紧的约束下压的, 已不是
+    # 今天的决策依据)。真跑 mosdns v5.3.4 + 生产模板 + 145591 条 geosite, 逐档量 RSS:
+    #     15 万 61.6 MiB · 30 万 77.8 · 50 万 108.6 · 60 万 109.5 · 80 万 123.0 · 100 万 166.7
+    # 选 50 万是因为它正好在一个台阶顶上(50 万与 60 万的 RSS 几乎一样), 再多一点不会突然
+    # 多吃内存。512M 机器上非 mosdns 部分实测约 217 MiB(mihomo 36.4 + bot 39.6 + lan 40.9
+    # + 系统底噪), 50 万条时整机约 326 MiB, **余量 186 MiB 且不依赖 swap**。
+    # 延迟与条数无关: 150 qps 定速下 p50 稳在 0.11 ms、p95 0.18 ms, 从 15 万到 100 万看不出
+    # 趋势 —— domain_set 的查询是 O(域名长度) 而不是 O(表大小)。约束只在内存。
+    "max_entries": 500000,
     "max_bytes": 8 * 1024 * 1024,
     "max_drop_ratio": 0.5,
+    # 逐行域名校验失败允许跳过的比例上限。第三方表是**别人**在维护, 上游一行手滑不该让用户
+    # 整张表用不了(线上实测: 21.5 万条的表里一行下划线就全废)。但也不能静默丢 —— 跳过要计数
+    # 并上报, 超过这个比例仍然整份拒: 格式真的变了(比如返回半页 HTML), 比例会立刻远超 1%。
+    "max_skip_ratio": 0.01,
 }
 
-_DOMAIN_RE = re.compile(r"^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
-                        r"(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$")
+# 放行下划线: DNS 协议本身允许(`_dmarc` / `_acme-challenge` 就是), 只是 RFC 1123 的
+# **hostname** 规范不允许。作为阻断规则的模式串, 下划线不造成任何歧义或注入, 而拒掉它等于
+# 对一类真实存在、也确实该拦的名字视而不见(线上那张表里的 fb_servpub-a.akamaihd.net)。
+# 放宽的**只有**下划线 —— 连字符不许出现在标签首尾这条没动, 通配符 / 路径 / ABP / 正则 /
+# IP 字面量仍然由 _SYNTAX_CHARS 与后面几道判据整份拒。
+_DOMAIN_RE = re.compile(r"^(?=.{1,253}$)[a-z0-9_]([a-z0-9_-]{0,61}[a-z0-9_])?"
+                        r"(\.[a-z0-9_]([a-z0-9_-]{0,61}[a-z0-9_])?)+$")
 _IPV4_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
 _REJECT_HINTS = ("<html", "<!doctype", "<head", "<body")
 # ABP / 正则 / URL / 通配这些语法一律不吃 —— 首版只做精确与后缀两种匹配。
@@ -84,36 +103,47 @@ def normalize(names):
 
 
 def parse_source(text):
-    """把一份第三方表解析成域名列表。**拒绝比接受更重要** —— 拒不掉的坏输入会变成一张
+    """薄封装: 只要域名列表。整份被拒时返回空列表, 与首版行为一致。"""
+    return parse_source_ex(text)[0]
+
+
+def parse_source_ex(text):
+    """(names, skipped, reject_reason)。把一份第三方表解析成域名列表。**拒绝比接受更重要** —— 拒不掉的坏输入会变成一张
     看着正常的假表。任何一行认不出来就整份拒(返回空列表),不做"尽力而为"的部分解析:
     部分解析出来的表少了多少条没人知道,而少掉的正是被跳过的那些。
     """
     if not text or not text.strip():
-        return []
+        return ([], 0, "空内容")
     head = text[:4096].lower()
     if any(h in head for h in _REJECT_HINTS):
-        return []                                   # HTML 错页
-    names = []
+        return ([], 0, "看着像 HTML 错页")           # 结构性不对 → 整份拒
+    names, skipped = [], 0
     for line in text.splitlines():
         s = line.strip()
         if not s or s.startswith("#") or s.startswith("!"):
             continue                                # 注释(# 与 ABP 的 !)
         if any(c in _SYNTAX_CHARS for c in s):
-            return []                               # ABP / 正则 / URL / 通配
+            return ([], 0, "含 ABP / 正则 / URL / 通配语法")   # 结构性不对
         parts = s.split()
         if len(parts) == 2 and _IPV4_RE.match(parts[0]):
             cand = parts[1]                         # hosts 格式: 0.0.0.0 domain
         elif len(parts) == 1:
             cand = parts[0]
         else:
-            return []                               # 认不出的形态
+            return ([], 0, "认不出的行形态")         # 结构性不对
         cand = cand.strip().lower().rstrip(".")
         if _IPV4_RE.match(cand) or cand in ("localhost", "localhost.localdomain", "local"):
-            return []                               # 纯 IP / localhost
+            return ([], 0, "出现纯 IP / localhost 条目")   # 结构性不对 → 整份拒
         if not _DOMAIN_RE.match(cand):
-            return []
+            skipped += 1                            # 逐行的域名不合格: 跳过并计数
+            continue
         names.append(cand)
-    return normalize(names)
+    total = len(names) + skipped
+    if skipped and total and skipped > total * LIMITS["max_skip_ratio"]:
+        return ([], skipped,
+                "跳过的行 %d / %d 超过上限 %.0f%%(格式可能已经变了)"
+                % (skipped, total, LIMITS["max_skip_ratio"] * 100))
+    return (normalize(names), skipped, "")
 
 
 def validate_candidate(domains, prev_count=None):
@@ -332,7 +362,10 @@ def update_lists(state_dir=None, sources=None, fetch=None):
         if len(text.encode("utf-8", "replace")) > LIMITS["max_bytes"]:
             errs.append("%s: 超过最大体积" % url)
             continue
-        names = parse_source(text)
+        names, skipped, rej = parse_source_ex(text)
+        if rej:
+            errs.append("%s: %s" % (url, rej))
+            continue
         good, why = validate_candidate(names, prev_count=prev)
         if not good:
             errs.append("%s: %s" % (url, why))
@@ -342,7 +375,7 @@ def update_lists(state_dir=None, sources=None, fetch=None):
         try:
             _atomic_write(lk, "\n".join(names) + "\n")
             _atomic_write(os.path.join(d, "meta.json"), json.dumps({
-                "count": len(names), "source": url,
+                "count": len(names), "source": url, "skipped": skipped,
                 "updated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             }, ensure_ascii=False) + "\n")
         except Exception as e:                              # noqa: BLE001

--- a/deploy/bot/cfgrestore.py
+++ b/deploy/bot/cfgrestore.py
@@ -44,6 +44,9 @@ MEMBER_TARGET = {
     # 第三方编译产物有意不在这张表里 —— 它在 /var/lib 下, 可再生, 也不进全局快照。
     "etc/mosdns/rules/adblock_allow.txt": "mosdns_rule:adblock_allow.txt",
     "etc/mosdns/rules/adblock_block.txt": "mosdns_rule:adblock_block.txt",
+    # 用户配置的第三方源: 和上面两份一样是**用户数据**, 回滚必须带回去 —— 换过源的机器
+    # 回滚后要是悄悄退回内置默认, 现场看着一切正常, 拉的却是另一张表。
+    "etc/privdns-gateway/adblock-sources.txt": "adblock_sources",
     "opt/pdg-bot/rulesets.json": "rs_meta",
     # iOS 描述文件生命周期三件套。缺任何一件, 恢复出来的都是自相矛盾的状态。
     "etc/privdns-gateway/ios-profile.json": "ios_profile_state",

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5762,6 +5762,7 @@ _lan_nft_reapply(){
 ADB_STATE_DIR="/var/lib/privdns-gateway/adblock"
 ADB_USER_ALLOW="/etc/mosdns/rules/adblock_allow.txt"
 ADB_USER_BLOCK="/etc/mosdns/rules/adblock_block.txt"
+ADB_SOURCES="/etc/privdns-gateway/adblock-sources.txt"   # 用户配置的第三方源; 是用户数据, 进快照
 ADB_MARK_PL=">>> pdg-adblock managed block (plugins)"
 ADB_MARK_SQ=">>> pdg-adblock managed block (internal_sequence)"
 
@@ -5967,7 +5968,7 @@ cmd_adblock(){
     update)
       need_root adblock; _lock; _adblock_ensure_files || return 1
       local mod out; mod="$(_pdg_module adblock.py)" || return 1
-      out="$(python3 "$mod" update "$ADB_STATE_DIR" 2>&1)"
+      out="$(python3 "$mod" update "$ADB_STATE_DIR" "$ADB_SOURCES" 2>&1)"
       if grep -q '"ok": *true' <<<"$out"; then
         c_g "✅ 规则表已更新。"
         [[ "$(_adblock_intent)" == 1 ]] && { _adblock_apply 1 || return 1; }
@@ -6096,6 +6097,72 @@ sys.exit(0 if hit else 1)' "$_norm" "$ADB_USER_ALLOW"; then
       rm -f "$_src_bak" "$_eb_bak" "$_el_bak"
       _adb_emit applied "$_change" "$_restarted" "$_ovr"
       return 0;;
+    source)
+      # 第三方源可配。存在 $ADB_SOURCES(一行一个 URL, 允许 # 注释); 文件缺失或为空就沿用
+      # adblock.py 里的内置默认 —— 老机器升上来行为一个字节不变。
+      # 白名单跟着**配置过的源**走(见 adblock.py allowed_fetch_hosts): 没 add 过的主机照样
+      # 连不上, 而零重定向 / 非公网拒绝 / DNS-连接绑定 / TLS 校验那几道一条都没松。
+      local _sub="${1:-list}" _url="${2:-}" mod
+      mod="$(_pdg_module adblock.py)" || return 1
+      case "$_sub" in
+        list)
+          python3 "$mod" list-sources "$ADB_SOURCES" 2>/dev/null | python3 -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit("读不到源列表")
+cur=d.get("sources") or []; dft=d.get("defaults") or []
+using_default = cur == dft
+print("  当前生效的第三方源%s:" % ("(内置默认, 未自定义)" if using_default else ""))
+for u in cur: print("    " + u)
+if not using_default:
+    print("  内置默认(reset 可回到这里):")
+    for u in dft: print("    " + u)'
+          ;;
+        add)
+          need_root adblock
+          [[ -n "$_url" ]] || { c_y "❌ 需要一个 URL。"; return 2; }
+          # 当场校验, 不拖到 update —— 那时用户已经把它记进配置里了。
+          local _cw
+          if ! _cw="$(python3 "$mod" check-source "$_url" 2>/dev/null)"; then
+            c_y "❌ 这个 URL 不能作为规则源: $(printf '%s' "$_cw" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("why",""))
+except Exception: print("")')"
+            c_y "   只接受 https、默认 443 端口、主机名是合法域名(不能是 IP 字面量)。"
+            return 2
+          fi
+          _lock
+          mkdir -p "$(dirname "$ADB_SOURCES")" || return 1
+          if [[ -f "$ADB_SOURCES" ]] && grep -qxF "$_url" "$ADB_SOURCES"; then
+            c_g "  已存在, 未改动。"; return 0          # 幂等
+          fi
+          local _t; _t="$(mktemp)" || return 1
+          [[ -f "$ADB_SOURCES" ]] && cat "$ADB_SOURCES" > "$_t"
+          printf '%s\n' "$_url" >> "$_t"
+          install -m644 "$_t" "$ADB_SOURCES" || { rm -f "$_t"; c_y "❌ 写入失败, 未改动。"; return 1; }
+          rm -f "$_t"
+          c_g "  ✅ 已添加。下次 pdg adblock update 生效。"
+          ;;
+        del)
+          need_root adblock
+          [[ -n "$_url" ]] || { c_y "❌ 需要一个 URL。"; return 2; }
+          [[ -f "$ADB_SOURCES" ]] && grep -qxF "$_url" "$ADB_SOURCES" \
+            || { c_y "❌ 这个源不在列表里, 未改动。"; return 1; }
+          _lock
+          local _t; _t="$(mktemp)" || return 1
+          grep -vxF "$_url" "$ADB_SOURCES" > "$_t"
+          install -m644 "$_t" "$ADB_SOURCES" || { rm -f "$_t"; c_y "❌ 写入失败, 未改动。"; return 1; }
+          rm -f "$_t"
+          c_g "  ✅ 已删除。"
+          ;;
+        reset)
+          need_root adblock
+          _lock
+          : > "$ADB_SOURCES" 2>/dev/null || { c_y "❌ 清空失败。"; return 1; }
+          c_g "  ✅ 已回到内置默认源。"
+          ;;
+        *)
+          echo "用法: pdg adblock source <list|add <URL>|del <URL>|reset>"; return 1;;
+      esac
+      ;;
     check)
       # **恰好一个参数。**多给一个多半是引号没打对(`check "a b"` 写成了 `check a b`),
       # 那时按第一个参数回答等于对着一个用户没打算问的东西给出确定结论。
@@ -6129,7 +6196,7 @@ try: d=json.loads(sys.argv[1] or "{}"); print("%s 条, 更新于 %s, 来源 %s" 
 except Exception: print("(读不到元数据)")' "$meta" 2>/dev/null)"
       echo "  使用 LKG  : $([[ -s "$ADB_STATE_DIR/list.lkg" ]] && echo 是 || echo 否)";;
     *)
-      echo "用法: pdg adblock <status|enable|disable|update|check <域名>>";;
+      echo "用法: pdg adblock <status|enable|disable|update|check <域名>|source <list|add|del|reset>|rule-add <域名>|rule-del <域名>>";;
   esac
 }
 

--- a/deploy/bot/pdgtx.py
+++ b/deploy/bot/pdgtx.py
@@ -112,6 +112,11 @@ _STATIC = {
     "mosdns_conf":    ("/etc/mosdns/config.yaml", 0o644, False, ("mosdns_probe",)),
     "rs_meta":        ("/opt/pdg-bot/rulesets.json", 0o644, False, ("json_any",)),
     "profile_env":    ("/etc/privdns-gateway/profile.env", 0o600, False, ("kv_env",)),
+    # 用户配置的去广告第三方源。**它决定 update 会往哪儿发请求**, 所以恢复时要逐行校验:
+    # 一份被换过的快照不该借着回滚把任意 URL 塞进来。校验器只判 URL 形态, 真正的门仍在
+    # adblock._safe_fetch(零重定向 / 非公网地址拒绝 / DNS 与连接地址绑定 / TLS 原始主机名)。
+    "adblock_sources": ("/etc/privdns-gateway/adblock-sources.txt", 0o644, False,
+                        ("adblock_sources",)),
     "nftables_conf":  ("/etc/nftables.conf", 0o644, False, ("nft_check",)),
     "mitm_json":      ("/etc/privdns-gateway/mitm.json", 0o600, False, ("json_any",)),
     # iOS 描述文件的身份与修订记录。它是**用户持久数据**: 丢了会在下次生成时造出第二个身份,
@@ -184,6 +189,9 @@ _TARGET_ACTIONS = {
     "nftables_conf": ("nft:apply",),
     "sysctl_tfo": ("sysctl:apply",),
     "rs_meta": (),
+    # 第三方源清单: 没有任何运行中的服务读它, 只有 `pdg adblock update` 被调用时读一次。
+    # 恢复它不该顺手重启 DNS。动作**显式写成空**而不是不写(见上面那段 fail-closed 的说明)。
+    "adblock_sources": (),
     "profile_env": (),
     "dot_marker": (),
     # 纯运行状态: 改它本身不牵动任何服务。真正要重启内核的是同一笔事务里的 model/mihomo_cfg,
@@ -637,6 +645,21 @@ def _nft_bin():
 _MOSDNS_LINE = re.compile(r"^(#.*|\s*|(domain|full|keyword|regexp):\S+|[A-Za-z0-9_.*-]+)$")
 
 
+# https://<host>[:443][/path] —— userinfo(`@`)、非 443 端口、非 https 一律匹配不上。
+# 下划线放行的理由与 adblock._DOMAIN_RE 一致。
+_ADBLOCK_SRC_RE = re.compile(
+    r"^https://([a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?"
+    r"(?:\.[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?)+)(?::443)?(?:/[^\s]*)?$", re.I)
+
+
+def _looks_like_ip(host):
+    try:
+        __import__("ipaddress").ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
 def _v_mosdns_lines(path, data, ctx):
     """domain/规则文件的严格行级格式校验。
 
@@ -649,6 +672,29 @@ def _v_mosdns_lines(path, data, ctx):
     for i, ln in enumerate(text.splitlines(), 1):
         if not _MOSDNS_LINE.match(ln.strip()):
             return False, "第 %d 行不是合法的 mosdns 域名条目: %r" % (i, ln[:60])
+    return True, ""
+
+
+def _v_adblock_sources(path, data, ctx):
+    """去广告第三方源清单的行级校验: 一行一个 https URL, 允许空行与 # 注释。
+
+    判据与 adblock.check_source_url 一致(https / 无 userinfo / 默认 443 / 主机名不是 IP
+    字面量)。这里**不 import adblock** —— pdgtx 是只依赖标准库的事务核心, 反向依赖它的
+    消费方会把层次拧反; 两边不漂移由 test-restore-actions.py 的共用语料对照守着。"""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False, "不是 UTF-8 文本"
+    for i, ln in enumerate(text.splitlines(), 1):
+        s_ = ln.strip()
+        if not s_ or s_.startswith("#"):
+            continue
+        m = _ADBLOCK_SRC_RE.match(s_)
+        if not m:
+            return False, "第 %d 行不是合法的 https 源 URL" % i
+        host = m.group(1)
+        if _looks_like_ip(host):
+            return False, "第 %d 行的主机名是 IP 字面量" % i
     return True, ""
 
 
@@ -888,9 +934,10 @@ VALIDATORS = {
     "ruleset_format": _v_ruleset_format, "kv_env": _v_kv_env, "hostname_line": _v_hostname_line,
     "pem_cert": _v_pem_cert, "pem_key": _v_pem_key, "systemd_unit": _v_systemd_unit,
     "mobileconfig": _v_mobileconfig,
+    "adblock_sources": _v_adblock_sources,
 }
 # 只做行级格式校验的目标: 报告里要标出来, 不能说成完整配置强校验
-LINE_LEVEL_ONLY = ("mosdns_lines", "kv_env", "hostname_line")
+LINE_LEVEL_ONLY = ("mosdns_lines", "kv_env", "hostname_line", "adblock_sources")
 
 
 # ── 全局锁(fail-closed)────────────────────────────────────────────────────────

--- a/tests/test-adblock-sources.sh
+++ b/tests/test-adblock-sources.sh
@@ -162,8 +162,36 @@ grep -qF "anti-ad.net" <<<"$out" \
 
 echo
 echo "══ ⑦ 用户源是用户数据, 必须进版本快照 ══"
-grep -q 'adblock-sources' "$ROOT/deploy/bot/cfgrestore.py" \
-  && ok "cfgrestore 的快照表里登记了 adblock-sources" || bad "源文件没进快照 —— 回滚会丢用户配置"
+# 这一格原来只是 `grep -q adblock-sources cfgrestore.py` —— **它放跑了一个 P0**: 映射加了、
+# pdgtx 没登记, grep 照样命中, CI 全绿, 而真恢复会整笔 fail-closed。grep 只能证明"有人写过
+# 这个词", 证明不了"这条链走得通"。改成真的走一遍链: 成员名 → target_for → pdgtx.resolve_target。
+_r7="$(python3 - "$ROOT" <<'PY7'
+import sys
+sys.path.insert(0, sys.argv[1] + "/deploy/bot")
+import cfgrestore, pdgtx
+m = "etc/privdns-gateway/adblock-sources.txt"
+t = cfgrestore.target_for(m)
+if not t:
+    print("NOTMAPPED"); raise SystemExit
+try:
+    path, mode, _s, _v = pdgtx.resolve_target(t)
+except Exception as e:
+    print("UNRESOLVED %s %s" % (t, type(e).__name__)); raise SystemExit
+try:
+    pdgtx.actions_for_targets([t])
+except Exception as e:
+    print("NOACTION %s %s" % (t, type(e).__name__)); raise SystemExit
+print("OK %s %s" % (t, path))
+PY7
+)"
+case "$_r7" in
+  "OK adblock_sources /etc/privdns-gateway/adblock-sources.txt")
+    ok "源文件走得通整条恢复链(成员 → target → pdgtx 白名单 → 服务动作)" ;;
+  NOTMAPPED*)   bad "源文件没进恢复映射 —— 回滚会丢用户配置" ;;
+  UNRESOLVED*)  bad "映射有了但 pdgtx 不认这个目标, 含它的快照会**整笔**恢复失败: $_r7" ;;
+  NOACTION*)    bad "pdgtx 推不出这个目标的服务动作, 恢复会被拒: $_r7" ;;
+  *)            bad "恢复链判定结果意外: $_r7" ;;
+esac
 
 echo
 echo "══ ⑧ 白名单跟着源走, 但只跟着**配置过的**源走 ══"

--- a/tests/test-adblock-sources.sh
+++ b/tests/test-adblock-sources.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 第三方源可配: `pdg adblock source list|add <URL>|del <URL>|reset`。
+#
+# 现状是 anti-AD 写死在 DEFAULT_SOURCES 里, 用户换不了 —— 那是一直开着的 P3
+# 「单一默认源, 无自动回退」的后半句。前半句其实早就有: update_lists 会按顺序遍历 sources
+# 并在失败时退到下一个, 只是没有任何接口能把用户的源传进去。
+#
+# 这一支钉接口契约与存储语义:
+#   · 源存在 /etc/privdns-gateway/adblock-sources.txt, 一行一个, 允许 # 注释;
+#   · 文件缺失或为空 → 沿用内置默认(向后兼容: 老机器升上来行为不变);
+#   · add 时就按下载器的规矩校验 URL(https / 443 / 非 IP 字面量), 当场拒, 不拖到 update;
+#   · add 幂等, del 精确匹配且删不存在的要报错, reset 回到默认;
+#   · 任何一步失败都不写文件;
+#   · 用户源是**用户数据**, 必须进版本快照。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; ROOT="$(cd "$HERE/.." && pwd)"
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+WORK="$(mktemp -d)" || exit 1
+trap 'rm -rf "$WORK"' EXIT
+
+extract(){
+  local fn="$1" ln
+  ln="$(grep -n "^${fn}()" "$ROOT/deploy/bot/pdg.sh" | head -1 | cut -d: -f1)"
+  [[ -n "$ln" ]] || { echo "抽不到 $fn" >&2; return 1; }
+  if sed -n "${ln}p" "$ROOT/deploy/bot/pdg.sh" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*\(\)\{.*\}[[:space:]]*$'; then
+    sed -n "${ln}p" "$ROOT/deploy/bot/pdg.sh"
+  else
+    sed -n "${ln},/^}/p" "$ROOT/deploy/bot/pdg.sh"
+  fi
+}
+CLOSURE="$WORK/closure.sh"; : > "$CLOSURE"
+for fn in c_g c_y _pdg_module _adblock_intent _adblock_ensure_files _adblock_status cmd_adblock; do
+  extract "$fn" >> "$CLOSURE" || { bad "抽不到 $fn"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+  echo >> "$CLOSURE"
+done
+cat >> "$CLOSURE" <<'STUB'
+need_root(){ :; }
+_lock(){ :; }
+PDG_LOCKED=""
+STUB
+
+new_box(){
+  local w="$WORK/$1"; mkdir -p "$w/etc/privdns-gateway" "$w/etc/mosdns/rules" "$w/var/adblock" "$w/repo/deploy" "$w/bin"
+  ln -sfn "$ROOT/deploy/bot" "$w/repo/deploy/bot"
+  : > "$w/etc/mosdns/rules/adblock_allow.txt"; : > "$w/etc/mosdns/rules/adblock_block.txt"
+  printf 'PDG_INTERNAL_CIDR=172.22.0.0/16\n' > "$w/etc/privdns-gateway/profile.env"
+  echo "$w"
+}
+run_box(){
+  local w="$1" body="$2"
+  ( set +e
+    PATH="$w/bin:$PATH"; export PATH
+    REPO_DIR="$w/repo"; PROFILE_ENV="$w/etc/privdns-gateway/profile.env"
+    ADB_STATE_DIR="$w/var/adblock"
+    ADB_USER_ALLOW="$w/etc/mosdns/rules/adblock_allow.txt"
+    ADB_USER_BLOCK="$w/etc/mosdns/rules/adblock_block.txt"
+    ADB_SOURCES="$w/etc/privdns-gateway/adblock-sources.txt"
+    LOCK="$w/pdg.lock"
+    export REPO_DIR PROFILE_ENV ADB_STATE_DIR ADB_USER_ALLOW ADB_USER_BLOCK ADB_SOURCES LOCK
+    # shellcheck source=/dev/null
+    source "$CLOSURE"
+    eval "$body"
+  ) > "$w/out.log" 2>&1
+  echo $?
+}
+srcfile(){ echo "$1/etc/privdns-gateway/adblock-sources.txt"; }
+U1="https://gcore.jsdelivr.net/gh/217heidai/adblockfilters@main/rules/adblockmosdns.txt"
+U2="https://example.invalid/list.txt"
+
+echo "══ ① 子命令存在 ══"
+W="$(new_box s1)"; run_box "$W" 'cmd_adblock source list' >/dev/null
+grep -q '用法: pdg adblock' "$W/out.log" && bad "source 落到了用法分支 —— 尚未实现" || ok "source 已被 cmd_adblock 识别"
+
+echo
+echo "══ ② 缺文件时沿用内置默认(向后兼容)══"
+W="$(new_box s2)"; run_box "$W" 'cmd_adblock source list' >/dev/null
+grep -qi 'anti-ad' "$W/out.log" && ok "list 在无用户源时列出内置默认" || bad "没列出内置默认: $(head -2 "$W/out.log"|tr '\n' ' ')"
+[[ ! -e "$(srcfile "$W")" ]] && ok "list 是只读的, 没有凭空建出源文件" || bad "list 建了文件"
+
+echo
+echo "══ ③ add: 落盘 + 幂等 ══"
+W="$(new_box s3)"
+rc="$(run_box "$W" "cmd_adblock source add '$U1'")"
+[[ "$rc" == 0 ]] && ok "add 合法 https URL 成功(rc=0)" || bad "rc=$rc: $(tail -2 "$W/out.log"|tr '\n' ' ')"
+grep -qxF "$U1" "$(srcfile "$W")" 2>/dev/null && ok "URL 逐字落盘" || bad "没落盘"
+before="$(sha256sum "$(srcfile "$W")" 2>/dev/null|cut -c1-16)"
+rc="$(run_box "$W" "cmd_adblock source add '$U1'")"
+[[ "$rc" == 0 ]] && ok "重复 add 幂等返回 0" || bad "重复 add rc=$rc"
+[[ "$(sha256sum "$(srcfile "$W")" 2>/dev/null|cut -c1-16)" == "$before" ]] && ok "重复 add 文件逐字节未变" || bad "重复 add 改了文件"
+
+echo
+echo "══ ④ add 的 URL 门(当场拒, 不拖到 update)══"
+W="$(new_box s4)"
+for u in 'http://plain.example.com/l.txt' 'https://example.com:8443/l.txt' 'https://192.0.2.1/l.txt' 'ftp://x.example.com/l.txt' 'not-a-url'; do
+  rc="$(run_box "$W" "cmd_adblock source add '$u'")"
+  [[ "$rc" != 0 ]] && ok "拒绝 $u (rc=$rc)" || bad "竟然接受了 $u"
+done
+[[ ! -s "$(srcfile "$W")" ]] && ok "全部被拒后源文件仍为空" || bad "被拒的 URL 却落盘了: $(cat "$(srcfile "$W")" 2>/dev/null|tr '\n' ' ')"
+
+echo
+echo "══ ⑤ del 精确匹配 / reset 回默认 ══"
+W="$(new_box s5)"
+run_box "$W" "cmd_adblock source add '$U1'" >/dev/null
+run_box "$W" "cmd_adblock source add '$U2'" >/dev/null
+[[ "$(grep -c . "$(srcfile "$W")" 2>/dev/null)" == 2 ]] && ok "两个源都在" || bad "源数 $(grep -c . "$(srcfile "$W")" 2>/dev/null)"
+rc="$(run_box "$W" "cmd_adblock source del '$U1'")"
+{ [[ "$rc" == 0 ]] && grep -qxF "$U2" "$(srcfile "$W")" && ! grep -qxF "$U1" "$(srcfile "$W")"; } \
+  && ok "del 只删掉指定的那一条" || bad "del 结果不对: $(cat "$(srcfile "$W")" 2>/dev/null|tr '\n' ' ')"
+rc="$(run_box "$W" "cmd_adblock source del 'https://never-added.example.com/x.txt'")"
+[[ "$rc" != 0 ]] && ok "del 不存在的源返回非零" || bad "del 不存在的源返回 0"
+rc="$(run_box "$W" 'cmd_adblock source reset')"
+[[ "$rc" == 0 ]] && ok "reset 返回 0" || bad "reset rc=$rc"
+[[ ! -s "$(srcfile "$W")" ]] && ok "reset 后源文件为空(回到内置默认)" || bad "reset 没清空"
+
+echo
+echo "══ ⑥ update 真的用用户源 ══"
+W="$(new_box s6)"
+run_box "$W" "cmd_adblock source add '$U1'" >/dev/null
+run_box "$W" 'cmd_adblock update' >/dev/null 2>&1
+out="$(cat "$W/out.log")"
+grep -qF "gcore.jsdelivr.net" <<<"$out" \
+  && ok "update 试的是用户配置的源" || bad "update 没有用上用户源: $(echo "$out"|tail -2|tr '\n' ' ')"
+grep -qF "anti-ad.net" <<<"$out" \
+  && bad "update 仍在试内置默认源(应当已被用户配置替换)" || ok "内置默认源没有被再试一遍"
+
+echo
+echo "══ ⑦ 用户源是用户数据, 必须进版本快照 ══"
+grep -q 'adblock-sources' "$ROOT/deploy/bot/cfgrestore.py" \
+  && ok "cfgrestore 的快照表里登记了 adblock-sources" || bad "源文件没进快照 —— 回滚会丢用户配置"
+
+echo
+echo "══ ⑧ 白名单跟着源走, 但只跟着**配置过的**源走 ══"
+# 选的是"白名单从 内置默认 + 用户配置 算出来"这条路。安全价值在后面几道(零重定向 /
+# 非公网拒绝 / DNS-连接绑定 / TLS 校验), 它们一条不松; 白名单在这里挡的是"URL 被改成
+# 任意主机"。用户显式 source add 本身就是授权 —— 但**没 add 过的主机必须照样连不上**,
+# 否则等于把这道门废了。
+W="$(new_box s8)"
+run_box "$W" "cmd_adblock source add '$U1'" >/dev/null
+python3 - "$ROOT" "$(srcfile "$W")" <<'PY'
+import sys, urllib.parse
+sys.path.insert(0, sys.argv[1] + "/deploy/bot")
+import adblock
+srcfile = sys.argv[2]
+try:
+    hosts = adblock.allowed_fetch_hosts(adblock.read_sources(srcfile))
+except AttributeError as e:
+    print("[FAIL] 白名单还不是按源算的(缺 %s)" % e); sys.exit(0)
+added = urllib.parse.urlsplit("https://gcore.jsdelivr.net/x").hostname
+print("[OK]   add 过的主机进了白名单" if added in hosts
+      else "[FAIL] add 过的主机不在白名单里")
+print("[OK]   白名单只含生效源的主机(用户配置 = 替换而非追加, 否则内置源永远删不掉)"
+      if "anti-ad.net" not in hosts else
+      "[FAIL] 未配置的内置主机仍在白名单里 —— 那等于连不该连的地方也放行")
+print("[OK]   没 add 过的主机仍被挡在外面" if "evil.example.com" not in hosts
+      else "[FAIL] 没 add 过的主机竟然也在白名单里")
+PY
+for _ in 1 2 3; do :; done
+# 上面 python 直接打印判据行, 这里把计数补上
+n_ok=$(python3 - "$ROOT" "$(srcfile "$W")" <<'PY'
+import sys, urllib.parse
+sys.path.insert(0, sys.argv[1] + "/deploy/bot")
+try:
+    import adblock
+    hosts = adblock.allowed_fetch_hosts(adblock.read_sources(sys.argv[2]))
+    c = sum([urllib.parse.urlsplit("https://gcore.jsdelivr.net/x").hostname in hosts,
+             "anti-ad.net" not in hosts, "evil.example.com" not in hosts])
+except Exception:
+    c = 0
+print(c)
+PY
+)
+pass=$((pass + n_ok)); nfail=$((nfail + 3 - n_ok))
+run_box "$W" 'cmd_adblock source reset' >/dev/null
+n2=$(python3 - "$ROOT" "$(srcfile "$W")" <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1] + "/deploy/bot")
+try:
+    import adblock
+    hosts = adblock.allowed_fetch_hosts(adblock.read_sources(sys.argv[2]))
+    print(1 if "anti-ad.net" in hosts else 0)
+except Exception:
+    print(0)
+PY
+)
+[[ "$n2" == 1 ]] && ok "reset 之后白名单回到内置默认" || bad "reset 之后白名单没回到内置默认"
+
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-adblock-sources.sh
+++ b/tests/test-adblock-sources.sh
@@ -50,6 +50,32 @@ _lock(){ :; }
 PDG_LOCKED=""
 STUB
 
+# §6 的接缝: 把这个 box 的 adblock.py 换成一层薄壳。`update` 只调**真模块**的 read_sources()
+# 把生效源打印出来, 不出网; 其余子命令 execv 原样转交真模块。
+#
+# 为什么必须这样: 原来那格直接断言 update 的真实输出里含用户源的主机名 —— 它**只在跑测试
+# 的机器能连外网时才绿**。我本地能连, 所以本地 25/0; CI 连不上, 抓到 0 条, 于是红。这既是
+# 假绿, 也违反"CI 不碰真实 anti-AD 网络"。壳挡掉的只有 socket 那一层: pdg.sh 是否把
+# $ADB_SOURCES 交下去、真模块是否据此解析出用户源而非内置默认, 两件事都仍在真代码里跑。
+shim_module(){
+  local w="$1" d f
+  d="$w/repo/deploy/bot"
+  rm -f "$d"; mkdir -p "$d"
+  for f in "$ROOT/deploy/bot"/*; do ln -sfn "$f" "$d/$(basename "$f")"; done
+  rm -f "$d/adblock.py"
+  cat > "$d/adblock.py" <<PYEOF
+import os, sys, importlib.util
+REAL = "$ROOT/deploy/bot/adblock.py"
+if len(sys.argv) > 1 and sys.argv[1] == "update":
+    spec = importlib.util.spec_from_file_location("adblock_real", REAL)
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+    for u in m.read_sources(sys.argv[3] if len(sys.argv) > 3 else None):
+        print("WOULD-FETCH " + u)
+    sys.exit(0)
+os.execv(sys.executable, [sys.executable, REAL] + sys.argv[1:])
+PYEOF
+}
+
 new_box(){
   local w="$WORK/$1"; mkdir -p "$w/etc/privdns-gateway" "$w/etc/mosdns/rules" "$w/var/adblock" "$w/repo/deploy" "$w/bin"
   ln -sfn "$ROOT/deploy/bot" "$w/repo/deploy/bot"
@@ -125,7 +151,7 @@ rc="$(run_box "$W" 'cmd_adblock source reset')"
 
 echo
 echo "══ ⑥ update 真的用用户源 ══"
-W="$(new_box s6)"
+W="$(new_box s6)"; shim_module "$W"
 run_box "$W" "cmd_adblock source add '$U1'" >/dev/null
 run_box "$W" 'cmd_adblock update' >/dev/null 2>&1
 out="$(cat "$W/out.log")"

--- a/tests/test-adblock-sources.sh
+++ b/tests/test-adblock-sources.sh
@@ -37,6 +37,13 @@ for fn in c_g c_y _pdg_module _adblock_intent _adblock_ensure_files _adblock_sta
   extract "$fn" >> "$CLOSURE" || { bad "抽不到 $fn"; echo "通过 $pass, 失败 $nfail"; exit 1; }
   echo >> "$CLOSURE"
 done
+# pdg.sh 的**顶层常量**整体注入。只抽函数会漏掉它们, 而 pdg.sh 跑在 `set -u` 下 ——
+# 漏一个就是 unbound variable, 而且往往只在某条分支上炸(本地与 CI 失败点不同, 就成了假绿)。
+# 这一类缺口已经栽过三次: PDG_LOCKED、LOCK、ACME_HOME。不再一个个补, 整体注入了事。
+# 安全性: 这 34 条里**零条含命令替换**(`grep -cE '^[A-Z][A-Z0-9_]*=.*\$\(' = 0`), 纯字面量
+# 与变量引用, 注入不会执行任何东西。沙箱随后 export 的同名变量会覆盖它们。
+grep -E '^[A-Z][A-Z0-9_]*=' "$ROOT/deploy/bot/pdg.sh" \
+  | sed -E 's/^([A-Z][A-Z0-9_]*)=(.*)$/\1="${\1:-}"; [[ -z "${\1}" ]] \&\& \1=\2/' >> "$CLOSURE"
 cat >> "$CLOSURE" <<'STUB'
 need_root(){ :; }
 _lock(){ :; }

--- a/tests/test-adblock-upstream-tolerance.py
+++ b/tests/test-adblock-upstream-tolerance.py
@@ -103,7 +103,11 @@ n_bad = int(n_good * ((adblock.LIMITS["max_skip_ratio"] or 0.01) * 4)) + 50
 heavy = body(n_good, ["bad..%d" % i for i in range(n_bad)])
 names, skipped, why = adblock.parse_source_ex(heavy)
 (ok if not names else bad)("坏行过多时整份拒(实得 %d 条)" % len(names))
-(ok if skipped >= 0 else bad)("skipped 是真实计数, 不是兜底(实得 %r)" % skipped)
+# 整份拒时 skipped 必须仍是**真实计数**, 不能因为要返回空表就顺手回 0 ——
+# 这个数字是运维判断"上游是不是换格式了"的唯一依据。
+# (原来这里写的是 `skipped >= 0`: 对任何计数都恒真, 兜底的 0 照样过, 等于没测。)
+(ok if skipped == n_bad else bad)(
+    "整份拒时 skipped 仍是真实计数(实得 %r, 应 %d)" % (skipped, n_bad))
 (ok if why and "尚不存在" not in why else bad)("给出了整份拒的理由(实得 %r)" % why)
 (ok if not adblock.parse_source(heavy) else bad)("parse_source 薄封装同样返回空")
 

--- a/tests/test-adblock-upstream-tolerance.py
+++ b/tests/test-adblock-upstream-tolerance.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""第三方表的容错边界: 下划线主机名, 与"一行坏不该废掉整张表"。
+
+线上实测(从 jp 取真实的 adblockfilters mosdns 表, 215320 行)——
+
+    _REJECT_HINTS 命中: 无
+    含语法字符的行: 0
+    形态认不出的行: 0
+    不匹配 _DOMAIN_RE 的行: 1
+       L68711: 'fb_servpub-a.akamaihd.net'
+
+**21.5 万条因为一个下划线全废。** 两个原因叠在一起:
+
+  ① `_DOMAIN_RE` 按 RFC 1123 的 hostname 规矩不放行下划线。但 DNS 协议本身是允许的
+     (`_dmarc` / `_acme-challenge` 就是), 而作为**阻断规则的模式串**, 下划线不造成任何
+     歧义或注入 —— 拒掉它等于对一类真实存在、也确实该拦的名字视而不见。
+  ② parse_source 是"一行坏、整份废"。那条规矩的核心担忧是对的(注释里写着: 部分解析出来的
+     表少了多少条没人知道), 但对**第三方表**有个副作用: 用户对上游没有控制权, 上游一行手滑
+     就整张表用不了, 代价不成比例。
+
+修法要同时保住两边:
+  · 下划线放行, **且只放行下划线** —— 通配符 / 路径 / ABP / 正则 / IP 字面量一条不松;
+  · 逐行域名校验失败改成**跳过并计数**, 但跳过比例超阈值仍然整份拒(fail-closed);
+  · **结构性**不对(HTML 错页 / ABP 语法 / 认不出的形态)仍然整份拒 —— 那不是"有几行坏",
+    是"这压根不是我们要的文件"。
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "deploy/bot"))
+import adblock          # noqa: E402
+
+# 红灯阶段这些还不存在。缺了就让对应判据红, 而不是让整支测试崩在 AttributeError 上 ——
+# 崩掉的话后面每一格都跑不到, 红灯就看不出覆盖面。
+if not hasattr(adblock, "parse_source_ex"):
+    adblock.parse_source_ex = lambda t: (adblock.parse_source(t), -1, "<parse_source_ex 尚不存在>")
+adblock.LIMITS.setdefault("max_skip_ratio", None)
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def body(n, extra=()):
+    """造一份 n 条合法域名 + extra 若干行的表。"""
+    lines = ["# header"] + ["a%d.invalid" % i for i in range(n)] + list(extra)
+    return "\n".join(lines) + "\n"
+
+
+print("══ 1. 下划线主机名必须被接受 ══")
+for name in ("fb_servpub-a.akamaihd.net", "_dmarc.example.com", "a_b.example.com"):
+    got = adblock.parse_source(body(1200, [name]))
+    (ok if name in got else bad)("接受 %s(实得 %d 条)" % (name, len(got)))
+
+print()
+print("══ 2. 只放行下划线, 其余照拒(整份)══")
+for label, line in (("通配符", "*.evil.invalid"), ("路径", "evil.invalid/ads"),
+                    ("ABP", "||evil.invalid^"), ("正则", "/ads?/"),
+                    ("IP 字面量", "1.2.3.4"), ("localhost", "localhost"),
+                    ("空格分三段", "a b c")):
+    got = adblock.parse_source(body(1200, [line]))
+    (ok if not got else bad)("%s(%s)仍然整份拒(实得 %d 条)" % (label, line, len(got)))
+
+print()
+print("══ 3. 少量坏行: 跳过并计数, 不废掉整张表 ══")
+mixed = body(2000, ["bad..double.dot", "-leading-hyphen.invalid", "trailing-.invalid"])
+names, skipped, why = adblock.parse_source_ex(mixed)
+(ok if len(names) == 2000 else bad)("合法行全部保留(实得 %d, 应 2000)" % len(names))
+(ok if skipped == 3 else bad)("坏行被跳过且计数正确(实得 %d, 应 3)" % skipped)
+(ok if not why else bad)("没有整份拒的理由(实得 %r)" % why)
+(ok if len(adblock.parse_source(mixed)) == 2000 else bad)("parse_source 薄封装仍返回合法行")
+
+print()
+print("══ 4. 坏行比例超阈值 → 整份拒(fail-closed)══")
+n_good = 1000
+n_bad = int(n_good * ((adblock.LIMITS["max_skip_ratio"] or 0.01) * 4)) + 50
+heavy = body(n_good, ["bad..%d" % i for i in range(n_bad)])
+names, skipped, why = adblock.parse_source_ex(heavy)
+(ok if not names else bad)("坏行过多时整份拒(实得 %d 条)" % len(names))
+(ok if skipped >= 0 else bad)("skipped 是真实计数, 不是兜底(实得 %r)" % skipped)
+(ok if why and "尚不存在" not in why else bad)("给出了整份拒的理由(实得 %r)" % why)
+(ok if not adblock.parse_source(heavy) else bad)("parse_source 薄封装同样返回空")
+
+print()
+print("══ 5. 阈值本身要在 LIMITS 里具名 ══")
+r = adblock.LIMITS.get("max_skip_ratio")
+(ok if r is not None else bad)("LIMITS 里有 max_skip_ratio(实得 %r)" % r)
+(ok if isinstance(r, float) and 0 < r <= 0.05 else bad)(
+    "阈值取值在合理区间(实得 %r)" % r)
+
+print()
+print("══ 6. 条数上限按 512M 实测重定为 500000 ══")
+(ok if adblock.LIMITS["max_entries"] == 500000 else bad)(
+    "max_entries = 500000(实得 %s)" % adblock.LIMITS["max_entries"])
+src = (ROOT / "deploy/bot/adblock.py").read_text(encoding="utf-8")
+seg = src.split('"max_entries"')[0][-1200:]
+(ok if "512M" in seg else bad)("注释引用了 512M 整机实测")
+(ok if "108.6" in seg or "166.7" in seg else bad)("注释里有这次实测的具体 RSS 数字, 不是空口")
+(ok if '"max_entries": 150000' not in src else bad)("旧值 150000 已不再是上限")
+
+print()
+print("══ 7. 真实上游那一行(线上实测到的那个)必须能过 ══")
+real = body(1200, ["fb_servpub-a.akamaihd.net"])
+got = adblock.parse_source(real)
+(ok if len(got) == 1201 else bad)("21.5 万条那张表不再因一行下划线全废(实得 %d)" % len(got))
+
+print("-" * 62)
+print("test-adblock-upstream-tolerance.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-adblock-upstream-tolerance.py
+++ b/tests/test-adblock-upstream-tolerance.py
@@ -65,10 +65,27 @@ print()
 print("══ 2. 只放行下划线, 其余照拒(整份)══")
 for label, line in (("通配符", "*.evil.invalid"), ("路径", "evil.invalid/ads"),
                     ("ABP", "||evil.invalid^"), ("正则", "/ads?/"),
-                    ("IP 字面量", "1.2.3.4"), ("localhost", "localhost"),
                     ("空格分三段", "a b c")):
     got = adblock.parse_source(body(1200, [line]))
     (ok if not got else bad)("%s(%s)仍然整份拒(实得 %d 条)" % (label, line, len(got)))
+
+print()
+print("══ 2b. 少量 IP / localhost 条目: 跳过计数, 不废掉整张表 ══")
+# 线上实测: adblockfilters 那张 215320 行的表里混着 **57 条纯 IPv4**(103.179.189.35 之类)。
+# 合并型广告表从多个上游拼起来, 掺进几条 IP 是常态。而 domain_set 里放一个 IPv4 字面量,
+# mosdns 会把它当域名匹配 —— 永远匹配不到真实查询, **无害也无用**。
+# 为这 0.026% 废掉 21.5 万条不成比例, 所以它们和"域名不合格"归一类: 跳过并计数。
+mixed_ip = body(2000, ["1.2.3.4", "203.0.113.9", "localhost", "localhost.localdomain"])
+names, skipped, why = adblock.parse_source_ex(mixed_ip)
+(ok if len(names) == 2000 else bad)("合法域名全部保留(实得 %d, 应 2000)" % len(names))
+(ok if skipped == 4 else bad)("IP/localhost 被跳过且计数正确(实得 %d, 应 4)" % skipped)
+(ok if not why else bad)("没有整份拒(实得 %r)" % why)
+
+# 但"整张表都是 IP"必须照样整份拒 —— 那是真拿错了文件(比如拿到一份 IP 黑名单)。
+allip = "\n".join("10.0.%d.%d" % (i // 256, i % 256) for i in range(1500)) + "\n"
+names, skipped, why = adblock.parse_source_ex(allip)
+(ok if not names else bad)("整表都是 IP 时仍整份拒(实得 %d 条)" % len(names))
+(ok if why else bad)("给出了整份拒的理由(实得 %r)" % why)
 
 print()
 print("══ 3. 少量坏行: 跳过并计数, 不废掉整张表 ══")

--- a/tests/test-restore-actions.py
+++ b/tests/test-restore-actions.py
@@ -489,6 +489,42 @@ finally:
     _cr_real.MEMBER_TARGET.update(_orig)
 (ok if _caught else bad)("负控: 没登记的目标确实解析不了(这一格不是空话)")
 
+# ── 14. 真走一遍: 含第三方源清单的快照必须能恢复 ─────────────────────────
+# 前面几格证明的是"resolve_target 返回了一个元组"。这一格证明的是用户真正会遇到的那件事:
+# 一台配过第三方源的机器, 回滚回得去。原缺陷下这里会拿到
+# "目标 adblock_sources 不在事务白名单里 …… 拒绝执行", 而且是**整笔**被拒。
+_SRC_OLD = "https://old.example.com/list.txt\n"
+_SRC_NEW = "# \u6ce8\u91ca\nhttps://new.example.com/list.txt\nhttps://two.example.com/l.txt\n"
+box = Box()
+base = seed(box, [("etc/privdns-gateway/adblock-sources.txt", _SRC_OLD)])
+sid = snap(box, [("etc/privdns-gateway/adblock-sources.txt", _SRC_NEW)])
+cr = load_cr(box)
+open(box.calls, "w").close()
+res = cr.restore_managed(sid, expect_digest=cr.snapshot_digest(sid), trigger_source="rescue")
+_p = os.path.join(box.root, "etc/privdns-gateway/adblock-sources.txt")
+(ok if res.get("ok") else bad)("含第三方源清单的快照恢复成功(实得 error=%r)" % res.get("error"))
+(ok if open(_p, encoding="utf-8").read() == _SRC_NEW else
+ bad)("源清单逐字节恢复成快照里的那份")
+_c = calls(box)
+(ok if _c.get("mutating") == 0 else
+ bad)("只换源清单不重启任何服务(实得 mutating=%r)" % _c.get("mutating"))
+(ok if oct(os.stat(_p).st_mode & 0o777) == "0o644" else
+ bad)("恢复出来的权限是 0644(实得 %s)" % oct(os.stat(_p).st_mode & 0o777))
+
+# 反面: 快照里那份被换成非法 URL, 必须整笔拒且现网不动
+box.clean()
+box = Box()
+base = seed(box, [("etc/privdns-gateway/adblock-sources.txt", _SRC_OLD)])
+sid = snap(box, [("etc/privdns-gateway/adblock-sources.txt",
+                  "https://ok.example.com/l.txt\nhttp://evil.example.com/x\n")])
+cr = load_cr(box)
+res = cr.restore_managed(sid, expect_digest=cr.snapshot_digest(sid), trigger_source="rescue")
+_p = os.path.join(box.root, "etc/privdns-gateway/adblock-sources.txt")
+(ok if not res.get("ok") else bad)("快照里带非法源 URL: 恢复被拒(实得 ok=%r)" % res.get("ok"))
+(ok if open(_p, encoding="utf-8").read() == _SRC_OLD else
+ bad)("被拒之后现网的源清单逐字节不变")
+box.clean()
+
 # ── 13. 源清单校验器不许与 adblock.check_source_url 漂移 ─────────────────
 # pdgtx 是只依赖标准库的事务核心, 不 import adblock —— 代价是同一条判据有两份实现。
 # 两份实现就会漂移, 所以用同一份语料逐条对照: 一边说行、另一边说不行, 这一格就红。

--- a/tests/test-restore-actions.py
+++ b/tests/test-restore-actions.py
@@ -444,6 +444,89 @@ else:
     bad("bot.env 被改了")
 box.clean()
 
+# ── 12. MEMBER_TARGET 整张表必须与 pdgtx 白名单对得上 ────────────────────
+# 第 10 格测的是"塞一个未知目标会 fail-closed"—— 行为对了, 但**没人验过真表本身**。
+# 于是往 MEMBER_TARGET 里加一行、忘了在 pdgtx 登记, CI 全绿, 到回滚那一刻才炸: 而且按
+# cfgrestore.py:496-502 的设计, 那是**整笔恢复被拒**, 不是跳过一个成员 —— 一台换过第三方
+# 源的机器, 快照从此恢复不了, 且只在最需要回滚的时候才发现。
+# 这一格遍历真表, 让"加映射忘登记"在 CI 就红。
+import cfgrestore as _cr_real                                   # noqa: E402
+import pdgtx as _tx_real                                        # noqa: E402
+
+_bad_resolve, _bad_actions = [], []
+for _member, _target in sorted(_cr_real.MEMBER_TARGET.items()):
+    try:
+        _tx_real.resolve_target(_target)
+    except Exception as _e:                                     # noqa: BLE001
+        _bad_resolve.append("%s→%s(%s)" % (_member, _target, type(_e).__name__))
+        continue
+    if _target in _tx_real.EXPLICIT_ONLY:
+        continue                    # 动作必须由调用方显式声明, 不该能自动推导
+    try:
+        _tx_real.actions_for_targets([_target])
+    except Exception as _e:                                     # noqa: BLE001
+        _bad_actions.append("%s→%s(%s)" % (_member, _target, type(_e).__name__))
+
+if not _bad_resolve:
+    ok("MEMBER_TARGET 里每个目标都在 pdgtx 白名单里(%d 个)" % len(_cr_real.MEMBER_TARGET))
+else:
+    bad("这些目标 pdgtx 不认识, 含它们的快照会**整笔**恢复失败: %s" % ", ".join(_bad_resolve))
+if not _bad_actions:
+    ok("MEMBER_TARGET 里每个目标都推得出服务动作")
+else:
+    bad("这些目标推不出服务动作, 恢复会被拒: %s" % ", ".join(_bad_actions))
+
+# 反面: 真塞一个没登记的进去, 这一格必须变红 —— 否则它只是句空话。
+_orig = _cr_real.MEMBER_TARGET.copy()
+_cr_real.MEMBER_TARGET["etc/privdns-gateway/never-registered.txt"] = "never_registered"
+try:
+    _tx_real.resolve_target("never_registered")
+    _caught = False
+except Exception:                                               # noqa: BLE001
+    _caught = True
+finally:
+    _cr_real.MEMBER_TARGET.clear()
+    _cr_real.MEMBER_TARGET.update(_orig)
+(ok if _caught else bad)("负控: 没登记的目标确实解析不了(这一格不是空话)")
+
+# ── 13. 源清单校验器不许与 adblock.check_source_url 漂移 ─────────────────
+# pdgtx 是只依赖标准库的事务核心, 不 import adblock —— 代价是同一条判据有两份实现。
+# 两份实现就会漂移, 所以用同一份语料逐条对照: 一边说行、另一边说不行, 这一格就红。
+import adblock as _adb                                          # noqa: E402
+
+_CORPUS = [
+    "https://gcore.jsdelivr.net/gh/x/y@main/rules/a.txt",       # 正常
+    "https://anti-ad.net/domains.txt",
+    "https://a.example.com:443/l.txt",                          # 显式默认端口
+    "https://fb_servpub-a.example.com/l.txt",                   # 下划线主机
+    "http://plain.example.com/l.txt",                           # 非 https
+    "https://example.com:8443/l.txt",                           # 非 443
+    "https://192.0.2.1/l.txt",                                  # IP 字面量
+    "https://[2001:db8::1]/l.txt",                              # IPv6 字面量
+    "https://u:p@example.com/l.txt",                            # userinfo
+    "ftp://x.example.com/l.txt",                                # 非 http(s)
+    "not-a-url",
+    "https:///l.txt",                                           # 无主机名
+    "https://example.com/l.txt?a=1#f",                          # 带 query/fragment
+]
+_drift = []
+for _u in _CORPUS:
+    _a = _adb.check_source_url(_u)[0]
+    _t = _tx_real.VALIDATORS["adblock_sources"]("/x", (_u + "\n").encode(), None)[0]
+    if _a != _t:
+        _drift.append("%s: adblock=%s pdgtx=%s" % (_u, _a, _t))
+(ok if not _drift else bad)("两份 URL 判据同判(%d 条语料)%s"
+                            % (len(_CORPUS), "" if not _drift else ": " + "; ".join(_drift)))
+
+# 校验器本身也得能吃真实文件形态: 空行 + 注释 + 多行
+_real_file = b"# \xe6\xb3\xa8\xe9\x87\x8a\n\nhttps://a.example.com/l.txt\nhttps://b.example.com/l.txt\n"
+(ok if _tx_real.VALIDATORS["adblock_sources"]("/x", _real_file, None)[0] else
+ bad)("源清单校验器接受 空行 + 注释 + 多行 的真实形态")
+_poison = b"https://a.example.com/l.txt\nhttps://evil.example.com:9999/x\n"
+_r = _tx_real.VALIDATORS["adblock_sources"]("/x", _poison, None)
+(ok if not _r[0] and "第 2 行" in _r[1] else
+ bad)("被投毒的快照逐行拒并指出行号(实得 %r)" % (_r,))
+
 shutil.rmtree(work, ignore_errors=True)
 print("─" * 40)
 print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))


### PR DESCRIPTION
## 起因

用户想加 `adblockmosdns.txt` 这类第三方表,但源是写死的;真去加又发现两个硬边界挡着。这一支解决三件事,外加自审时发现的一个 P0。

## ① 第三方源可配

新增 `pdg adblock source <list|add <URL>|del <URL>|reset>`。

- 配置落在 `/etc/privdns-gateway/adblock-sources.txt`,一行一个,允许 `#` 注释
- **文件缺失或为空就沿用内置默认** —— 老机器升上来行为一个字节不变
- `add` **当场校验**(https / 无 userinfo / 默认 443 / 主机名是合法域名且不是 IP 字面量),不拖到 `update` 才报:那时用户已经把它记进配置里了
- `add` 幂等;`del` 精确匹配;`list` 只读、不要 root、不会凭空建出源文件

### 安全边界

白名单跟着**配置过的源**走(`allowed_fetch_hosts`):用户 `add` 过的主机才进集合,那一步本身就是显式授权。**没被配置过的主机照样连不上。**

`_safe_fetch` 后面几道一条都没松:零重定向(仅 200)/ 非公网地址拒绝 / DNS 解析结果与实际连接地址绑定 / TLS 用原始主机名校验 / 不吃环境代理。

## ② 上游容错

线上实测:21.5 万条的表里**一行下划线就全废**。

- **放行下划线**:DNS 协议本身允许(`_dmarc` / `_acme-challenge` 就是),只是 RFC 1123 的 *hostname* 规范不允许。放宽的只有下划线,连字符不许出现在标签首尾这条没动
- **纯 IP / localhost 改为跳过计数**,不整份拒 —— 合并型广告表掺进几条 IP 是常态(实测 215320 行里 57 条,占 0.026%),而 `domain_set` 里放一个 IPv4 字面量,mosdns 拿它当域名匹配,永远匹配不到真实查询,无害也无用
- 新增 `max_skip_ratio = 1%`:跳过要**计数并上报**,超比例仍整份拒。真拿错成一份 IP 黑名单时比例接近 100%,照样被挡

结构性不对的(HTML 错页 / ABP / 正则 / URL / 通配 / 认不出的行形态)仍然**整份拒**,一条没放松。

## ③ 条数上限 150000 → 500000

旧值出自更早的 Phase 0,那次的约束是 `MemoryMax=96M` —— 一个测试时人为加的上限,产品并不设它。按"整机 512M 可用"重测:

真跑 mosdns v5.3.4 + 生产模板 + 145591 条 geosite,逐档量 RSS:

| 条数 | 15万 | 30万 | 50万 | 60万 | 80万 | 100万 |
|---|---|---|---|---|---|---|
| RSS (MiB) | 61.6 | 77.8 | **108.6** | 109.5 | 123.0 | 166.7 |

选 50 万是因为它正好**在一个台阶顶上**(50 万与 60 万的 RSS 几乎一样),再多一点不会突然多吃内存。512M 机器上非 mosdns 部分实测约 217 MiB,50 万条时整机约 326 MiB,**余量 186 MiB 且不依赖 swap**。

延迟与条数无关:150 qps 定速下 p50 稳在 0.11 ms、p95 0.18 ms,从 15 万到 100 万看不出趋势 —— `domain_set` 的查询是 O(域名长度) 而不是 O(表大小)。**约束只在内存。**

## ④ 自审发现的 P0:恢复链断了

把源清单加进了 `cfgrestore.MEMBER_TARGET`,却没在 `pdgtx` 里登记 `adblock_sources`。

后果不是"跳过一个文件" —— `cfgrestore.py:496` 写明:成员映射与事务白名单对不上 = 两份定义漂移,**整笔受管恢复 fail-closed**:

```
目标 adblock_sources 不在事务白名单里(TxError) —— 恢复映射与事务核心不一致, 拒绝执行
```

触发面 = 跑过 `source add|del|reset` 的机器,也就是正好用了新功能的那批人;而且**只在回滚那一刻才发现** —— 安全网在最需要时才发现是破的,比没有更糟。

修法:pdgtx 登记目标;服务动作**显式写成空**(没有任何运行中的服务读它,只有 `update` 被调用时读一次,恢复它不该顺手重启 DNS);新增行级校验器 —— 这文件决定 update 往哪儿发请求,一份被换过的快照不该借着回滚把任意 URL 塞进来。校验器**不 import adblock**(pdgtx 是只依赖标准库的事务核心,反向依赖消费方会把层次拧反),两边不漂移由共用语料对照守着。

## 验证

新增/加强 4 个测试文件,合计 96 格。每条修复都配了变异负控,逐一确认断言真会翻:

| 变异 | 结果 |
|---|---|
| 从 `_STATIC` 摘掉登记 | resolve 那条红,真实错误文案一字不差出现 |
| 从 `_TARGET_ACTIONS` 摘掉动作 | 动作那条红 |
| 校验器放行 `http` | 漂移那条红(adblock=False pdgtx=True) |
| `update` 不传 `$ADB_SOURCES` | §6 两条红,输出里冒出内置默认的 anti-ad.net |
| 整份拒时把 skipped 抹成 0 | 计数那条红(实得 0, 应 90) |
| 摘掉 cfgrestore 映射 | §7 报"回滚会丢用户配置" |

### 一并修掉的两处假绿

- **`grep -q 'adblock-sources' cfgrestore.py`** —— 就是它放跑了上面那个 P0:映射加了、pdgtx 没登记,grep 照样命中。改成真走一遍链,并按断在哪一环报不同的话
- **`skipped >= 0`** —— 对任何计数恒真,自称在验的那件事一次都没验过。改成 `skipped == n_bad`

### 另外两件

- **`update` 那格本来依赖外网**:断言真实输出里含用户源主机名,只在跑测试的机器能连外网时才绿。改成薄壳接缝,`--network none` 下 25/0
- **顶层常量整体注入**:`ACME_HOME` 是本类第三次(前两次 `PDG_LOCKED`、`LOCK`)。pdg.sh 跑在 `set -u` 下,漏一个就在某条分支上炸,本地与 CI 失败点不同就成了假绿。不再一个个补

全量回归(容器内 195 个测试 vs `origin/main` 同载具基线):**失败集完全一致,零新增红灯**。

exact-head CI(workflow_dispatch @ `28a5ab20`):**29/29 全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)