### PR TITLE
feat(bot): Telegram 里管理去广告规则集

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,9 @@ jobs:
       - name: "Telegram 内联按钮管理去广告规则: 闭集 callback / 跨用户隔离 / 只经 argv 调 CLI"
         run: python3 tests/test-bot-adblock-inline.py
 
+      - name: "Telegram 里能管规则集(源)并让它生效: 下标按钮 / 点击时重新对照 / 慢操作走后台"
+        run: python3 tests/test-bot-adblock-sources.py
+
       - name: "去广告写入口并发闭包: 五个写命令共用全局锁 / 锁忙零副作用 / status 严格只读"
         run: bash tests/test-adblock-lock-closure.sh
 

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -216,10 +216,19 @@ MENU = {"inline_keyboard": [
 # 改变整台网关的解析行为并重启 mosdns, 属于要人坐在终端前确认的操作, 不该是手机上一次误触。
 ADBLOCK_MENU = {"inline_keyboard": [
     [{"text": "📊 当前状态", "callback_data": "adblock:status"}],
+    # 启用/停用与规则集管理以前只有 CLI 有。少了它们, Telegram 这边就是**半个功能**:
+    # 用户能往一份永远不会被下载的表里加单条域名, 却没有任何一条路把新表用起来。
+    [{"text": "🟢 启用", "callback_data": "adblock:enable"},
+     {"text": "🔴 停用", "callback_data": "adblock:disable"}],
     [{"text": "➕ 添加阻断规则", "callback_data": "adblock:add"},
      {"text": "➖ 删除阻断规则", "callback_data": "adblock:del"}],
     [{"text": "🔎 查询域名", "callback_data": "adblock:check"}],
+    [{"text": "📚 规则集(第三方源)", "callback_data": "adblock:src"}],
     [{"text": "↩️ 返回", "callback_data": "adblock:back"}],
+]}
+ADBLOCK_SRC_BACK = {"inline_keyboard": [
+    [{"text": "⬅️ 返回规则集", "callback_data": "adblock:src"}],
+    [{"text": "🛡 去广告菜单", "callback_data": "adblock:menu"}],
 ]}
 ADBLOCK_BACK = {"inline_keyboard": [[{"text": "⬅️ 返回去广告", "callback_data": "adblock:menu"}],
                                     [{"text": "🏠 主菜单", "callback_data": "menu"}]]}
@@ -4401,6 +4410,44 @@ def _adblock_bulk_reply(d):
     return "\n".join(parts)
 
 
+def _adblock_sources():
+    """当前生效的源与内置默认。读不到就返回两个空列表 —— 不编。"""
+    r = sh([PDG_CLI, "adblock", "source", "list", "--json"])
+    for line in reversed((r.stdout or "").strip().splitlines()):
+        try:
+            d = json.loads(line)
+        except Exception:                                # noqa: BLE001
+            continue
+        return (d.get("sources") or [], d.get("defaults") or [])
+    return ([], [])
+
+
+def _adblock_src_menu_kb():
+    return {"inline_keyboard": [
+        [{"text": "➕ 添加规则集", "callback_data": "adblock:srcadd"},
+         {"text": "➖ 删除规则集", "callback_data": "adblock:srcdel"}],
+        [{"text": "↩️ 恢复内置默认", "callback_data": "adblock:srcreset"}],
+        [{"text": "🔄 立即更新(下载并生效)", "callback_data": "adblock:srcupd"}],
+        [{"text": "⬅️ 返回去广告", "callback_data": "adblock:menu"}],
+    ]}
+
+
+def _adblock_src_text():
+    """子菜单正文顺带把当前源列出来 —— 不用再点一次才知道现在是什么。"""
+    cur, dft = _adblock_sources()
+    if not cur:
+        return "📚 <b>规则集</b>\n\n(读不到当前源列表)"
+    same = cur == dft
+    lines = ["📚 <b>规则集(第三方源)</b>", ""]
+    lines.append("当前生效%s:" % ("(内置默认，未自定义)" if same else ""))
+    lines += ["  • <code>%s</code>" % html.escape(u) for u in cur]
+    if not same and dft:
+        lines += ["", "内置默认(可用「恢复内置默认」回到这里):"]
+        lines += ["  • <code>%s</code>" % html.escape(u) for u in dft]
+    lines += ["", "改完记得点「🔄 立即更新」才会真正下载并生效。"]
+    return "\n".join(lines)
+
+
 def _adblock_pending(chat, uid, kind):
     """建立待输入状态。值里带发起者 uid —— 状态本身是 chat 键(沿用既有约定),
     但**谁发起的就只有谁能完成**, 群里旁人发的下一条不算数。"""
@@ -4411,7 +4458,24 @@ def handle_cb(chat, mid, data, uid=None):
     # ── 去广告(闭集 callback, 不接受任意动作名)────────────────────────────────
     if data.startswith("adblock:"):
         act = data.split(":", 1)[1]
-        if act not in ("menu", "status", "add", "del", "check", "cancel", "back"):
+        # 删除是"点按钮选一条", 按钮里放的是**下标** —— callback_data 只有 64 字节,
+        # URL 放不下。下标在**点的那一刻**重新对照当前列表: 渲染与点击之间列表可能被另一条
+        # 会话或 CLI 改过, 拿旧下标直接删等于删掉另一条。对不上就拒绝, 让用户重新进一次。
+        if act.startswith("srcdel:"):
+            state.pop(chat, None)
+            cur, _d = _adblock_sources()
+            raw = act.split(":", 1)[1]
+            if not raw.isdigit() or int(raw) >= len(cur):
+                edit(chat, mid, "这个列表已失效(源列表变过了)，请重新进一次「删除规则集」。",
+                     ADBLOCK_SRC_BACK); return
+            url = cur[int(raw)]
+            r = sh([PDG_CLI, "adblock", "source", "del", url])
+            good = r.returncode == 0
+            edit(chat, mid, ("✅ 已删除 <code>%s</code>\n\n点「🔄 立即更新」让改动生效。"
+                             if good else "❌ 删除失败：<code>%s</code>")
+                 % html.escape(url), ADBLOCK_SRC_BACK); return
+        if act not in ("menu", "status", "add", "del", "check", "cancel", "back",
+                       "enable", "disable", "src", "srcadd", "srcdel", "srcreset", "srcupd"):
             # 未知或过期的 adblock callback: fail-closed, 什么都不做, 也不留状态。
             state.pop(chat, None)
             edit(chat, mid, "这个操作已失效，请重新从菜单进入。", ADBLOCK_BACK); return
@@ -4420,6 +4484,50 @@ def handle_cb(chat, mid, data, uid=None):
             if act == "back":
                 edit(chat, mid, status_text(), MENU); return
             edit(chat, mid, "🛡 <b>DNS 去广告</b> — 选一项:", ADBLOCK_MENU); return
+        if act in ("enable", "disable"):
+            # 慢操作(要重编译, 可能重启 mosdns)—— 不能把 Bot 卡在这儿。
+            def _task(act=act, chat=chat, mid=mid):
+                r = sh([PDG_CLI, "adblock", act])
+                out = ((r.stdout or "") + (r.stderr or "")).strip()[-500:] or "(没有输出)"
+                edit(chat, mid, ("✅ 已%s。\n<pre>%s</pre>" if r.returncode == 0
+                                 else "❌ %s失败：\n<pre>%s</pre>")
+                     % ("启用" if act == "enable" else "停用", html.escape(out)), ADBLOCK_BACK)
+            edit(chat, mid, "处理中…（可能重启 DNS，几秒）", ADBLOCK_BACK)
+            run_bg(chat, _task); return
+        if act == "src":
+            state.pop(chat, None)
+            edit(chat, mid, _adblock_src_text(), _adblock_src_menu_kb()); return
+        if act == "srcadd":
+            _adblock_pending(chat, uid, "srcadd")
+            edit(chat, mid,
+                 "发一个规则集 URL（只接受 https、默认 443 端口、主机名是合法域名）。\n"
+                 "例：<code>https://gcore.jsdelivr.net/gh/…/adblockmosdns.txt</code>\n\n"
+                 "注意：配了自定义源就是<b>替换</b>内置默认，不是追加。\n/cancel 或按下面的按钮取消。",
+                 ADBLOCK_CANCEL); return
+        if act == "srcdel":
+            state.pop(chat, None)
+            cur, _d = _adblock_sources()
+            if not cur:
+                edit(chat, mid, "读不到当前源列表，未做任何改动。", ADBLOCK_SRC_BACK); return
+            rows = [[{"text": "➖ %s" % (u[:48] + ("…" if len(u) > 48 else "")),
+                      "callback_data": "adblock:srcdel:%d" % i}] for i, u in enumerate(cur)]
+            rows.append([{"text": "⬅️ 返回规则集", "callback_data": "adblock:src"}])
+            edit(chat, mid, "选一个要删除的规则集：", {"inline_keyboard": rows}); return
+        if act == "srcreset":
+            r = sh([PDG_CLI, "adblock", "source", "reset"])
+            edit(chat, mid, ("✅ 已恢复内置默认源。\n\n点「🔄 立即更新」让改动生效。"
+                             if r.returncode == 0 else "❌ 恢复失败。"),
+                 ADBLOCK_SRC_BACK); return
+        if act == "srcupd":
+            # 真下载 + 可能重启 mosdns, 是这一组里最慢的一步 —— 必须后台。
+            def _upd(chat=chat, mid=mid):
+                r = sh([PDG_CLI, "adblock", "update"])
+                out = ((r.stdout or "") + (r.stderr or "")).strip()[-800:] or "(没有输出)"
+                edit(chat, mid, ("✅ 规则表已更新。\n<pre>%s</pre>" if r.returncode == 0
+                                 else "❌ 更新失败（继续用上一份可用的表）：\n<pre>%s</pre>")
+                     % html.escape(out), ADBLOCK_SRC_BACK)
+            edit(chat, mid, "正在下载并编译规则表…（几十秒，可能重启 DNS）", ADBLOCK_SRC_BACK)
+            run_bg(chat, _upd); return
         if act == "status":
             r = sh([PDG_CLI, "adblock", "status"])
             out = (r.stdout or "").strip() or "(读不到状态)"
@@ -5059,6 +5167,16 @@ def handle_text(chat, text, mid=None, uid=None):
             r = sh([PDG_CLI, "adblock", "check", text])
             out = (r.stdout or "").strip() or "(没有输出)"
             send(chat, "🔎 <pre>" + html.escape(out) + "</pre>", ADBLOCK_BACK); return
+        if kind == "srcadd":
+            r = sh([PDG_CLI, "adblock", "source", "add", text.strip()])
+            out = ((r.stdout or "") + (r.stderr or "")).strip()[-400:]
+            if r.returncode == 0:
+                send(chat, "✅ 已添加规则集。\n点「🔄 立即更新」才会真正下载并生效。",
+                     ADBLOCK_SRC_BACK)
+            else:
+                send(chat, "❌ 没能添加：\n<pre>%s</pre>" % html.escape(out or "(没有输出)"),
+                     ADBLOCK_SRC_BACK)
+            return
         if kind in ("add", "del"):
             # 一条消息里可以给多个域名(换行或空格分隔)。批量走 CLI 的 rule-add-many ——
             # **不在这里循环调 N 次 rule-add**: 那只是把 N 次 mosdns 重启从用户手里搬进

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -6299,6 +6299,13 @@ sys.exit(0 if hit else 1)' "$_norm" "$ADB_USER_ALLOW"; then
       mod="$(_pdg_module adblock.py)" || return 1
       case "$_sub" in
         list)
+          # `--json` 给机器看(Telegram Bot 走这条): Bot **认字段不认措辞** —— 让它去解析
+          # 下面那段中文, 措辞一改 Bot 就瞎了。人看的那份保持原样, 一个字没动。
+          if [[ "$_url" == "--json" ]]; then
+            python3 "$mod" list-sources "$ADB_SOURCES" 2>/dev/null || {
+              echo '{"sources":[],"defaults":[]}'; return 1; }
+            return 0
+          fi
           python3 "$mod" list-sources "$ADB_SOURCES" 2>/dev/null | python3 -c 'import json,sys
 try: d=json.load(sys.stdin)
 except Exception: sys.exit("读不到源列表")
@@ -6353,7 +6360,7 @@ except Exception: print("")')"
           c_g "  ✅ 已回到内置默认源。"
           ;;
         *)
