### PR TITLE
chore: 清掉 HANDOFF 剩下的三条收尾

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,9 @@ jobs:
       - name: "LAN 产物没变就别重启反代(跳过重启的那条路仍要补回内核白名单)"
         run: bash tests/test-lan-restart-idempotent.sh
 
+      - name: "功能测试成功路径也要打印 mihomo 日志(截断要说清楚)"
+        run: bash tests/test-functional-log-visibility.sh
+
       - name: "Location 改写: 真 Caddy 打真响应头(静态测试证明不了头被改了)"
         run: bash tests/test-lan-location-live.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
       - name: "反代重载的唯一入口(admin off 下 reload 必败, 只生成不重启=进程用着旧的)"
         run: bash tests/test-lan-proxy-reload-chokepoint.sh
 
+      - name: "LAN 产物没变就别重启反代(跳过重启的那条路仍要补回内核白名单)"
+        run: bash tests/test-lan-restart-idempotent.sh
+
       - name: "Location 改写: 真 Caddy 打真响应头(静态测试证明不了头被改了)"
         run: bash tests/test-lan-location-live.sh
 

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -922,12 +922,6 @@ def _internal_seq_block(conf):
             out.append(ln)
     return "\n".join(out)
 
-_RL_WARN = ("warn", "限流", "mosdns 单客户端 QPS 兜底(rate_limiter)缺失或参数/动作异常; "
-                            "运行 sudo pdg restart 或 sudo pdg 触发迁移。高度自定义配置请手动在 "
-                            "internal_sequence 缓存前加 client_limiter(qps200/burst400/mask4-32/mask6-128)+ "
-                            "'!$client_limiter → reject 5'。")
-_RL_WANT = {"qps": "200", "burst": "400", "mask4": "32", "mask6": "128"}
-
 def _lan_route_projection(text):
     """把一份 Caddyfile 投影成 {host: 上游}。
 
@@ -1126,6 +1120,15 @@ def check_adblock():
                                     "公共域): %s —— 这些域名不在保护内。" % note)
     return ("ok", name, msg)
 
+
+# 这两个常量的**唯一**消费者就是下面那个函数。它们原本在 200 行开外 —— v1.10.16 把
+# check_lan_proxy_routes 插在了中间, 于是判据的期望值和用它的地方隔着两个不相干的函数。
+# 行为没受影响, 但改判据的人得先找到它们; 而"找不到就照着记忆改"正是判据悄悄漂掉的起点。
+_RL_WARN = ("warn", "限流", "mosdns 单客户端 QPS 兜底(rate_limiter)缺失或参数/动作异常; "
+                            "运行 sudo pdg restart 或 sudo pdg 触发迁移。高度自定义配置请手动在 "
+                            "internal_sequence 缓存前加 client_limiter(qps200/burst400/mask4-32/mask6-128)+ "
+                            "'!$client_limiter → reject 5'。")
+_RL_WANT = {"qps": "200", "burst": "400", "mask4": "32", "mask6": "128"}
 
 def check_mosdns_ratelimit():
     """单客户端 QPS 兜底(rate_limiter)是否就位且参数/动作正确:

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5856,9 +5856,11 @@ _nft_apply_main(){
 # 把内网面板的出站白名单补回内核。只在**反代确实在跑**时做 —— 没在跑的话那张表本来就
 # 不该存在(disable/purge 之后留一张表反而是残留)。
 _lan_nft_reapply(){
-  [[ -s /etc/nftables-pdg-lan.conf ]] || return 0
+  # 路径走 $LAN_NFT_CONF, 不写死 —— 同一个文件有两个真源, 迟早对不上; 而且写死之后沙箱
+  # 测试根本指不到假根, 于是这个函数在测试里永远走"文件不存在"那条早退, 什么都没验到。
+  [[ -s "$LAN_NFT_CONF" ]] || return 0
   systemctl is-active --quiet pdg-lan 2>/dev/null || return 0
-  nft -f /etc/nftables-pdg-lan.conf 2>/dev/null && return 0
+  nft -f "$LAN_NFT_CONF" 2>/dev/null && return 0
   c_y "⚠️ 内网面板的出站白名单没能重新加载 —— 反代此刻**能连到内网任意地址**。"
   c_y "   跑 sudo systemctl restart pdg-lan 补上。"
   return 0

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5467,8 +5467,47 @@ _lan_cert_missing(){
 #   · `pdg lan render` 重新生成了配置却不重启, pdg-lan 停在 9 小时前, 新规则没进内存。
 #
 # 没在跑就什么都不做 —— 那是"还没 enable", 不是故障。
+# LAN 的三个派生产物的联合指纹。**三个都要算** —— 少算一个, 那个产物变了就不会重启, 而
+# "配置变了进程没跟上"正是本项目反复出事的形态。文件缺失也要体现在指纹里(用一个占位标记),
+# 否则"产物被删"会被当成"没变"而跳过重启, 可那时反代恰恰该被拉起来。
+_lan_artifacts_digest(){
+  local f h out=""
+  for f in "$LAN_CADDYFILE" "$LAN_NFT_CONF" "$LAN_UNIT"; do
+    if [[ -f "$f" ]]; then
+      h="$(sha256sum "$f" 2>/dev/null | cut -d" " -f1)"
+      # **算不出来就整个作废**(打印空串)。文件在但读不到时 sha256sum 只吐一个空串, 那会让
+      # 两份**内容不同**的产物得到同一个指纹 —— 于是"没变"成立、重启被跳过, 而磁盘上其实
+      # 已经换了一份。指纹的用途只有一个: 判断"能不能安全地不重启"; 算不出来时唯一安全的
+      # 答案是"不知道", 而"不知道"必须落到重启那一边。
+      [[ -n "$h" ]] || { printf ''; return 1; }
+      out+="$h"$'\n'
+    else
+      out+="ABSENT:$f"$'\n'      # 缺文件与空文件是两回事, 不能都算成"没内容"
+    fi
+  done
+  printf '%s' "$out" | sha256sum | cut -d" " -f1
+}
+
+# $1(可选)= 改动**之前**取的产物指纹。给了就先比一比: 一个字节都没变就不重启。
+#
+# 为什么值得: LAN 的派生产物在产物层已经是逐字节幂等的, 于是每一次 pdg update、每一次面板
+# 同步都会为一份没变的配置重启一次反代 —— 重启期间反代是断的, 手机上开着的面板会掉一次,
+# 而这类重启没有任何事情能从中获益。本项目在别处早就守着同一条规矩(去广告是"产物真变才
+# 重启", 恢复是"动作从这次内容确实变了的目标推出来"), 这里是唯一的例外。
+#
+# 但跳过重启**不能只是不做事**: 出站白名单是靠 unit 的 ExecStartPre 进内核的, 跳过重启就
+# 跳过了那一步。所以那条路上仍要走一遍 _lan_nft_reapply(它自己幂等, 且只在反代确实在跑时
+# 动手)—— 否则"少一次重启"换来的是一个反代能连内网任意地址的窗口。
+#
+# **不传参数时保持原行为(无条件重启)**: 老调用点的语义是"我不知道变没变", 那时默认值只能
+# 偏保守 —— 静默地少一次重启, 比多一次重启危险得多。
 _lan_apply_proxy(){
+  local before="${1:-}"
   systemctl is-active --quiet pdg-lan 2>/dev/null || return 0
+  if [[ -n "$before" && "$before" == "$(_lan_artifacts_digest)" ]]; then
+    _lan_nft_reapply
+    return 0
+  fi
   systemctl restart pdg-lan >/dev/null 2>&1 && return 0
   c_y "⚠️ pdg-lan 重启失败 —— 新的反代配置与出站白名单都还没生效。"
   return 1
@@ -5496,12 +5535,15 @@ _lan_rollback_converge(){
   systemctl is-active --quiet pdg-lan 2>/dev/null && active=1
 
   if [[ "$intent" == 1 ]]; then
+    # 渲染**之前**取指纹: 回滚收敛在绝大多数机器上会渲出一份与现网逐字节相同的产物
+    # (面板表没变过), 那时不该为它断一次反代。
+    local _lan_d0; _lan_d0="$(_lan_artifacts_digest)"
     if ! _lan_render; then
       c_y "⚠️ LAN 回滚不完整: 派生产物没能按恢复出来的面板表重新生成(第一失败点: 渲染/落盘)。"
       c_y "   面板表与 profile 已经回滚到位; 反代仍在用回滚前的配置。手工补: sudo pdg lan render"
       return 1
     fi
-    if ! _lan_apply_proxy; then
+    if ! _lan_apply_proxy "$_lan_d0"; then
       c_y "⚠️ LAN 回滚不完整: 产物已按面板表更新, 但反代没能重启(第一失败点: 重启 pdg-lan)。"
       c_y "   此刻磁盘是新的、进程还用着旧的。手工补: sudo systemctl restart pdg-lan"
       return 1
@@ -5529,11 +5571,12 @@ _lan_sync_after_change(){
     echo "   (内网面板还没启用, 派生物等 pdg lan enable 时一起生成。)"
     return 0
   fi
+  local _lan_d0; _lan_d0="$(_lan_artifacts_digest)"     # 渲染前, 用来判断产物到底变没变
   _lan_render || { c_y "⚠️ 反代配置/白名单没能重新生成 —— 新面板还不会生效。"; return 1; }
   _lan_wire   || { c_y "⚠️ DNS 劫持集/分流没能同步 —— 新面板还不会生效。"; return 1; }
   # 失败必须向上传播: 这里曾是 `|| true` —— 反代没重启起来, 而调用方照旧打印"已同步"。
   # "磁盘对了、进程没跟上"是本项目反复出事的那个形态, 不能由一句成功文案盖过去。
-  _lan_apply_proxy || return 1
+  _lan_apply_proxy "$_lan_d0" || return 1
   c_g "✅ 反代配置、出站白名单、DNS 劫持集与分流已同步。"
   local miss; miss="$(_lan_cert_missing)"
   if [[ -n "$miss" ]]; then

--- a/tests/functional-test.sh
+++ b/tests/functional-test.sh
@@ -13,7 +13,8 @@
 # 测试里直接连该端口即可 —— sniffer 的 override-destination 会用嗅到的 SNI 顶掉原目的地,
 # 正是生产中"手机连过来 → 嗅 SNI → 按域名选出口"那条路。
 #
-# 退出码 0 = 通过; 非 0 = 失败(并打印 mihomo 输出便于排查)。
+# 退出码 0 = 通过; 非 0 = 失败。**两种情况都打印 mihomo 输出** —— 绿的时候拿不到它,
+# 真出事时就只能拿红 run 去猜正常长什么样。
 # ─────────────────────────────────────────────────────────────────────────────
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -35,7 +36,25 @@ drop_conntrack_table(){
     NFT_TABLE=""
   fi
 }
+# mihomo 的输出**成功时也要打出来**。以前只有失败路径 cat 它, 而 cleanup 又把整个 $WORK
+# 删掉 —— 于是绿的那些 run 里根本拿不到 mihomo 日志。真出事的时候(HANDOFF §9.12 那个坑)
+# 只能拿红 run 去猜"绿的时候它是什么样", 而那正是最需要对照的东西。
+#
+# 幂等: 失败路径已经就地 cat 过一次的, 这里不再重复(_MH_DUMPED)。
+# 截断到最后 200 行: 一次跑只有几秒, 正常远不到这个量; 设上限是防"mihomo 疯狂刷日志"
+# 那种情形把 CI 日志淹掉。截断了就说清楚, 不假装打全了。
+_MH_DUMPED=0
+dump_mihomo(){
+  [[ "$_MH_DUMPED" == 1 ]] && return 0
+  [[ -s "$WORK/mh.out" ]] || return 0
+  _MH_DUMPED=1
+  local n; n="$(wc -l < "$WORK/mh.out")"
+  echo "---- mihomo 输出(共 $n 行$( (( n > 200 )) && echo ", 只显示最后 200 行" ))----" >&2
+  tail -200 "$WORK/mh.out" >&2
+  echo "---- mihomo 输出结束 ----" >&2
+}
 cleanup(){
+  dump_mihomo
   for p in "${PIDS[@]:-}"; do kill "$p" 2>/dev/null; done
   rm -rf "$WORK"
   drop_conntrack_table
@@ -175,14 +194,14 @@ for _ in $(seq 1 50); do
   if python3 -c 'import socket,sys; s=socket.socket(); s.settimeout(.2); sys.exit(0 if s.connect_ex(("127.0.0.1",18443))==0 else 1)'; then ready=1; break; fi
   sleep 0.1
 done
-[[ "$ready" == 1 ]] || { cat "$WORK/mh.out" >&2; fail "mihomo 入口 :18443 未就绪"; }
+[[ "$ready" == 1 ]] || { dump_mihomo; fail "mihomo 入口 :18443 未就绪"; }
 
 # ── 4. 各 SNI 断言落到正确出口(只比对 host, 端口随入口口子) ──
 check_case(){  # $1=SNI $2=期望日志文件 $3=出口名
   local sni="$1" log="$2" name="$3"
   python3 "$HERE/sni_client.py" 127.0.0.1 18443 "$sni"
   for _ in $(seq 1 30); do grep -q "^${sni}:" "$log" 2>/dev/null && { note "  $sni → $name ✓"; return 0; }; sleep 0.1; done
-  echo "---- mihomo 输出 ----" >&2; cat "$WORK/mh.out" >&2
+  dump_mihomo
   fail "SNI=$sni 未按预期到达 $name (A='$(tr '\n' ' ' <"$LOGA")' B='$(tr '\n' ' ' <"$LOGB")' D='$(tr '\n' ' ' <"$LOGD")')"
 }
 

--- a/tests/lan-fixture.sh
+++ b/tests/lan-fixture.sh
@@ -41,6 +41,9 @@ LAN_FX_FUNCS=(
   _lan_hosts _lan_intent _lan_migrate_certs _lan_cert_missing
   _lan_render _lan_install_managed _lan_restore_pre
   _lan_apply_proxy _lan_sync_after_change _lan_disable
+  # _lan_apply_proxy 现在要判"产物变没变"(不变就不重启), 并在跳过重启时把内核白名单补回去。
+  # 这两个是它新的内部依赖 —— 漏抽的话它会 127, 而 127 在这组里恰好长得像"收敛没执行"。
+  _lan_artifacts_digest _lan_nft_reapply
 )
 
 # 沙箱专用的桩(**不是**生产函数): need_root 在非 root 下会 exit 1, 而这一组测的不是

--- a/tests/test-firewall-live-drift.py
+++ b/tests/test-firewall-live-drift.py
@@ -164,6 +164,8 @@ try:
         # **抽取清单要跟着依赖走** —— 少抽一个的后果不是报错, 而是被测函数里那次调用
         # 静默失败, 于是同步看起来是 no-op, 而失败信息指向别处。
         'eval "$(sed -n "/^_nft_apply_main()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
+        # 常量跟着抽: 路径已从函数体收归 $LAN_NFT_CONF, set -u 下漏了就是 unbound。
+        'eval "$(grep -E \'^LAN_NFT_CONF=\' %s/deploy/bot/pdg.sh)"; '
         'eval "$(sed -n "/^_lan_nft_reapply()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'eval "$(sed -n "/^_fw_tailnet_direct()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
         'eval "$(sed -n "/^_fw_ssh_match()/,/^}/p" %s/deploy/bot/pdg.sh)"; '
@@ -172,7 +174,7 @@ try:
         'migrate_firewall_template_sync %s; echo "rc=$?"'
         # ROOT 的个数必须与上面 eval 行数一致 —— 少一个 shell 会拿到字面 "%s" 当路径,
       # sed 读不到文件、抽出空串、函数未定义, 而失败信息指向别处。
-      % (ROOT, SUDO, NS, ROOT, ROOT, ROOT, ROOT, ROOT, ROOT, ROOT, conf))
+      % (ROOT, SUDO, NS, ROOT, ROOT, ROOT, ROOT, ROOT, ROOT, ROOT, ROOT, conf))
     fn = subprocess.run(SYNC_CMD, shell=True, capture_output=True, text=True, executable="/bin/bash", env=env)
     rc = re.search(r"rc=(\d+)", fn.stdout or "")
     rc = int(rc.group(1)) if rc else -1

--- a/tests/test-functional-log-visibility.sh
+++ b/tests/test-functional-log-visibility.sh
@@ -25,7 +25,13 @@ mkclosure(){
   printf '%s' "$c"
 }
 C="$(mkclosure)"
-run(){ ( set +e; WORK="$1"; _MH_DUMPED="${2:-0}"; export WORK; source "$C"; dump_mihomo ) 2>&1; }
+run(){
+  ( set +e
+    WORK="$1"; _MH_DUMPED="${2:-0}"; export WORK
+    # shellcheck source=/dev/null
+    source "$C"
+    dump_mihomo ) 2>&1
+}
 
 echo "══ 1. 有日志就打出来 ══"
 B="$WORK/b1"; mkdir -p "$B"; printf 'line-A\nline-B\n' > "$B/mh.out"

--- a/tests/test-functional-log-visibility.sh
+++ b/tests/test-functional-log-visibility.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# functional-test.sh 必须在**成功路径上也打印 mihomo 的输出**。
+#
+# 以前只有失败路径 cat 它, 而 cleanup 又 `rm -rf "$WORK"` 把整个工作目录删掉 —— 于是所有
+# 绿的 run 里根本拿不到 mihomo 日志。HANDOFF §9.12 那个坑就是这么来的: 真出事时只能拿红
+# run 去猜"正常的时候它是什么样", 而那正是最需要对照的东西。
+#
+# (本轮就撞过一次现成的例子: PR #40 的 functional 抖动, 错因 `Start Redir server error:
+#  operation not permitted` 只在红 run 里看得到 —— 要判断它是不是常态, 得有绿 run 的日志比。)
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){   echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){  echo "[FAIL] $1"; nfail=$((nfail+1)); }
+F="$ROOT/tests/functional-test.sh"
+
+# 真跑 dump_mihomo(抽函数, 不跑整支 —— 那要真起 mihomo)
+mkclosure(){
+  local c="$WORK/c.sh"
+  { echo 'set -uo pipefail'
+    sed -n '/^dump_mihomo()/,/^}/p' "$F"
+  } > "$c"
+  bash -n "$c" || { bad "抽不出 dump_mihomo 或语法坏了 —— 后面所有断言都不作数"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+  printf '%s' "$c"
+}
+C="$(mkclosure)"
+run(){ ( set +e; WORK="$1"; _MH_DUMPED="${2:-0}"; export WORK; source "$C"; dump_mihomo ) 2>&1; }
+
+echo "══ 1. 有日志就打出来 ══"
+B="$WORK/b1"; mkdir -p "$B"; printf 'line-A\nline-B\n' > "$B/mh.out"
+out="$(run "$B")"
+grep -q 'line-A' <<<"$out" && grep -q 'line-B' <<<"$out" \
+  && ok "日志内容被打出来了" || bad "没打出内容: $(head -c 120 <<<"$out")"
+grep -q 'mihomo 输出' <<<"$out" && ok "带了可辨认的分隔头" || bad "没有分隔头"
+
+echo
+echo "══ 2. 幂等: 失败路径已经打过就不再重复 ══"
+out2="$(run "$B" 1)"
+[[ -z "$out2" ]] && ok "_MH_DUMPED=1 时不重复打印" || bad "重复打印了: $(head -c 80 <<<"$out2")"
+
+echo
+echo "══ 3. 没有日志时安静退出(不打空的分隔头)══"
+B2="$WORK/b2"; mkdir -p "$B2"; : > "$B2/mh.out"
+out3="$(run "$B2")"
+[[ -z "$out3" ]] && ok "空日志时什么都不打" || bad "空日志也打了: $(head -c 80 <<<"$out3")"
+B3="$WORK/b3"; mkdir -p "$B3"
+out4="$(run "$B3")"
+[[ -z "$out4" ]] && ok "日志文件不存在时什么都不打" || bad "无文件也打了"
+
+echo
+echo "══ 4. 超长日志截断, 而且**说清楚截断了** ══"
+# 不说就是在撒谎: 读的人以为看到的是全部, 于是"日志里没有那条错误"成了一个错误的结论。
+B4="$WORK/b4"; mkdir -p "$B4"
+for i in $(seq 1 500); do echo "L$i"; done > "$B4/mh.out"
+out5="$(run "$B4")"
+grep -q 'L500' <<<"$out5" && ok "保留了最后几行(最新的那部分)" || bad "尾部丢了"
+grep -q 'L1$' <<<"$out5" && bad "500 行全打了 —— 没截断" || ok "超长时确实截断了"
+grep -qE '共 500 行' <<<"$out5" && ok "把真实总行数说出来了" || bad "没说总行数"
+grep -q '只显示最后' <<<"$out5" && ok "明说了这是截断过的" || bad "截断了却不说 —— 读的人会以为看到了全部"
+
+echo
+echo "══ 5. cleanup 里必须调它(否则成功路径还是拿不到)══"
+body="$(sed -n '/^cleanup()/,/^}/p' "$F")"
+grep -q 'dump_mihomo' <<<"$body" \
+  && ok "cleanup 调了 dump_mihomo(成功/失败/中断三条路都覆盖)" \
+  || bad "cleanup 没调 —— 成功路径依旧拿不到日志"
+# 顺序要紧: 必须在 rm -rf 之前
+if grep -q 'dump_mihomo' <<<"$body"; then
+  d="$(grep -n 'dump_mihomo' <<<"$body" | head -1 | cut -d: -f1)"
+  r="$(grep -n 'rm -rf' <<<"$body" | head -1 | cut -d: -f1)"
+  { [[ -n "$d" && -n "$r" ]] && (( d < r )); } \
+    && ok "dump 在 rm -rf 之前(晚一步日志就已经被删了)" || bad "dump 排在 rm -rf 之后(d=$d r=$r)"
+fi
+
+echo
+echo "══ 6. 失败路径不许再有裸 cat(两条路必须同一个入口)══"
+# 两个入口就会漂: 一处改了格式/截断策略, 另一处还是老样子。
+grep -nE 'cat "\$WORK/mh\.out"' "$F" | sed 's/^/    /' >&2
+grep -qE 'cat "\$WORK/mh\.out"' "$F" \
+  && bad "还有裸 cat mh.out —— 应统一走 dump_mihomo" || ok "失败路径也走 dump_mihomo"
+
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail > 0 ? 1 : 0 ))

--- a/tests/test-ios-profile-ux.py
+++ b/tests/test-ios-profile-ux.py
@@ -543,6 +543,11 @@ sed -n '/^_ios_offer_download()/,/^}/p' deploy/bot/pdg.sh > "$CH_DIR/fn.sh"
 # 断言看起来像"没还原防火墙"这个产品缺陷, 其实是夹具少抽了一个函数。
 sed -n '/^_nft_apply_main()/,/^}/p'  deploy/bot/pdg.sh >> "$CH_DIR/fn.sh"
 sed -n '/^_lan_nft_reapply()/,/^}/p' deploy/bot/pdg.sh >> "$CH_DIR/fn.sh"
+# 常量也要跟着抽。`set -u` 下漏一个就是 unbound variable, 而那会让 _nft_apply_main 在
+# 调 _lan_nft_reapply 时半途死掉 —— 表现同样是"没还原防火墙", 与漏抽函数一模一样。
+# (_lan_nft_reapply 原先把这个路径写死在函数体里, 于是这里不抽也能跑; 路径收归常量之后
+#  就不行了 —— 写死路径让夹具"碰巧能用", 那本身就是它该被改掉的理由之一。)
+grep -E '^LAN_NFT_CONF=' deploy/bot/pdg.sh >> "$CH_DIR/fn.sh"
 grep -q 'http.server' "$CH_DIR/fn.sh" || { echo "EXTRACT-FAIL"; exit 9; }
 c_g(){ echo "$*"; }; c_y(){ echo "$*"; }
 # shellcheck source=/dev/null

--- a/tests/test-lan-restart-idempotent.sh
+++ b/tests/test-lan-restart-idempotent.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# 产物没变就别重启 pdg-lan。
+#
+# 现状: `_lan_apply_proxy` 无条件 `systemctl restart pdg-lan`。而 LAN 的三个派生产物
+# (caddy.conf / nftables-pdg-lan.conf / pdg-lan.service)在产物层**已经是逐字节幂等**的 ——
+# 也就是说每一次 `pdg update`、每一次面板同步、每一次回滚收敛, 都会为了一份一个字节都没变的
+# 配置去重启一次反代。
+#
+# 代价不是"多花两秒": 重启期间反代是断的, 手机上正开着的面板会掉一次; 而这类重启没有任何
+# 事情能从中获益 —— 配置一样, 结果也一样。本项目在别处已经守着同一条规矩(去广告那边是
+# "产物真变才重启", 恢复那边是"动作从**这次内容确实变了的**目标推出来")。这里是唯一的例外。
+#
+# 但**不能简单地不重启就完事**: 出站白名单是靠 unit 的 `ExecStartPre` 进内核的, 跳过重启
+# 就跳过了那一步。所以跳过重启的那条路上必须仍然保证内核里那张表在位 —— 走已有的
+# `_lan_nft_reapply`(它自己就是幂等的, 且只在反代确实在跑时动手)。
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){   echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){  echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+PDG="$ROOT/deploy/bot/pdg.sh"
+
+mkclosure(){   # 抽函数 + 打桩, 记录 systemctl 被怎么调的
+  local c="$WORK/c.sh"
+  {
+    echo 'set -uo pipefail'
+    echo 'c_g(){ echo "$*"; }; c_y(){ echo "CY:$*"; }'
+    echo 'CALLS="'"$WORK"'/calls.log"'
+    # systemctl 桩: is-active 按 $LAN_ACTIVE 回答, 其余一律记账
+    cat <<'STUB'
+systemctl(){
+  printf '%s\n' "$*" >> "$CALLS"
+  case "$1" in
+    is-active) [[ "${LAN_ACTIVE:-1}" == 1 ]] && return 0 || return 1;;
+    *) return 0;;
+  esac
+}
+nft(){ printf 'nft %s\n' "$*" >> "$CALLS"; return 0; }
+STUB
+    sed -n '/^_lan_artifacts_digest()/,/^}/p' "$PDG"
+    sed -n '/^_lan_nft_reapply()/,/^}/p' "$PDG"
+    sed -n '/^_lan_apply_proxy()/,/^}/p' "$PDG"
+  } > "$c"
+  bash -n "$c" || { bad "闭包语法坏了 —— 后面所有断言都不作数"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+  printf '%s' "$c"
+}
+
+seed(){   # 造出三个派生产物
+  mkdir -p "$WORK/etc/pdg-lan" "$WORK/etc/systemd/system"
+  printf 'caddy conf v1\n'  > "$WORK/etc/pdg-lan/caddy.conf"
+  printf 'table inet pdglan {}\n' > "$WORK/etc/nftables-pdg-lan.conf"
+  printf '[Service]\nExecStart=/x\n' > "$WORK/etc/systemd/system/pdg-lan.service"
+}
+
+run(){    # $1=body
+  ( set +e
+    LAN_CADDYFILE="$WORK/etc/pdg-lan/caddy.conf"
+    LAN_NFT_CONF="$WORK/etc/nftables-pdg-lan.conf"
+    LAN_UNIT="$WORK/etc/systemd/system/pdg-lan.service"
+    LAN_ACTIVE="${LAN_ACTIVE:-1}"
+    export LAN_CADDYFILE LAN_NFT_CONF LAN_UNIT LAN_ACTIVE
+    # shellcheck source=/dev/null
+    source "$C"
+    eval "$1" )
+}
+# `grep -c` 无匹配时**既打印 0 又返回非零**, 写成 `grep -c … || echo 0` 会得到 "0\n0" ——
+# 于是 `[[ "$(restarts)" == 0 ]]` 恒假, 每一格都红得莫名其妙。(这一版就先踩了一次。)
+restarts(){ grep -c '^restart pdg-lan' "$WORK/calls.log" 2>/dev/null; true; }
+nftloads(){ grep -c '^nft -f' "$WORK/calls.log" 2>/dev/null; true; }
+
+C="$(mkclosure)"
+seed
+
+echo "══ 1. 产物没变 → 不重启 ══"
+: > "$WORK/calls.log"
+D="$(run '_lan_artifacts_digest')"
+[[ -n "$D" ]] && ok "算得出产物指纹(实得 ${D:0:12}…)" || bad "指纹是空的 —— 后面几格不作数"
+: > "$WORK/calls.log"
+run "_lan_apply_proxy '$D'" >/dev/null
+[[ "$(restarts)" == 0 ]] && ok "指纹相同时一次都没重启" || bad "还是重启了 $(restarts) 次"
+
+echo
+echo "══ 2. 跳过重启时, 内核白名单仍要补回去 ══"
+# 白名单是靠 unit 的 ExecStartPre 进内核的。跳过重启 = 跳过那一步, 所以这条路上必须
+# 自己把那张表加载回去 —— 否则"少一次重启"换来的是一个能连内网任意地址的窗口。
+[[ "$(nftloads)" -ge 1 ]] && ok "跳过重启时调了 nft -f 补白名单" || bad "既没重启也没补白名单 —— 那是个安全窗口"
+
+echo
+echo "══ 3. 产物变了 → 照常重启 ══"
+: > "$WORK/calls.log"
+printf 'caddy conf v2\n' > "$WORK/etc/pdg-lan/caddy.conf"
+run "_lan_apply_proxy '$D'" >/dev/null
+[[ "$(restarts)" == 1 ]] && ok "指纹变了就重启(恰好一次)" || bad "该重启却重启了 $(restarts) 次"
+
+echo
+echo "══ 4. 不传指纹 → 保持原行为(无条件重启)══"
+# 老调用点不传参数。它们的语义是"我不知道变没变", 那时**必须**重启 —— 默认值只能偏保守。
+: > "$WORK/calls.log"
+run '_lan_apply_proxy' >/dev/null
+[[ "$(restarts)" == 1 ]] && ok "不传指纹时仍然重启" || bad "不传指纹时没重启 —— 老调用点会静默失效"
+
+echo
+echo "══ 5. 反代没在跑 → 什么都不做 ══"
+: > "$WORK/calls.log"
+LAN_ACTIVE=0 run '_lan_apply_proxy' >/dev/null
+[[ "$(restarts)" == 0 ]] && ok "反代没在跑时不重启" || bad "反代没跑却重启了"
+[[ "$(nftloads)" == 0 ]] && ok "反代没在跑时也不加载白名单(那张表本来就不该存在)" || bad "反代没跑却加载了白名单"
+
+echo
+echo "══ 6. 指纹必须覆盖全部三个派生产物 ══"
+# 少算一个, 那个产物变了就不会重启 —— 而"配置变了进程没跟上"正是本项目反复出事的形态。
+for f in "$WORK/etc/pdg-lan/caddy.conf" "$WORK/etc/nftables-pdg-lan.conf" "$WORK/etc/systemd/system/pdg-lan.service"; do
+  before="$(run '_lan_artifacts_digest')"
+  printf 'mutated %s\n' "$RANDOM" >> "$f"
+  after="$(run '_lan_artifacts_digest')"
+  [[ "$before" != "$after" ]] && ok "指纹跟着 $(basename "$f") 变" || bad "改了 $(basename "$f") 指纹却没变"
+done
+
+echo
+echo "══ 7. 缺文件不能等于「没变」══"
+# 产物被删掉时指纹若与"内容为空"或与上一次相同, 就会跳过重启 —— 而那时反代其实该被拉起来。
+before="$(run '_lan_artifacts_digest')"
+rm -f "$WORK/etc/pdg-lan/caddy.conf"
+after="$(run '_lan_artifacts_digest')"
+[[ "$before" != "$after" ]] && ok "产物被删之后指纹也变了" || bad "删掉产物指纹没变 —— 会被当成「没变」而跳过重启"
+
+echo
+echo "══ 8. 指纹算不出来时必须落到「重启」那一边 ══"
+# 文件在但读不到时 sha256sum 只吐空串。若照单收下, 两份**内容不同**的产物会得到同一个
+# 指纹 —— "没变"成立、重启被跳过, 而磁盘上其实已经换了一份。算不出来 = 不知道, 而不知道
+# 只能落到重启那边。
+printf 'caddy conf v3\n' > "$WORK/etc/pdg-lan/caddy.conf"
+D8="$(run '_lan_artifacts_digest')"
+[[ -n "$D8" ]] && ok "正常情况下算得出指纹" || bad "基线指纹就是空的, 这一格不作数"
+chmod 000 "$WORK/etc/pdg-lan/caddy.conf"
+if [[ -r "$WORK/etc/pdg-lan/caddy.conf" ]]; then
+  ok "(跳过: 这个环境下 chmod 000 仍可读 —— 多半是 root, 无法构造不可读)"
+  ok "(同上)"
+else
+  D8b="$(run '_lan_artifacts_digest')"
+  [[ -z "$D8b" ]] && ok "读不到产物时指纹为空(= 不知道)" || bad "读不到却给出了指纹: $D8b"
+  : > "$WORK/calls.log"
+  run "_lan_apply_proxy '$D8'" >/dev/null
+  [[ "$(restarts)" == 1 ]] && ok "指纹算不出来时照常重启" || bad "指纹算不出来却跳过了重启"
+fi
+chmod 644 "$WORK/etc/pdg-lan/caddy.conf"
+
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail > 0 ? 1 : 0 ))

