### PR TITLE
chore(cli): 顶层用法串补上 lan 与 adblock

### DIFF
--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -6635,5 +6635,5 @@ case "${1:-menu}" in
   link)          shift || true; cmd_link "$@";;
   uninstall|rm)  shift || true; cmd_uninstall "$@";;
   rescue)        shift || true; cmd_rescue "$@";;
-  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
+  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|lan <status|list|check|routes|add|rm>|adblock <status|enable|disable|update|check <域名>|rule-add <域名>|rule-del <域名>|source <list|add <URL>|del <URL>|reset>>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
 esac

--- a/tests/test-cli-dispatch.py
+++ b/tests/test-cli-dispatch.py
@@ -306,6 +306,32 @@ for argv, want_n, label in (([], "40", "pdg log 默认 40 行"),
     else:
         bad("%s 不对: %r" % (label, out))
 
+# ── 用法串必须覆盖 dispatcher 的每一条分支 ────────────────────────────────
+# `pdg` 打错子命令时唯一的自助线索就是这一行用法串。它是**手写**的, 而 dispatcher 是另一处
+# 手写的 —— 两处手写就会漂移: 加了子命令、忘了改用法, 于是那条命令**存在但没人知道**。
+# 实测漂了两条(lan 在 v1.9 加的、adblock 在 v1.11 加的), 一直没人发现, 因为没有一格在看。
+import re as _re                                                # noqa: E402
+
+_src = open(PDG, encoding="utf-8").read().splitlines()
+_ui = [i for i, l in enumerate(_src) if "用法: pdg [" in l]
+(ok if len(_ui) == 1 else bad)("顶层用法串恰好一处(实得 %d)" % len(_ui))
+if len(_ui) == 1:
+    _u = _ui[0]
+    _arms = []
+    for _l in _src[max(0, _u - 70):_u]:
+        _m = _re.match(r"^  ([a-z][a-z0-9|_-]*)\)", _l)
+        if _m:
+            _arms.append(_m.group(1))
+    (ok if len(_arms) >= 20 else bad)("抽到了 dispatcher 的分支(实得 %d, 少于 20 说明抽法坏了)" % len(_arms))
+    _inside = _re.search(r"用法: pdg \[(.*)\]", _src[_u])
+    _listed = _inside.group(1) if _inside else ""
+    (ok if _listed else bad)("用法串里抽得出方括号内容")
+    _missing = [a for a in _arms
+                if not any(_re.search(r"(?<![a-z-])%s(?![a-z-])" % _re.escape(n), _listed)
+                           for n in a.split("|"))]
+    (ok if not _missing else
+     bad)("这些子命令**存在但用法串没列**, 用户无从知道: %s" % ", ".join(_missing))
+
 print("─" * 40)
 print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
 for d in TMPS:


### PR DESCRIPTION
`pdg` 打错子命令时唯一的自助线索就是那一行用法串。它是**手写**的,dispatcher 是另一处手写的 —— 两处手写必然漂移:加了子命令、忘了改用法,那条命令就**存在但没人知道**。

## 抓到两条

```
[FAIL] 这些子命令**存在但用法串没列**, 用户无从知道: lan, adblock
```

`lan` 是 v1.9 加的、`adblock` 是 v1.11 加的,一直没人发现 —— 因为一格都没有在看。

## 守卫先行

新增的那一格遍历 dispatcher 的分支,逐个在用法串里找。抽法本身也钉住了(分支数少于 20 就判红),免得哪天正则失配、这一格静默通过。

## 补的内容不是我编的

照各自 `cmd_lan` / `cmd_adblock` 里自报的用法串抄的 —— 第一版我把 `lan` 写成了 `<status|panel|route>`,那是凭印象写的。**帮助里写假信息比不写更坏**,订正成了它自报的 `<status|list|check|routes|add|rm>`。

## 验证

- shellcheck 干净,`bash -n` 过
- 负控(从用法串摘掉 adblock)→ 27/1 点名 adblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)