-          echo "用法: pdg adblock source <list|add <URL>|del <URL>|reset>"; return 1;;
+          echo "用法: pdg adblock source <list [--json]|add <URL>|del <URL>|reset>"; return 1;;
       esac
       ;;
     check)
@@ -6832,5 +6839,5 @@ case "${1:-menu}" in
   link)          shift || true; cmd_link "$@";;
   uninstall|rm)  shift || true; cmd_uninstall "$@";;
   rescue)        shift || true; cmd_rescue "$@";;
-  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|lan <status|list|check|routes|add|rm>|adblock <status|enable|disable|update|check <域名>|rule-add <域名>|rule-del <域名>|source <list|add <URL>|del <URL>|reset>>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
+  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|lan <status|list|check|routes|add|rm>|adblock <status|enable|disable|update|check <域名>|rule-add <域名>|rule-del <域名>|source <list [--json]|add <URL>|del <URL>|reset>>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
 esac

--- a/tests/test-bot-adblock-inline.py
+++ b/tests/test-bot-adblock-inline.py
@@ -148,8 +148,11 @@ want = ["当前状态", "添加", "删除", "查询", "返回"]
 missing = [w for w in want if not any(w in t for t, _ in menu)]
 (ok if not missing else bad)("五个按钮齐全(缺: %s)" % (missing or "无"))
 datas = {d for _, d in menu if d}