--- a/tests/test-ratelimit-judgement.py
+++ b/tests/test-ratelimit-judgement.py
@@ -127,6 +127,32 @@ poisoned_bad = LINE_RE.sub("", poisoned)
 lvl2, _ = verdict(poisoned_bad)
 (ok if lvl2 == "warn" else bad)("同样有注释但判据真缺失时仍然 warn(实得 %s)" % lvl2)
 
+print()
+print("══ 5. 判据的期望值必须挨着用它的那个函数 ══")
+# `_RL_WARN` / `_RL_WANT` 的唯一消费者就是 check_mosdns_ratelimit。它们曾经被隔在 200 行
+# 开外(v1.10.16 把 check_lan_proxy_routes 插在了中间)—— 行为没受影响, 但改判据的人得先
+# 找到它们, 而"找不到就照着记忆改"正是判据悄悄漂掉的起点(这一版修的那条假警告就是这么来的)。
+_src = (ROOT / "deploy/bot/checks.py").read_text(encoding="utf-8").splitlines()
+_pos = {}
+for _i, _l in enumerate(_src, 1):
+    if _l.startswith("_RL_WARN =") and "warn" not in _pos:
+        _pos["warn"] = _i
+    if _l.startswith("_RL_WANT =") and "want" not in _pos:
+        _pos["want"] = _i
+    if _l.startswith("def check_mosdns_ratelimit(") and "fn" not in _pos:
+        _pos["fn"] = _i
+(ok if len(_pos) == 3 else bad)("三处都找得到(实得 %r)" % _pos)
+if len(_pos) == 3:
+    _gap = max(_pos["fn"] - _pos["warn"], _pos["fn"] - _pos["want"])
+    (ok if 0 < _gap <= 20 else
+     bad)("常量就在函数上方 20 行内(实得相隔 %d 行 —— 中间又被插进别的东西了)" % _gap)
+    # 反面: 它们**必须**在函数之前(不能被挪到后面, 那样 import 时就 NameError)
+    (ok if _pos["warn"] < _pos["fn"] and _pos["want"] < _pos["fn"] else
+     bad)("常量定义在函数之前")
+# 还有一条更要紧的: 别处不许再出现第二份同名期望值
+_dups = [i for i, l in enumerate(_src, 1) if l.startswith("_RL_WANT =")]
+(ok if len(_dups) == 1 else bad)("_RL_WANT 只有一处定义(实得 %r)" % _dups)
+
 print("-" * 62)
 print("test-ratelimit-judgement.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
 sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-rescue-lifecycle.sh
+++ b/tests/test-rescue-lifecycle.sh
@@ -123,6 +123,10 @@ N
             migrate_rescue_plane; do
     sed -n "/^${fn}(){/,/^}/p" "$ROOT/deploy/bot/pdg.sh"
   done
+  # 常量也要跟着抽: _lan_nft_reapply 现在从 $LAN_NFT_CONF 读路径(以前写死在函数体里, 被
+  # 下面那条 sed 顺手改掉了)。`set -u` 下漏一个就是 unbound variable, 而它半途死掉的表现
+  # 与"漏抽函数"一模一样 —— 报出来的是"防火墙放行失败", 看起来像救援平面自己的缺陷。
+  grep -E '^LAN_NFT_CONF=' "$ROOT/deploy/bot/pdg.sh"
 } > "$WORK/fns.sh"
 
   # _nft_apply_main / _lan_nft_reapply: 救援平面的放行走它们(主规则加载完顺带把内网面板的
