### PR TITLE
fix(ssh-source): tailnet 直连端口跟随 tailscaled 的实际配置

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: "SSH 来源限制必须活过模板重建 (收紧过的 22 端口不能被更新悄悄开回全网)"
         run: bash tests/test-ssh-source-persist.sh
 
+      - name: "Tailscale 直连端口跟随 tailscaled 的 PORT= (切回 any 时按 comment 清除)"
+        run: bash tests/test-tailnet-custom-port.sh
+
       - name: "E2E 探针生命周期回归(重复启动/退出/信号/并发/临时目录清理)"
         run: bash tests/test-e2e-probe-lifecycle.sh
 

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -394,9 +394,64 @@ migrate_botenv(){
 # 刻意**不做成独立开关**: 放行这个端口的唯一理由就是"SSH 只能从 tailnet 进来, 所以那条路
 # 必须随时可用"。拆成两个开关, 迟早出现"收紧了但没放行"的组合 —— 那正是冷启动连不上的形态,
 # 而且从配置上完全看不出两者有关系。
+# Tailscale 直连端口。41641 是官方默认值, 但**它是可配的** —— Debian 12 上来自
+# /etc/default/tailscaled 的 `PORT=`, unit 经 EnvironmentFile 传给 `tailscaled --port=${PORT}`。
+#
+# 解析**不在这里做**: EnvironmentFile 的覆盖语义(后面的赋值盖前面的)、引号剥离、端口范围
+# 校验, checks.py 的 `_tailscaled_port` 已经全写好了, 而且 doctor 的对账判据用的就是它。
+# shell 里再写一遍正则, 两份迟早对不上 —— 对不上的表现是防火墙放行了一个没人监听的端口,
+# 不会有任何报错, 只会在某次真出事、想连进去的时候发现连不上。
+#
+# 取不到就退回 41641: 没装 Tailscale、不是 deb 装的、文件里没有合法 PORT=, 都属于正常情形,
+# 而 41641 是这些情形下唯一有依据的猜测。**不静默** —— 调用方用 _ssh_ts_why 把原因说出来。
+# 探一次: 输出 `端口<TAB>原因`。原因非空 = 用了回退默认值。
+#
+# 为什么是"输出"而不是"设全局变量": `$(_ssh_ts_port)` 是**子 shell**, 函数里给全局变量赋的
+# 值回不到父进程。第一版就是那么写的 —— 提示语句在, 条件永远为假, 端口取不到时用户什么也
+# 看不到, 而防火墙已经按 41641 放行了。死代码比没有代码更坏: 读的人以为这件事被覆盖了。
+_ssh_ts_probe(){
+  local f="${TAILSCALED_DEFAULTS:-/etc/default/tailscaled}" out
+  out="$(python3 - "$f" <<'PY_TSPORT' 2>/dev/null
+import os, sys
+sys.path.insert(0, os.environ.get("REPO_DIR", "/opt/privdns-gateway") + "/deploy/bot")
+sys.path.insert(0, "/opt/pdg-bot")
+try:
+    import checks
+except Exception:
+    print("41641\t读不到 checks 模块"); raise SystemExit
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        txt = fh.read()
+except OSError as e:
+    print("41641\t读不到 %s(%s)" % (sys.argv[1], e.strerror or e)); raise SystemExit
+port, why = checks._tailscaled_port(txt)
+print("%d\t" % port if port else "41641\t%s" % why)
+PY_TSPORT
+)" || out=""
+  [[ -n "$out" ]] || out="41641"$'\t'"端口解析没跑起来"
+  printf '%s' "$out"
+}
+# 两个薄封装。**必须写成多行、`}` 独占一行**: 全仓的测试闭包都靠 `sed -n '/^f(){/,/^}/p'`
+# 抽函数, 单行函数会让那个范围一路吃到下一个函数的收尾 —— 抽出来的东西语法上还成立, 于是
+# 闭包静默地少定义几个函数, 表现是"输出全空"而不是报错。(这一版就先踩了一次。)
+_ssh_ts_port(){
+  local o; o="$(_ssh_ts_probe)"
+  printf '%s' "${o%%$'\t'*}"
+}
+_ssh_ts_why(){
+  local o; o="$(_ssh_ts_probe)"
+  printf '%s' "${o#*$'\t'}"
+}
+
+# 那一行放行规则的**唯一**生成处。端口跟着上面派生, comment 固定 —— comment 才是这条规则的
+# 身份标记(doctor 的对账判据也是按它找的), 端口只是内容。
+_ssh_ts_accept(){
+  printf 'udp dport %s accept comment "pdg-tailnet-direct"' "$(_ssh_ts_port)"
+}
+
 _fw_tailnet_direct(){
   if [[ -n "${1:-}" ]]; then
-    printf '%s' 'udp dport 41641 accept comment "pdg-tailnet-direct"'
+    _ssh_ts_accept
   else
     printf '%s' '# (SSH 未收紧为 tailnet, 故不放行 Tailscale 直连端口)'
   fi
@@ -4738,7 +4793,8 @@ cmd_link(){
 #      而不是要你去翻服务商的网页控制台。
 _SSH_REVERT_UNIT=pdg-ssh-source-revert
 _SSH_REVERT_MIN="${PDG_SSH_REVERT_MIN:-10}"
-_SSH_TS_ACCEPT='udp dport 41641 accept comment "pdg-tailnet-direct"'
+# 这一行以前是常量 _SSH_TS_ACCEPT。改成函数 _ssh_ts_accept(定义在 _fw_tailnet_direct 上面):
+# 端口要跟着 /etc/default/tailscaled 走, 常量在 source 时就定死了, 跟不了。
 
 # 当前是否有一条**经 tailnet 进来的** SSH 会话。判据取 established 的本地 22 连接,
 # 对端落在 tailnet 段, 且该地址确实是本机 tailscale0 的对端(不只看 100.64/10 —— 那个段
@@ -4769,9 +4825,15 @@ _ssh_source_show(){
   fi
   if [[ -n "$m" ]]; then
     c_g "当前: tailnet —— 只允许经 Tailscale 登录, 公网上看不到 SSH 端口"
-    grep -qE "^[[:space:]]*udp dport 41641 accept" "$f" \
-      && echo "  Tailscale 直连端口(UDP 41641): 已放行(避免空闲后第一次连接超时)" \
-      || c_y "  ⚠️ 41641 未放行 —— 空闲一段后第一次 SSH 可能超时。跑一次 pdg ssh-source tailnet 修复。"
+    # 按 comment 认, 不按端口号认: 端口是可配的(见 _ssh_ts_port)。按数字认的话, 换过端口
+    # 的机器会一直被告知"41641 未放行, 跑一次 tailnet 修复"—— 而跑完还是这句, 把人指进一个
+    # 修不好的循环。顺带把**实际放行的端口**报出来: 用户改过端口时, 这是唯一能看见它的地方。
+    local _tsline; _tsline="$(grep -oE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' "$f" | head -1)" || _tsline=""
+    if [[ -n "$_tsline" ]]; then
+      echo "  Tailscale 直连端口(UDP $(sed -E 's/.*udp dport ([0-9]+).*/\1/' <<<"$_tsline")): 已放行(避免空闲后第一次连接超时)"
+    else
+      c_y "  ⚠️ Tailscale 直连端口未放行 —— 空闲一段后第一次 SSH 可能超时。跑一次 pdg ssh-source tailnet 修复。"
+    fi
   else
     echo "当前: any —— SSH 对全网放行(默认)"
   fi
@@ -4787,13 +4849,14 @@ _ssh_source_rewrite(){          # $1=目标模式(any|tailnet) $2=输入 $3=输�
   local mode="$1" src="$2" dst="$3"
   if [[ "$mode" == tailnet ]]; then
     sed -E -e 's|^([[:space:]]*)tcp dport \{ ([0-9]+) \} accept$|\1iifname "tailscale0" tcp dport { \2 } accept|' "$src" > "$dst" || return 1
-    # 41641 已经在就不重复插(幂等)
-    if ! grep -qE '^[[:space:]]*udp dport 41641 accept' "$dst"; then
-      sed -i -E 's|^([[:space:]]*)iifname "tailscale0" tcp dport \{ ([0-9]+) \} accept$|\1iifname "tailscale0" tcp dport { \2 } accept\n\1'"$_SSH_TS_ACCEPT"'|' "$dst" || return 1
+    # 已经在就不重复插(幂等)。**按 comment 认, 不按端口号认** —— 端口是可配的, 按数字认
+    # 的话换过端口的机器会被判成"还没插", 于是插第二条, 两条都在。
+    if ! grep -qE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' "$dst"; then
+      sed -i -E 's|^([[:space:]]*)iifname "tailscale0" tcp dport \{ ([0-9]+) \} accept$|\1iifname "tailscale0" tcp dport { \2 } accept\n\1'"$(_ssh_ts_accept)"'|' "$dst" || return 1
     fi
   else
     sed -E -e 's|^([[:space:]]*)iifname "tailscale0" tcp dport \{ ([0-9]+) \} accept$|\1tcp dport { \2 } accept|' \
-           -e '/^[[:space:]]*udp dport 41641 accept comment "pdg-tailnet-direct"$/d' "$src" > "$dst" || return 1
+           -e '/^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$/d' "$src" > "$dst" || return 1
   fi
   return 0
 }
@@ -6373,12 +6436,14 @@ cmd_ssh_source(){
       [[ -z "$cur" ]] && { echo "已经是 any, 无需改动。"; return 0; }
       _ssh_source_apply any || return 1
       _ssh_revert_disarm; rm -f "$(_ssh_revert_path)"
-      c_g "✅ SSH 已恢复对全网放行(Tailscale 直连端口 41641 一并撤销)。"
+      c_g "✅ SSH 已恢复对全网放行(Tailscale 直连端口一并撤销)。"
       return 0 ;;
 
     tailnet)
-      local cur; cur="$(_fw_ssh_match /etc/nftables.conf)" || { c_y "❌ 认不出当前形态, 拒绝改动"; return 1; }
-      if [[ -n "$cur" ]] && grep -qE '^[[:space:]]*udp dport 41641 accept' /etc/nftables.conf; then
+      local cur _tswhy; cur="$(_fw_ssh_match /etc/nftables.conf)" || { c_y "❌ 认不出当前形态, 拒绝改动"; return 1; }
+      # 幂等判据同样按 comment 认。按 41641 认的话, 换过端口的机器每次都被判成"还没收紧",
+      # 于是重复 apply 并**再起一次自动回退定时器** —— 而用户以为什么都没发生。
+      if [[ -n "$cur" ]] && grep -qE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' /etc/nftables.conf; then
         echo "已经是 tailnet, 无需改动。"; return 0
       fi
       # ★ 前置判据: 你此刻必须正通过 tailnet 连着
@@ -6393,7 +6458,9 @@ cmd_ssh_source(){
       fi
       _ssh_source_apply tailnet || return 1
       _ssh_revert_arm || true
-      c_g "✅ SSH 已收紧: 只允许经 tailnet 登录; UDP 41641 已放行(消除冷启动窗口)。"
+      c_g "✅ SSH 已收紧: 只允许经 tailnet 登录; UDP $(_ssh_ts_port) 已放行(消除冷启动窗口)。"
+      _tswhy="$(_ssh_ts_why)"
+      [[ -n "$_tswhy" ]] && c_y "   ⚠️ 端口按默认 41641 处理: $_tswhy"
       echo
       c_y "现在**另开一条 tailnet SSH 会话**验证能进来 —— 别关当前这条。"
       echo "  验证通过 → pdg ssh-source confirm    (确认, 取消自动回退)"

--- a/tests/test-ssh-source-persist.sh
+++ b/tests/test-ssh-source-persist.sh
@@ -40,6 +40,10 @@ run_sync(){ # $1=配置路径 $2=pdg.sh 路径
     echo '_fw_live_has_template_invariants(){ return 0; }'
     # 判据本体在 _fw_ssh_match(三处渲染共用), 必须一并抽出来 —— 少了它函数未定义,
     # 返回 127, sync 判成"形态认不出"而跳过, 于是这支测试测的是漏抽而不是产品。
+    # 直连端口现在从 /etc/default/tailscaled 派生(_ssh_ts_probe → checks._tailscaled_port),
+    # 这三个不抽的话 _fw_tailnet_direct 里那句命令替换取到空串, 重建出来的配置里那一行是**空的** ——
+    # 而空行不会让任何东西报错, 只会让"41641 放行"这条判据静默地不成立。
+    sed -n '/^_ssh_ts_probe(){/,/^}/p;/^_ssh_ts_port(){/,/^}/p;/^_ssh_ts_accept(){/,/^}/p' "$2"
     sed -n '/^_fw_tailnet_direct(){/,/^}/p' "$2"
     sed -n '/^_fw_ssh_match(){/,/^}/p' "$2"
     sed -n '/^migrate_firewall_template_sync(){/,/^}/p' "$2"
@@ -127,7 +131,7 @@ echo
 echo "── 六、★ 联动: 41641 放行必须与 SSH 收紧同进同退 ──"
 # 选项 A 的核心保证。拆成两个独立开关的话, 迟早出现"收紧了但没放行"的组合 —— 那正是
 # 冷启动连不上的形态(入站打洞包被 policy drop 丢掉), 而且从配置上完全看不出两者有关系。
-has41641(){ grep -qE '^[[:space:]]*udp dport 41641 accept' "$1" && echo 有 || echo 无; }
+has41641(){ grep -qE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' "$1" && echo 有 || echo 无; }
 [[ "$(has41641 "$WORK/a.conf")" == 无 ]] \
   && ok "any 模式(未收紧)→ 不放行 41641(不平白多开一个对公网可见的 UDP 口)" \
   || bad "未收紧却放行了 41641"
@@ -143,15 +147,19 @@ echo "── 七、cmd_ssh_source 的改写与前置判据 ──"
 # 改写走 _ssh_source_rewrite(就地改两行), 有意**不整份重渲染** —— 那会抹掉救援平面注入的
 # 规则和用户 include 里的东西。收紧 SSH 不该顺手动别的。
 sr(){ # $1=模式 $2=输入 $3=输出
-  { echo '_SSH_TS_ACCEPT='"'"'udp dport 41641 accept comment "pdg-tailnet-direct"'"'"''
+  # 这里以前把 _SSH_TS_ACCEPT **假造成一个常量**。端口改成从 /etc/default/tailscaled 派生
+  # 之后, 那个假常量就成了"测试自己造的现实" —— 真函数换了实现, 这支照样绿。引真的三个函数。
+  { sed -n '/^_ssh_ts_probe(){/,/^}/p;/^_ssh_ts_port(){/,/^}/p;/^_ssh_ts_accept(){/,/^}/p' \
+        "$ROOT/deploy/bot/pdg.sh"
     sed -n '/^_ssh_source_rewrite(){/,/^}/p' "$ROOT/deploy/bot/pdg.sh"
     echo "_ssh_source_rewrite '$1' '$2' '$3'"
   } > "$WORK/sr.sh"
-  bash "$WORK/sr.sh"
+  # 沙箱里没有 /etc/default/tailscaled → 派生回退到官方默认 41641, 与这支原本的期望一致。
+  TAILSCALED_DEFAULTS="$WORK/no-such-tailscaled" REPO_DIR="$ROOT" bash "$WORK/sr.sh"
 }
 render "" "$NOTE_ANY" "$WORK/g0.conf"
 sr tailnet "$WORK/g0.conf" "$WORK/g1.conf"
-{ [[ "$(ssh_form "$WORK/g1.conf")" == tailnet ]] && grep -qE '^[[:space:]]*udp dport 41641 accept' "$WORK/g1.conf"; } \
+{ [[ "$(ssh_form "$WORK/g1.conf")" == tailnet ]] && grep -qE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' "$WORK/g1.conf"; } \
   && ok "any → tailnet: SSH 收紧且 41641 一并放行" \
   || bad "any → tailnet 改写不对: form=$(ssh_form "$WORK/g1.conf") 41641=$(grep -c 41641 "$WORK/g1.conf")"
 
@@ -161,7 +169,7 @@ sr tailnet "$WORK/g1.conf" "$WORK/g1b.conf"
   || bad "重复执行插了 $(grep -c '^[[:space:]]*udp dport 41641 accept' "$WORK/g1b.conf") 条 41641"
 
 sr any "$WORK/g1.conf" "$WORK/g2.conf"
-{ [[ "$(ssh_form "$WORK/g2.conf")" == any ]] && ! grep -qE '^[[:space:]]*udp dport 41641 accept' "$WORK/g2.conf"; } \
+{ [[ "$(ssh_form "$WORK/g2.conf")" == any ]] && ! grep -qE '^[[:space:]]*udp dport [0-9]+ accept comment "pdg-tailnet-direct"$' "$WORK/g2.conf"; } \
   && ok "tailnet → any: SSH 放开且 41641 一并撤销" \
   || bad "tailnet → any 改写不对"
 

--- a/tests/test-tailnet-custom-port.sh
+++ b/tests/test-tailnet-custom-port.sh
@@ -31,7 +31,7 @@ extract(){
   [[ -n "$ln" ]] || return 1
   sed -n "${ln},/^}/p" "$ROOT/deploy/bot/pdg.sh"
 }
-for fn in _fw_tailnet_direct _ssh_source_rewrite _ssh_ts_port _ssh_ts_accept; do
+for fn in _fw_tailnet_direct _ssh_source_rewrite _ssh_ts_probe _ssh_ts_port _ssh_ts_why _ssh_ts_accept; do
   extract "$fn" >> "$CLOSURE" 2>/dev/null || true      # 后两个是本支要新增的, 现在抽不到
   echo >> "$CLOSURE"
 done
@@ -122,15 +122,54 @@ else
 fi
 
 echo
-echo "══ 7. 端口解析只有一份实现(不许 shell 里再造一个)══"
+echo "══ 7. 状态显示与幂等判据也不许按端口号认 ══"
+# 这两处不是文案问题, 是**判据**:
+#   · _ssh_source_show 按 41641 找放行 —— 自定义端口下会报"41641 未放行, 跑一次 tailnet 修复",
+#     而跑完还是这句, 用户被指向一个修不好的循环。
+#   · `ssh-source tailnet` 的"已经是 tailnet"判据同样按 41641 找 —— 自定义端口下判成"还没收紧",
+#     于是又走一遍 apply(幸好 rewrite 那边幂等), 并再次起自动回退定时器。
+_pdgsh="$ROOT/deploy/bot/pdg.sh"
+_show_body="$(sed -n '/^_ssh_source_show()/,/^}/p' "$_pdgsh")"
+grep -qE 'udp dport 41641' <<<"$_show_body" \
+  && bad "_ssh_source_show 仍按 41641 认放行" || ok "_ssh_source_show 不按端口号认"
+grep -qE 'pdg-tailnet-direct' <<<"$_show_body" \
+  && ok "_ssh_source_show 按 comment 认" || bad "_ssh_source_show 没有按 comment 认"
+
+_tail_arm="$(sed -n '/^    tailnet)/,/^      _ssh_source_apply tailnet/p' "$_pdgsh")"
+grep -qE 'udp dport 41641' <<<"$_tail_arm" \
+  && bad "「已经是 tailnet」的幂等判据仍按 41641 认" || ok "幂等判据不按端口号认"
+
+echo
+echo "══ 8. 「按默认处理」的提示必须真的能触发 ══"
+# `$(_ssh_ts_port)` 是**子 shell** —— 函数里给全局变量赋的值回不到父进程。第一版就是这么写的:
+# 提示语句在, 条件永远为假, 于是端口取不到时用户什么也看不到, 而防火墙已经按 41641 放行了。
+# 死代码比没有代码更坏: 读代码的人以为这件事被覆盖了。
+mkdefaults 'PORT=abc'
+why="$(run '_ssh_ts_why')"
+[[ -n "$why" ]] && ok "取不到端口时给得出原因(实得: $why)" || bad "原因是空的 —— 提示永远不会触发"
+mkdefaults 'PORT=51820'
+why2="$(run '_ssh_ts_why')"
+[[ -z "$why2" ]] && ok "端口取到时原因为空(不虚报)" || bad "端口明明取到了却报了原因: $why2"
+
+echo
+echo "══ 9. 端口解析只有一份实现(不许 shell 里再造一个)══"
 # checks.py 的 _tailscaled_port 是唯一真源: EnvironmentFile 的覆盖语义、引号、范围校验
 # 都在那儿写好了。shell 里再写一遍正则, 两份迟早对不上 —— 而对不上的表现是防火墙放行了
 # 一个没人监听的端口, 不会有任何报错。
-if grep -qE '_tailscaled_port|checks\.py' <<<"$(sed -n "/^_ssh_ts_port()/,/^}/p" "$ROOT/deploy/bot/pdg.sh")"; then
-  ok "_ssh_ts_port 复用 checks.py 的解析器"
-else
-  bad "_ssh_ts_port 没有复用 checks.py 的解析器(或函数不存在)"
-fi
+_probe_body="$(sed -n "/^_ssh_ts_probe()/,/^}/p" "$ROOT/deploy/bot/pdg.sh")"
+grep -q '_tailscaled_port' <<<"$_probe_body" \
+  && ok "_ssh_ts_probe 复用 checks.py 的 _tailscaled_port" \
+  || bad "_ssh_ts_probe 没有复用 checks.py 的解析器(或函数不存在)"
+# 端口派生这一处不许在 shell 里再造一份解析 —— 那就是漂移的起点。
+# 范围只取 `_ssh_ts_*` 三个函数体: 全文扫会扫到 PDG_RESCUE_PORT 之类完全无关的行(第一版
+# 就是这么误报的), 那种红灯除了让人学会忽略它以外没有别的作用。
+_ts_bodies="$(sed -n '/^_ssh_ts_probe()/,/^}/p;/^_ssh_ts_port()/,/^}/p;/^_ssh_ts_why()/,/^}/p' \
+              "$ROOT/deploy/bot/pdg.sh")"
+[[ -n "$_ts_bodies" ]] && ok "抽得到 _ssh_ts_* 函数体" || bad "抽不到 _ssh_ts_* 函数体, 这一格不作数"
+_shellparse="$(grep -nE '(grep|sed|awk|cut)[^#]*PORT' <<<"$_ts_bodies" | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+[[ -z "$_shellparse" ]] \
+  && ok "端口派生里没有 shell 版 PORT 解析" \
+  || bad "端口派生里出现了 shell 版 PORT 解析 —— 两份判据迟早对不上: $_shellparse"
 
 echo "────────────────────────────────────────"
 echo "通过 $pass, 失败 $nfail"

--- a/tests/test-tailnet-custom-port.sh
+++ b/tests/test-tailnet-custom-port.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# `pdg ssh-source tailnet` 放行的 UDP 端口必须**跟着 tailscaled 实际配置的端口走**。
+#
+# 41641 是 Tailscale 的官方默认值, 但它是可配的 —— Debian 12 上来自 /etc/default/tailscaled
+# 的 `PORT=`, unit 经 EnvironmentFile 传给 `tailscaled --port=${PORT}`。项目里那个数字一直是
+# 硬编码常量, 生成规则时从不读那份文件。
+#
+# 后果是**双向失效**, 而且从配置上完全看不出两者有关系:
+#   · 41641 那条没有监听者, 成了永远不会有人应答的陈旧放行;
+#   · 真正在用的端口被 input 链的 policy drop 挡掉。
+# 于是 `pdg ssh-source tailnet` 当初要消除的冷启动窗口原样回来: 空闲几小时后出事想连进去,
+# 第一次 SSH 必超时 —— 而这正是这条命令存在的全部理由。
+#
+# doctor 早就能看见这件事(check_tailnet_direct_port), 但它只会告诉你"本命令不会替你处理"。
+# 这一支要的是让命令自己处理。
+#
+# 还有一处更隐蔽的: 切回 `any` 时删规则是**按端口号 41641 匹配**的。自定义端口下那条删不掉,
+# 于是"已恢复对全网放行"说完, 机器上还留着一条没人知道的 UDP 放行。
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){   echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){  echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+# pdg.sh 的函数闭包。顶层常量整体注入(沙箱没给才用生产默认) —— 见 test-adblock-sources.sh
+# 里那段说明: 只抽函数会漏掉顶层赋值, 而 pdg.sh 跑在 set -u 下, 漏一个就在某条分支上炸。
+CLOSURE="$WORK/closure.sh"; : > "$CLOSURE"
+extract(){
+  local ln; ln="$(grep -n "^$1()" "$ROOT/deploy/bot/pdg.sh" | head -1 | cut -d: -f1)" || return 1
+  [[ -n "$ln" ]] || return 1
+  sed -n "${ln},/^}/p" "$ROOT/deploy/bot/pdg.sh"
+}
+for fn in _fw_tailnet_direct _ssh_source_rewrite _ssh_ts_port _ssh_ts_accept; do
+  extract "$fn" >> "$CLOSURE" 2>/dev/null || true      # 后两个是本支要新增的, 现在抽不到
+  echo >> "$CLOSURE"
+done
+# `=(` 开头的是**多行数组**赋值(_PLAT_IOS_REQUIRED), 逐行改写会把它切碎, 整个闭包从那里
+# 语法错、后面的定义全部丢失 —— 而表现是"函数没定义、输出全空", 看不出根因在这里。跳过它们。
+grep -E '^[A-Z_][A-Z0-9_]*=' "$ROOT/deploy/bot/pdg.sh" \
+  | grep -vE '^[A-Z_][A-Z0-9_]*=\(' \
+  | sed -E 's/^([A-Z_][A-Z0-9_]*)=(.*)$/\1="${\1:-}"; [[ -z "${\1}" ]] \&\& \1=\2/' >> "$CLOSURE"
+# 闭包必须**能整份解析**。上面那类切碎一旦再发生, 这里立刻判死 —— 否则后面每一格都在
+# 空输出上打转, 而空输出恰好能骗过"不含 41641"之类的否定断言。
+bash -n "$CLOSURE" || { bad "闭包语法坏了 —— 后面所有断言都不作数"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+
+# tailscaled 配置的假根。TAILSCALED_DEFAULTS 指到这里, 生产代码必须读它而不是写死。
+mkdefaults(){ mkdir -p "$WORK/etc/default"; printf '%s\n' "$1" > "$WORK/etc/default/tailscaled"; }
+
+run(){    # $1=要跑的 body; 在闭包里跑, 假根经环境变量传入
+  ( set +e
+    TAILSCALED_DEFAULTS="$WORK/etc/default/tailscaled"; export TAILSCALED_DEFAULTS
+    PDG_REPO_ROOT="$ROOT"; export PDG_REPO_ROOT
+    REPO_DIR="$ROOT"; export REPO_DIR
+    # shellcheck source=/dev/null
+    # shellcheck source=/dev/null
+    source "$CLOSURE"
+    eval "$1" )
+}
+
+echo "══ 1. 默认端口(没有 PORT= 赋值)仍是 41641 ══"
+mkdefaults '# 空配置'
+out="$(run '_fw_tailnet_direct x')"
+{ [[ -n "$out" ]] && [[ "$out" == *'udp dport 41641 accept'* ]]; } \
+  && ok "没配 PORT 时沿用官方默认 41641(实得: $out)" || bad "默认端口不对: ${out:-<空>}"
+
+echo
+echo "══ 2. 自定义端口必须被跟上 ══"
+mkdefaults 'PORT="51820"'
+out="$(run '_fw_tailnet_direct x')"
+[[ "$out" == *'udp dport 51820 accept'* ]] \
+  && ok "PORT=51820 时放行 51820" || bad "没跟上自定义端口, 实得: $out"
+# 空输出也"不含 41641" —— 所以必须先要求它确实生成了一条放行, 否则这条是空断言。
+{ [[ "$out" == *'udp dport'* ]] && [[ "$out" != *41641* ]]; } \
+  && ok "不再同时留着 41641 那条陈旧放行" || bad "还带着 41641 或压根没出规则: ${out:-<空>}"
+
+echo
+echo "══ 3. PORT= 后面的赋值覆盖前面的(EnvironmentFile 语义)══"
+mkdefaults 'PORT=1111
+# 注释里的 PORT=2222 不算
+PORT=3333'
+out="$(run '_fw_tailnet_direct x')"
+[[ "$out" == *'udp dport 3333 accept'* ]] \
+  && ok "取最后一条赋值(3333), 不是第一条" || bad "覆盖语义不对, 实得: $out"
+
+echo
+echo "══ 4. 取不到合法端口时退回默认, 不能生成坏规则 ══"
+for bad_val in 'PORT=abc' 'PORT=99999' 'PORT='; do
+  mkdefaults "$bad_val"
+  out="$(run '_fw_tailnet_direct x')"
+  [[ "$out" == *'udp dport 41641 accept'* ]] \
+    && ok "[$bad_val] 退回 41641" || bad "[$bad_val] 生成了坏规则: $out"
+done
+
+echo
+echo "══ 5. 未收紧为 tailnet 时不放行任何端口 ══"
+mkdefaults 'PORT=51820'
+out="$(run '_fw_tailnet_direct ""')"
+[[ "$out" != *'udp dport'* && "$out" == *'#'* ]] \
+  && ok "空匹配 → 渲染成注释, 不放行" || bad "不该放行却放行了: $out"
+
+echo
+echo "══ 6. 切回 any 时, 自定义端口那条也必须被删掉 ══"
+mkdefaults 'PORT=51820'
+cat > "$WORK/nft.in" <<'NFT'
+table inet pdg {
+  chain input {
+    iifname "tailscale0" tcp dport { 22 } accept
+    udp dport 51820 accept comment "pdg-tailnet-direct"
+  }
+}
+NFT
+run '_ssh_source_rewrite any "'"$WORK"'/nft.in" "'"$WORK"'/nft.out"' >/dev/null 2>&1
+if [[ -f "$WORK/nft.out" ]]; then
+  grep -q 'pdg-tailnet-direct' "$WORK/nft.out" \
+    && bad "切回 any 后仍残留一条无人知晓的 UDP 放行: $(grep 'pdg-tailnet-direct' "$WORK/nft.out")" \
+    || ok "切回 any 时按 comment 删除, 自定义端口那条也清掉了"
+  grep -qE '^[[:space:]]*tcp dport \{ 22 \} accept$' "$WORK/nft.out" \
+    && ok "SSH 放行同时恢复成对全网" || bad "SSH 那行没恢复"
+else
+  bad "_ssh_source_rewrite 没产出文件(函数抽不到?)"
+fi
+
+echo
+echo "══ 7. 端口解析只有一份实现(不许 shell 里再造一个)══"
+# checks.py 的 _tailscaled_port 是唯一真源: EnvironmentFile 的覆盖语义、引号、范围校验
+# 都在那儿写好了。shell 里再写一遍正则, 两份迟早对不上 —— 而对不上的表现是防火墙放行了
+# 一个没人监听的端口, 不会有任何报错。
+if grep -qE '_tailscaled_port|checks\.py' <<<"$(sed -n "/^_ssh_ts_port()/,/^}/p" "$ROOT/deploy/bot/pdg.sh")"; then
+  ok "_ssh_ts_port 复用 checks.py 的解析器"
+else
+  bad "_ssh_ts_port 没有复用 checks.py 的解析器(或函数不存在)"
+fi
+
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail > 0 ? 1 : 0 ))


### PR DESCRIPTION
## 症状

`pdg ssh-source tailnet` 放行的 UDP 端口写死 41641。那只是 Tailscale 的**官方默认值** —— Debian 12 上它来自 `/etc/default/tailscaled` 的 `PORT=`,unit 经 EnvironmentFile 传给 `tailscaled --port=${PORT}`。

用户改过端口之后,这条放行**双向失效**:

- 41641 那条没有监听者,成了永远不会有人应答的陈旧放行
- 真正在用的端口被 input 链的 policy drop 挡掉

于是这条命令当初要消除的冷启动窗口原样回来 —— 空闲几小时后出事想连进去,第一次 SSH 必超时。**而这正是它存在的全部理由。**

doctor 早就能看见(`check_tailnet_direct_port`),但它只能告诉你"本命令不会替你处理"。

## 修法

端口从 `/etc/default/tailscaled` 派生,**解析复用 `checks.py` 的 `_tailscaled_port`** —— EnvironmentFile 的覆盖语义(后面的赋值盖前面的)、引号剥离、端口范围校验都在那儿写好了,而且 doctor 的对账判据用的就是它。shell 里再写一遍正则,两份迟早对不上,而对不上的表现是防火墙放行了一个没人监听的端口,不会有任何报错。

取不到就退回 41641(没装 Tailscale、不是 deb 装的、文件里没有合法 `PORT=`,都是正常情形),并且**把原因说出来** —— 静默地按默认值放行,正是这条命令原来的毛病。

## 一并修掉三处按端口号认的判据(都不是文案问题)

| 位置 | 自定义端口下的后果 |
|---|---|
| `_ssh_source_rewrite` 切回 `any` | 那条删不掉。"已恢复对全网放行"说完,机器上还留着**一条没人知道的 UDP 放行** |
| `_ssh_source_show` | 一直报"41641 未放行,跑一次 tailnet 修复" —— 而跑完还是这句,把人指进一个修不好的循环 |
| "已经是 tailnet" 幂等判据 | 每次都判成"还没收紧",重复 apply 并**再起一次自动回退定时器**,而用户以为什么都没发生 |

comment 本来就该是这条规则的身份标记(doctor 的对账判据也是按它找的),端口只是内容。现在一律按 `comment "pdg-tailnet-direct"` 认。

## 写的过程里自己造的两个坑(都留了注释)

**① 死代码。** 第一版用全局变量 `_SSH_TS_PORT_WHY` 回传原因 —— `$(_ssh_ts_port)` 是**子 shell**,赋值回不到父进程,那句提示成了**永远不会触发的死代码**。死代码比没有代码更坏:读的人以为这件事被覆盖了。改成 `_ssh_ts_probe` 输出 `端口<TAB>原因`,两个薄封装各取一半。

**② 单行函数。** 薄封装第一版写成单行。全仓的测试闭包都靠 `sed -n '/^f(){/,/^}/p'` 抽函数,单行函数会让范围一路吃到下一个函数的收尾 —— 抽出来语法上还成立,于是闭包静默地少定义几个函数,表现是"输出全空"而不是报错。

## 两处夹具缺陷(既有测试)

- `test-ssh-source-persist.sh` 的 `sr()` 把 `_SSH_TS_ACCEPT` **假造成常量**。端口改成派生之后,那个假常量就是"测试自己造的现实" —— 真函数换了实现这支照样绿
- 同一支的 `run_sync()` 闭包没抽新函数,于是 `_fw_tailnet_direct` 里那句命令替换取到空串,重建出来的配置里那一行是**空的** —— 而空行不报错,只让"直连端口已放行"静默不成立。这正是那个函数上方注释早就写过的教训,又踩了一次

## 验证

新增 `tests/test-tailnet-custom-port.sh`(18 格)。负控三条:

| 变异 | 结果 |
|---|---|
| 端口写回硬编码 41641 | 15/3 |
| 切回 `any` 按端口号删 | 17/1,抓到残留放行 |
| `_ssh_ts_why` 恒返回空 | 17/1,抓到死代码 |

夹具上也栽了一次并记下:顶层常量注入按 `^[A-Z_]...` 抓会抓到 `_PLAT_IOS_REQUIRED=(` 这个**多行数组**,逐行改写把它切碎 → 闭包从那里语法错、后面的定义全丢 → 每格都在空输出上打转,而空输出**恰好**能骗过"不含 41641"这类否定断言。现在跳过数组,并且 `bash -n "$CLOSURE"` 不过就直接判死。

🤖 Generated with [Claude Code](https://claude.com/claude-code)