-CLOSED = {"adblock:menu", "adblock:status", "adblock:add", "adblock:del",
-          "adblock:check", "adblock:cancel", "adblock:back"}
+# 闭集要与 handle_cb 里那张白名单**同源** —— 两处手写会漂: 实现多一个动作而这里不知道,
+# 这一格就成了对旧世界的断言。直接从源码里把那张表抽出来。
+_wl = re.search(r'if act not in \(([^)]*)\)', SRC, re.S)
+CLOSED = {"adblock:" + m for m in re.findall(r'"([a-z]+)"', _wl.group(1))} if _wl else set()
+(ok if len(CLOSED) >= 7 else bad)("抽得到 handle_cb 的动作白名单(实得 %d 个)" % len(CLOSED))
 stray = {d for d in datas if d.startswith("adblock") and d not in CLOSED}
 (ok if not stray else bad)("callback_data 全在闭集内(越界: %s)" % (stray or "无"))
 (ok if all(len(d.encode()) <= 64 for d in datas) else bad)("callback_data 长度均 ≤64 字节")

--- a/tests/test-bot-adblock-sources.py
+++ b/tests/test-bot-adblock-sources.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Telegram 里必须能管**规则集**(第三方源), 而且管完能让它生效。
+
+现状是: Bot 的去广告菜单只有 状态 / 加规则 / 删规则 / 查域名 四项 —— **规则集加不了**,
+**去广告也启用不了、更新不了**。也就是说 v1.11.2 做的"第三方源可配"在 Telegram 里完全够
+不着: 用户看得到"去广告"这个菜单, 却没有任何一条路能把一份新表用起来。
+
+半个功能比没有更坏: 用户以为自己在管理去广告, 实际只能往一份**永远不会被下载**的表里加
+单条域名。
+
+这一支盯的是入口与边界, 不是源语义(那在 test-adblock-sources.sh):
+  · 菜单里真的有规则集入口, 且能走到 添加 / 删除 / 恢复默认 / 立即更新;
+  · callback 仍是**闭集**, 未知动作 fail-closed;
+  · 删除不靠让用户粘长 URL —— 列表按钮点选, 而按钮里放的是**下标**(callback_data 只有
+    64 字节, URL 放不下), 下标在点的那一刻重新对照当前列表, 对不上就拒绝;
+  · 谁发起的输入只有谁能完成(沿用既有约定);
+  · "立即更新"是慢操作(要下载、可能重启 mosdns), 必须走后台, 不能把 Bot 卡住。
+"""
+import importlib.util as u
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
+import tmpguard          # noqa: E402
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+ROOTFS = tmpguard.mkdtemp(prefix="pdg-bot-adblock.")
+os.makedirs(os.path.join(ROOTFS, "etc", "privdns-gateway"), exist_ok=True)
+os.makedirs(os.path.join(ROOTFS, "run"), exist_ok=True)
+PROFILE = os.path.join(ROOTFS, "etc", "privdns-gateway", "profile.env")
+with open(PROFILE, "w", encoding="utf-8") as _f:
+    _f.write("PDG_INTERNAL_CIDR=127.0.0.0/8\nPDG_SERVER_IP=127.0.0.1\n")
+os.environ["PDG_PROFILE_ENV"] = PROFILE
+os.environ["PDG_TX_FSROOT"] = ROOTFS
+os.environ["PDG_LOCKFILE"] = os.path.join(ROOTFS, "run", "privdns-gateway.lock")
+os.environ.setdefault("PDG_BOT_ALLOWED", "1")
+sys.path.insert(0, str(ROOT / "deploy/bot"))
+
+spec = u.spec_from_file_location("pdg_bot", str(ROOT / "deploy/bot/pdg-bot.py"))
+bot = u.module_from_spec(spec)
+spec.loader.exec_module(bot)
+SRC = (ROOT / "deploy/bot/pdg-bot.py").read_text(encoding="utf-8")
+
+EDITS, SENDS, PLAIN, POSTS, SHELL = [], [], [], [], []
+CLI_RESULT = {"rc": 0, "out": '{"result":"saved_inactive","change":"added","restarted":false,"overridden_by_allow":false}'}
+
+
+def setup():
+    for x in (EDITS, SENDS, PLAIN, POSTS, SHELL):
+        x.clear()
+    bot.state.clear()
+    bot.edit = lambda chat, mid, text, kb=None: EDITS.append((text, kb))
+    bot.edit_only = lambda chat, mid, text, kb=None: (EDITS.append((text, kb)) or True)
+    # 生产的 send 是 `reply_markup = kb or MENU` —— mock 不照做的话, 主菜单那一格
+    # 看到的永远是 None, 判据就成了对 mock 的断言。
+    bot.send = lambda chat, text, kb=None: SENDS.append((text, kb or bot.MENU))
+    bot.send_plain = lambda chat, text: PLAIN.append(text)
+    bot.answer_cb_async = lambda *a, **k: None
+    bot.status_text = lambda: "(主菜单)"
+    bot.post = lambda method, payload=None, **kw: (POSTS.append((method, payload)) or {"ok": True})
+
+    def fake_sh(cmd):
+        SHELL.append(list(cmd))
+        return type("R", (), {"returncode": CLI_RESULT["rc"],
+                              "stdout": CLI_RESULT["out"], "stderr": ""})()
+    bot.sh = fake_sh
+
+
+def all_text():
+    return "\n".join([t for t, _ in EDITS] + [t for t, _ in SENDS] + list(PLAIN))
+
+
+def all_buttons(kbs=None):
+    out = []
+    src = kbs if kbs is not None else [kb for _, kb in EDITS + SENDS if kb]
+    for kb in src:
+        rows = kb.get("inline_keyboard", []) if isinstance(kb, dict) else (kb or [])
+        for row in rows:
+            for b in row:
+                out.append((b.get("text", ""), b.get("callback_data", "")))
+    return out
+
+
+def _guard(fn, what):
+    """handler 抛异常时记成**具名失败**, 而不是让整支测试崩掉。
+
+    崩掉的代价不只是少几条断言: 负控靠"具名失败集合有没有新增"判一格有没有牙, 而崩溃
+    产生的是 traceback 不是 [FAIL] 行 —— 于是"把守卫摘掉"这种改坏反而显示成 0 条转红,
+    看上去像判据没牙, 实际是判据根本没跑到。
+    """
+    try:
+        return fn()
+    except Exception as e:  # noqa: BLE001
+        bad("%s 抛异常 %s: %s" % (what, type(e).__name__, str(e)[:60]))
+        return None
+
+
+def cb(data, chat=1, uid=1):
+    """调 handle_cb。新签名要能收 uid; 旧签名收不了就说清楚, 不静默降级。"""
+    def go():
+        try:
+            return bot.handle_cb(chat, 2, data, uid)
+        except TypeError:
+            return bot.handle_cb(chat, 2, data)
+    return _guard(go, "handle_cb(%s)" % data)
+
+
+def txt(text, chat=1, uid=1):
+    def go():
+        try:
+            return bot.handle_text(chat, text, 3, uid)
+        except TypeError:
+            return bot.handle_text(chat, text, 3)
+    return _guard(go, "handle_text")
+
+
+SRC_JSON = ('{"sources": ["https://a.example.com/l.txt", "https://b.example.com/l.txt"], '
+            '"defaults": ["https://anti-ad.net/domains.txt"]}')
+
+
+def buttons_of(kb):
+    return [(b.get("text", ""), b.get("callback_data", "")) for row in
+            (kb or {}).get("inline_keyboard", []) for b in row]
+
+
+print("══ 1. 去广告菜单里有规则集入口 ══")
+setup()
+cb("adblock:menu")
+btns = all_buttons()
+(ok if any(d == "adblock:src" for _, d in btns) else
+ bad)("菜单里有「规则集」按钮(实得 %r)" % [d for _, d in btns])
+(ok if any("规则集" in t for t, _ in btns) else bad)("按钮文案里出现「规则集」")
+
+print()
+print("══ 2. 启用/停用/立即更新也得够得着 ══")
+# 加了源却没法让它生效 = 半个功能。这三件事缺任何一件, 用户都走不完"换一份表"这条路。
+for want, label in (("adblock:enable", "启用"), ("adblock:disable", "停用")):
+    (ok if any(d == want for _, d in btns) else bad)("菜单里有「%s」(%s)" % (label, want))
+
+print()
+print("══ 3. 规则集子菜单: 四件事都在 ══")
+setup()
+CLI_RESULT["out"] = SRC_JSON
+cb("adblock:src")
+sb = all_buttons()
+for want, label in (("adblock:srcadd", "添加"), ("adblock:srcdel", "删除"),
+                    ("adblock:srcreset", "恢复默认"), ("adblock:srcupd", "立即更新")):
+    (ok if any(d == want for _, d in sb) else bad)("子菜单里有「%s」(%s)" % (label, want))
+(ok if any("a.example.com" in t for t in [x for x, _ in EDITS + SENDS]) else
+ bad)("子菜单顺带把当前生效的源列出来(不用再点一次才知道现在是什么)")
+
+print()
+print("══ 4. 添加: 走文本输入, 且只有发起者能完成 ══")
+setup()
+cb("adblock:srcadd")
+(ok if bot.state.get(1) else bad)("建立了待输入状态(实得 %r)" % bot.state.get(1))
+SHELL.clear()
+txt("https://new.example.com/list.txt", uid=99)          # 旁人
+(ok if not SHELL else bad)("群里旁人发的不算数(实得调用 %r)" % SHELL)
+txt("https://new.example.com/list.txt", uid=1)           # 发起者
+(ok if any("source" in c and "add" in c for c in SHELL) else
+ bad)("发起者发的真的调了 source add(实得 %r)" % SHELL)
+(ok if any("https://new.example.com/list.txt" in c for c in SHELL) else
+ bad)("URL 原样传给 CLI")
+
+print()
+print("══ 5. 删除: 点按钮选, 不让用户粘长 URL ══")
+setup()
+CLI_RESULT["out"] = SRC_JSON
+cb("adblock:srcdel")
+db = all_buttons()
+picks = [d for _, d in db if d.startswith("adblock:srcdel:")]
+(ok if len(picks) == 2 else bad)("两个源各出一个按钮(实得 %r)" % picks)
+# callback_data 只有 64 字节 —— 放 URL 迟早溢出, 必须放下标
+# `all([])` 恒真 —— 没渲出按钮时这两条会假绿, 所以先要求 picks 非空。
+(ok if picks and all(len(d.encode()) <= 64 for _, d in db) else
+ bad)("每个 callback_data 都在 64 字节内(实得 %r)" % [(d, len(d.encode())) for _, d in db])
+(ok if picks and all(d.split(":")[-1].isdigit() for d in picks) else
+ bad)("按钮里放的是下标而不是 URL(实得 %r)" % picks)
+
+print()
+print("══ 6. 下标必须在点的那一刻重新对照 ══")
+# 列表在渲染与点击之间可能变了(另一条会话删过、CLI 改过)。拿旧下标去删 = 删掉另一条。
+# 先证明**正常下标确实会删** —— 否则"越界不删"在功能压根没实现时也成立(空断言)。
+setup()
+CLI_RESULT["out"] = '{"sources": ["https://only-one.example.com/l.txt"], "defaults": []}'
+SHELL.clear()
+cb("adblock:srcdel:0")
+_okdel = [c for c in SHELL if "source" in c and "del" in c]
+(ok if _okdel else bad)("合法下标真的执行了删除(实得 %r)" % SHELL)
+(ok if any("only-one.example.com" in " ".join(c) for c in _okdel) else
+ bad)("删的是下标对应的那一条 URL(实得 %r)" % _okdel)
+setup()
+CLI_RESULT["out"] = '{"sources": ["https://only-one.example.com/l.txt"], "defaults": []}'
+SHELL.clear()
+cb("adblock:srcdel:5")                                   # 越界
+_delcalls = [c for c in SHELL if "source" in c and "del" in c]
+(ok if not _delcalls else bad)("下标越界时不执行删除(实得 %r)" % _delcalls)
+(ok if any("失效" in t or "已变" in t or "重新" in t for t in [x for x, _ in EDITS + SENDS]) else
+ bad)("越界时说清楚要重新进一次, 而不是静默无反应")
+
+print()
+print("══ 7. 立即更新是慢操作, 必须走后台 ══")
+setup()
+BG = []
+_orig_bg = getattr(bot, "run_bg", None)
+bot.run_bg = lambda chat, fn, *a, **k: BG.append(fn)
+cb("adblock:srcupd")
+(ok if BG else bad)("更新走了 run_bg(不能把 Bot 卡在下载上)")
+if _orig_bg is not None:
+    bot.run_bg = _orig_bg
+
+print()
+print("══ 8. callback 仍是闭集 ══")
+setup()
+cb("adblock:srcdrop")                                    # 编的
+(ok if any("失效" in t for t in [x for x, _ in EDITS + SENDS]) else
+ bad)("未知 adblock 动作 fail-closed")
+(ok if not bot.state.get(1) else bad)("fail-closed 时不留状态")
+
+print()
+print("══ 9. 不新增 slash command ══")
+# 入口是内联按钮。BotFather 的命令表多一条, 就多一条要维护、要文档化的表面。
+SRC = (ROOT / "deploy/bot/pdg-bot.py").read_text(encoding="utf-8")
+(ok if "/adblock" not in SRC.replace("/adblock-sources", "") or
+       SRC.count('"command": "adblock') == 0 else
+ bad)("没有为规则集新增 slash command")
+
+print()
+print("══ 10. Bot 调的那条 CLI 必须真的存在 ══")
+# 上面几格里 sh 是打桩的 —— 无论传什么都回 JSON。**那验不出 CLI 到底认不认这个参数。**
+# 这一格拿 Bot 真正会发的 argv 去对 pdg.sh: Bot 不许解析中文文案(它认字段不认措辞),
+# 所以 `source list` 必须有一个吐 JSON 的形态。
+import subprocess as _sp                                     # noqa: E402
+import tempfile as _tf                                       # noqa: E402
+
+setup()
+CLI_RESULT["out"] = SRC_JSON
+SHELL.clear()
+cb("adblock:src")
+_listcalls = [c for c in SHELL if "source" in c and "list" in c]
+(ok if _listcalls else bad)("子菜单确实调了 source list(实得 %r)" % SHELL)
+_argv = _listcalls[0] if _listcalls else []
+
+# 真跑一次: 把 Bot 那串 argv(去掉 PDG_CLI 前缀)喂给真 pdg.sh 的 cmd_adblock
+_W = tmpguard.mkdtemp(prefix="pdg-bot-srccli.")
+os.makedirs(os.path.join(_W, "etc/privdns-gateway"), exist_ok=True)
+open(os.path.join(_W, "etc/privdns-gateway/adblock-sources.txt"), "w",
+     encoding="utf-8").write("https://real.example.com/l.txt\n")
+_closure = os.path.join(_W, "c.sh")
+_pdgsh = str(ROOT / "deploy/bot/pdg.sh")
+with open(_closure, "w", encoding="utf-8") as f:
+    f.write("set -uo pipefail\n")
+    for fn in ("c_g", "c_y", "_pdg_module", "cmd_adblock"):
+        f.write(_sp.run(["sed", "-n", "/^%s()/,/^}/p" % fn, _pdgsh],
+                        capture_output=True, text=True).stdout + "\n")
+    # 顶层常量: **沙箱给了就用沙箱的**。照抄 `VAR=值` 会把 ADB_SOURCES 盖回 /etc 下的生产
+    # 路径, 于是这一格读的根本不是夹具那份文件 —— 而表现是"没有输出", 看不出根因在这里。
+    # 数组赋值(`VAR=(`)跳过: 逐行改写会把多行数组切碎, 整个闭包从那里语法错。
+    _consts = _sp.run(["grep", "-E", "^[A-Z_][A-Z0-9_]*=", _pdgsh],
+                      capture_output=True, text=True).stdout.splitlines()
+    for _c in _consts:
+        _name = _c.split("=", 1)[0]
+        if _c.startswith(_name + "=("):
+            continue
+        f.write('%s="${%s:-}"; [[ -z "${%s}" ]] && %s\n'
+                % (_name, _name, _name, _c))
+    f.write('\nneed_root(){ :; }\n_lock(){ :; }\nPDG_LOCKED=""\n')
+# 闭包必须能整份解析 —— 坏了的话下面拿到的是空输出, 而空输出看起来像"CLI 不认这个参数"。
+_syn = _sp.run(["bash", "-n", _closure], capture_output=True, text=True)
+(ok if _syn.returncode == 0 else
+ bad)("闭包语法完好(实得 %r)" % (_syn.stderr or "")[:120])
+# argv 形如 [pdg, adblock, source, list, --json]。闭包里直接调的是 cmd_adblock,
+# 所以要剥掉前两段 —— 少剥一段的话 "adblock" 会被当成子命令, 打出用法串。
+(ok if len(_argv) >= 2 and _argv[1] == "adblock" else
+ bad)("argv 形态与预期一致(实得 %r)" % (_argv,))
+_sub = list(_argv[2:]) if len(_argv) >= 2 else []
+_r = _sp.run(["bash", "-c", "source %s; cmd_adblock %s" % (_closure, " ".join(_sub))],
+             capture_output=True, text=True,
+             env=dict(os.environ, REPO_DIR=str(ROOT),
+                      ADB_SOURCES=os.path.join(_W, "etc/privdns-gateway/adblock-sources.txt")))
+_out = (_r.stdout or "").strip()
+_parsed = None
+for _l in reversed(_out.splitlines()):
+    try:
+        _parsed = json.loads(_l); break
+    except Exception:                                        # noqa: BLE001
+        continue
+(ok if _parsed is not None else
+ bad)("真 CLI 对这串 argv 吐得出 JSON(argv=%r 实得 %r)" % (_sub, _out[:160]))
+(ok if _parsed and "real.example.com" in str(_parsed.get("sources")) else
+ bad)("吐出来的就是那份源文件的内容(实得 %r)" % (_parsed,))
+
+print("-" * 62)
+print("test-bot-adblock-sources.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
## 缺口

Bot 的去广告菜单只有 状态 / 加规则 / 删规则 / 查域名 四项 —— **规则集加不了,去广告也启用不了、更新不了**。

也就是说 v1.11.2 做的「第三方源可配」在 Telegram 里完全够不着:用户看得到「去广告」这个菜单,却没有任何一条路能把一份新表用起来。**半个功能比没有更坏** —— 用户以为自己在管理去广告,实际只能往一份永远不会被下载的表里加单条域名。

## 新菜单

```
📊 当前状态
🟢 启用            🔴 停用              ← 新
➕ 添加阻断规则     ➖ 删除阻断规则
🔎 查询域名
📚 规则集(第三方源)                     ← 新
↩️ 返回
```

规则集子菜单:列出当前源 + `➕添加` / `➖删除` / `↩️恢复内置默认` / `🔄立即更新(下载并生效)`。

**为什么把启用/更新一起做进来**:只加「添加规则集」是半个功能 —— 加完没有任何一条路能让它生效。这三件事缺任何一件,「换一份表」这条路都走不完。

## 几处刻意的设计

**删除不让用户粘长 URL** —— 列出当前源,每条一个按钮。按钮里放的是**下标**(callback_data 只有 64 字节,URL 放不下)。下标在**点的那一刻**重新对照当前列表:渲染与点击之间列表可能被另一条会话或 CLI 改过,拿旧下标直接删等于删掉另一条。对不上就拒绝并让用户重新进一次。

**慢操作走后台** —— 更新要真下载、可能重启 mosdns,同步执行会把 Bot 卡住。

**子菜单正文直接列出当前源**,并明说两件最容易误解的事:改完要点「立即更新」才生效;自定义源是**替换**内置默认,不是追加。

## CLI 加了 `source list --json`

Bot **认字段不认措辞** —— 让它去解析那段中文,措辞一改 Bot 就瞎了。人看的那份输出一个字没动。

## 写这支时抓到一个夹具形状的假绿

测试里 `sh` 是打桩的,无论传什么都回 JSON —— 于是**从没验过 CLI 到底认不认 `--json`**(而当时它不认)。补了一格拿 Bot 真正会发的 argv 去跑真 `pdg.sh`,红灯当场出来。

那一格自己又踩了常量注入的老坑:照抄 `VAR=值` 会把 `ADB_SOURCES` 盖回生产路径,表现是「没有输出」,看起来像 CLI 不认参数 —— 改成「沙箱给了就用沙箱的」,并加了闭包语法自检。

## 验证

`tests/test-bot-adblock-sources.py` 29 格。负控五条:

| 变异 | 结果 |
|---|---|
| 去掉规则集入口 | 27/2 |
| 按钮放 URL 而不是下标 | 28/1 |
| 下标不再对照(越界照删) | 28/2 |
| 更新不走后台 | 28/1 |
| CLI 撤掉 `--json` | 27/2 |

顺带把 `test-bot-adblock-inline.py` 的 callback 闭集改成**从 `handle_cb` 的白名单抽**,不再手写第二份 —— 两处手写必然漂,实现多一个动作而测试不知道,那一格就成了对旧世界的断言。负控(菜单塞一个不在白名单里的按钮)→ 45/1 点名 `adblock:bogus`。

全量回归 202 支 vs 基线:**零新增红灯**。

## 线上预验证

已用非发布方式部署到 jp/jp2 做过实机确认(菜单渲染、`source list --json` 输出、CLI 人看的那份一字未变),两台服务全 active、doctor 零红黄。合并后会用正规 `pdg update` 重新部署到发布 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