@@ -131,7 +135,7 @@ N
   # 救援平面自己的缺陷。下面那条 sed 会一并把这两个函数里的默认路径也指到沙盒。
 
 # 生产代码读死 /etc/nftables.conf 与 /opt/pdg-bot —— 沙盒里把它们指到 BOX
-sed -i "s#/etc/nftables.conf#$BOX/etc/nftables.conf#g; s#/opt/pdg-bot#$BOX/opt/pdg-bot#g" "$WORK/fns.sh"
+sed -i "s#/etc/nftables-pdg-lan.conf#$BOX/etc/nftables-pdg-lan.conf#g; s#/etc/nftables.conf#$BOX/etc/nftables.conf#g; s#/opt/pdg-bot#$BOX/opt/pdg-bot#g" "$WORK/fns.sh"
 
 run(){ bash -c "source '$WORK/fns.sh' 2>/dev/null; $1" 2>&1; }
 


### PR DESCRIPTION
HANDOFF 里剩下的三条小收尾,合成一个 PR —— 因为第 ① 条的后续修正落在最后,拆开合会让中间态的 `main` 是红的。

## ① LAN 产物没变就别重启反代

`_lan_apply_proxy` 无条件 `systemctl restart pdg-lan`。而 LAN 的三个派生产物在产物层**已经是逐字节幂等**的 —— 于是每一次 `pdg update`、每一次面板同步、每一次回滚收敛,都为一份一个字节都没变的配置断一次反代。手机上正开着的面板会掉一次,而这类重启没有任何事情能从中获益。

本项目在别处早就守着同一条规矩(去广告是"产物真变才重启",恢复是"动作从这次内容确实变了的目标推出来"),这里是唯一的例外。

新增 `_lan_artifacts_digest`(三个产物的联合指纹),`_lan_apply_proxy` 接一个可选的"改动前指纹"。三条边界:

- 跳过重启时走一遍 `_lan_nft_reapply` —— 出站白名单靠 unit 的 `ExecStartPre` 进内核,不补的话"少一次重启"换来的是**一个反代能连内网任意地址的窗口**
- 不传指纹 = "不知道变没变" → 无条件重启。静默地少一次重启,比多一次重启危险得多
- 指纹**算不出来就整个作废**。文件在但读不到时 `sha256sum` 只吐空串,照单收下的话两份内容不同的产物会得到同一个指纹 —— "没变"成立、重启被跳过,而磁盘上其实已经换了一份

⚠️ 这条路径**至今没在真机上触发过**(jp/jp2 两轮升级都走正常路径,`_lan_rollback_converge` 只在 rollback 路径上跑)。有测试覆盖,但线上验证仍缺。

### 顺带修掉一个硬编码 —— 而且是**容器抓到、本机抓不到**的

`_lan_nft_reapply` 把 `/etc/nftables-pdg-lan.conf` 写死在函数体里。本机恰好有这个文件,所以本地全绿;容器里没有 → 函数走"文件不存在"早退 → 上面那格"跳过重启时要补白名单"**在本机是假绿**。

改成读 `$LAN_NFT_CONF` 之后,**四支抽了这个函数的测试里有一支当场红了**(`test-ios-profile-ux.py` 49/0 → 47/2):`set -u` 下常量未定义 = unbound variable,函数半途死掉,表现是"没还原防火墙" —— 与"漏抽函数"一模一样,而失败信息指向别处。

这正好说明了写死路径为什么该改:**它让那些夹具碰巧能用,依赖关系从没被写下来过。** 三支各自补上常量(`test-lan-nft-chokepoint.sh` 不用改,它只 grep 源码不执行)。

## ② 限流判据的期望值挪到它唯一的消费者旁边

`_RL_WARN` / `_RL_WANT` 被隔在 200 行开外 —— v1.10.16 把 `check_lan_proxy_routes` 插在了中间。

纯组织性问题,**函数体 sha256 逐字节未变**(`28494b694d32e396`,移动前后一致)。但它有代价:改判据的人得先找到期望值,而"找不到就照着记忆改"正是判据悄悄漂掉的起点 —— v1.11.2 修的那条假警告就是这么来的。

加了守卫:常量必须在函数上方 20 行内、必须在函数之前、`_RL_WANT` 只能有一处定义。

## ③ 功能测试成功路径也打印 mihomo 日志

`functional-test.sh` 只有失败路径 `cat mh.out`,而 `cleanup` 又 `rm -rf "$WORK"` —— 所有**绿的 run 里根本拿不到 mihomo 日志**。HANDOFF §9.12 那个坑就是这么来的:真出事时只能拿红 run 去猜"正常的时候它是什么样"。

**本轮就撞过一个现成例子**:PR #40 的 `functional` 抖动,错因 `Start Redir server error: operation not permitted` 只在红 run 里看得到 —— 要判断它是不是常态,得有绿 run 的日志去比。

`dump_mihomo` 收口成唯一入口,在 `cleanup` 里调(**成功、失败、中断**三条路都覆盖),且必须排在 `rm -rf` 之前。幂等;空日志安静退出;截断到最后 200 行并**把真实总行数与"已截断"说出来** —— 不说就是在撒谎,读的人以为看到的是全部,于是"日志里没有那条错误"成了一个错误的结论。

## 验证

三个新/改测试文件,合计 43 格。负控逐条(每条都精确翻掉对应断言):

| 变异 | 结果 |
|---|---|
| 指纹相同也照样重启 | 12/2 |
| 跳过重启时不补白名单 | 13/1 |
| 指纹漏算 unit 文件 | 13/1 |
| 算不出指纹也照单收下 | 13/1 |
| 不传指纹时也跳过重启 | 13/1 |
| 常量挪回 200 行开外 | 16/1 |
| cleanup 不调 dump | 10/1 |
| 截断了但不说 | 10/2 |
| 去掉 dump 的幂等 | 11/1 |
| 失败路径退回裸 cat | 11/1 |

全量回归(容器内 201 个测试 vs `origin/main` 同载具基线):**失败集完全一致,零新增红灯**。

夹具上栽了一次并记下:`grep -c` 无匹配时**既打印 0 又返回非零**,写成 `grep -c … || echo 0` 会得到 `"0\n0"`,于是 `[[ "$(restarts)" == 0 ]]` 恒假。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
