### PR TITLE
chore: mosdns 版本可见性 + adblock 条数渲染修复 + 主状态页去广告行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,6 +812,9 @@ jobs:
 
       - name: "限流判据必须认得模板与迁移两种形态(行尾注释不该被当成缺失)"
         run: python3 tests/test-ratelimit-judgement.py
+
+      - name: "doctor 报出 mosdns 版本并与钉死值精确对照(只对照, 不建议升级)"
+        run: python3 tests/test-mosdns-version-visibility.py
       - name: 出站 schema (锁定版 sing-box check 各协议 parse_link 输出)
         run: bash tests/test-outbound-schema.sh
       - name: 劫持形态 (真起 mosdns 验证 all=排除式劫持 / gfw=白名单放行)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,9 @@ jobs:
 
       - name: "adblock status 的条数渲染(0 条不许断行 / 注释空行不计 / 全仓守卫)"
         run: bash tests/test-adblock-status-render.sh
+
+      - name: "主状态页有去广告一行(未启用也要说话 / 措辞不许说成命中次数 / Bot 调的子命令真存在)"
+        run: python3 tests/test-status-adblock-line.py
       - name: 出站 schema (锁定版 sing-box check 各协议 parse_link 输出)
         run: bash tests/test-outbound-schema.sh
       - name: 劫持形态 (真起 mosdns 验证 all=排除式劫持 / gfw=白名单放行)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,9 @@ jobs:
 
       - name: "doctor 报出 mosdns 版本并与钉死值精确对照(只对照, 不建议升级)"
         run: python3 tests/test-mosdns-version-visibility.py
+
+      - name: "adblock status 的条数渲染(0 条不许断行 / 注释空行不计 / 全仓守卫)"
+        run: bash tests/test-adblock-status-render.sh
       - name: 出站 schema (锁定版 sing-box check 各协议 parse_link 输出)
         run: bash tests/test-outbound-schema.sh
       - name: 劫持形态 (真起 mosdns 验证 all=排除式劫持 / gfw=白名单放行)

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -333,6 +333,55 @@ def check_core_version():
     return ("ok", "mihomo 版本", "v" + m.group(1) + " ✓(版本随项目发布更新)") if m \
         else ("warn", "mihomo 版本", "读不到版本")
 
+# mosdns 的钉死版本。**从 lib/versions.sh 读**, 不在这里写第二份 —— 两处手写必然漂,
+# 而漂掉的表现是这条判据报绿、实际跑的却不是钉死那版。
+def _pinned_mosdns_ver():
+    for base in (os.environ.get("PDG_REPO_ROOT"), "/opt/privdns-gateway",
+                 os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))):
+        if not base:
+            continue
+        try:
+            with open(os.path.join(base, "lib/versions.sh"), encoding="utf-8") as f:
+                m = re.search(r'^MOSDNS_VER="([^"]+)"', f.read(), re.M)
+            if m:
+                return m.group(1)
+        except OSError:
+            continue
+    return ""
+
+
+def check_mosdns_version():
+    """现在跑的 mosdns 是不是钉死的那一版。
+
+    为什么单独立一条(mihomo 那条不够用): 两个组件的处境完全不同。mihomo 活跃维护、版本
+    随项目发布更新, 所以那条只报"读到了什么"就够。mosdns 近乎停摆 —— 最后一次发布
+    2026-01-11, 最后一次提交 2026-02-27, 近 100 笔提交的时间跨度回到 2023-11 —— 而它是
+    这台机器上**唯一不能坏**的组件。上游没人在修了, "现在跑的到底是哪一版"就成了一个需要
+    随时看得见的事实。
+
+    **只对照, 不建议。** 判据不说"该升级" —— mosdns 的版本恰恰不该被自动跟随, 换不换是
+    需要权衡的决定(触发条件记在项目文档里)。把它说成一条例行操作, 等于替人做了那个决定。
+
+    读不到版本时判 warn 而不是 ok: 那不是"没问题", 是"不知道"。
+    """
+    name = "mosdns 版本"
+    pinned = _pinned_mosdns_ver()
+    rc, out, err = _run(["mosdns", "version"])
+    m = re.search(r"v\d+\.\d+\.\d+", (out or "") + (err or ""))
+    if not m:
+        return ("warn", name, "读不到版本(rc=%s) —— 本项无结论" % rc)
+    cur = m.group(0)
+    if not pinned:
+        return ("warn", name, "跑的是 %s, 但读不到 lib/versions.sh 里的钉死值 —— 无从对照" % cur)
+    # **精确匹配**, 不用子串: 期望 v5.3.4 时跑着 v5.3.40 也会被子串判成命中,
+    # 而这类错判只在版本号进位到两位数时出现, 极难发现(见 tests/test-version-match.sh)。
+    if cur == pinned:
+        return ("ok", name, "%s ✓(钉死值; 上游近乎停摆, 有意不自动跟随)" % cur)
+    return ("warn", name,
+            "跑的是 %s, 钉死的是 %s —— 两边不一致。不自动处理: mosdns 换不换版本是需要"
+            "权衡的决定, 不是例行操作。" % (cur, pinned))
+
+
 def check_dot_arecord():
     d = _dot_domain(); sip = _server_ip()
     if not d or not sip:
@@ -2421,7 +2470,7 @@ def check_deep_lan_acl():
             pass
 
 
-ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_dot_arecord, check_dot_domain_sync,
+ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_mosdns_version, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue, check_tailnet_direct_port,
        check_lan_routes, check_lan_whitelist, check_lan_proxy_routes, check_lan_cert,

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -3947,6 +3947,17 @@ def _groups_desc(c):
     g = [o for o in c["outbounds"] if o.get("type") == "urltest"]
     return "\n".join(f"🔀 故障组 <b>{o['tag']}</b>: {' › '.join(o.get('outbounds', []))}" for o in g)
 
+def _adblock_line():
+    """主状态页那一行。文案来自 CLI(`pdg adblock status-line`), Bot 不自己拼 ——
+    两处措辞迟早有一处会把"表的大小"说成"命中次数", 而本项目没有命中统计。"""
+    try:
+        r = sh([PDG_CLI, "adblock", "status-line"])
+        out = (r.stdout or "").strip().splitlines()
+        return out[-1] if out and r.returncode == 0 else "(读不到)"
+    except Exception:                                        # noqa: BLE001
+        return "(读不到)"
+
+
 def status_text():
     svc = _core_svc()
     _st = sh(["systemctl", "is-active", "mosdns", svc, "pdg-bot"]).stdout.split()
@@ -3968,7 +3979,8 @@ def status_text():
             + (g + "\n" if g else "")
             + f"🎯 默认出口(其余国际): <b>{final}</b>\n"
             f"📚 规则集: {len(_rs_meta())} 个\n"
-            f"🌏 分流: {split}")
+            f"🌏 分流: {split}\n"
+            f"🛡 去广告: {_adblock_line()}")
 
 def exits_text():
     c = load(); lines = []

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5992,6 +5992,26 @@ _adblock_apply(){
   return 0
 }
 
+# 数一份规则文件里的**有效条数**(空行与 `#` 注释不算)。
+#
+# 单独抽出来是因为原地那种写法同时踩了两个坑, 而且互相盖住:
+#
+#   grep -vce '^$|^#' FILE 2>/dev/null || echo 0
+#
+#   ① `grep -c` 无匹配时**既打印 0、又返回退出码 1** —— 于是 `|| echo 0` 再追加一个 0,
+#      输出变成 "0\n0", status 那一行就断成两截。**只在某类规则为 0 条时出现**, 而那
+#      正是绝大多数机器的默认状态, 所以它一直没被发现。
+#   ② `-e` 是**基本正则**, 里面的 `|` 不是"或"而是字面竖线 —— 那个模式从来没排除过注释
+#      和空行。3 条规则会被数成 5 条。
+#
+# 两个坑叠在一起还互相掩护: ① 让人以为是显示问题, ② 让人以为数字本来就该那么大。
+_adb_count_rules(){
+  local f="${1:-}" n
+  [[ -f "$f" ]] || { printf '0'; return 0; }
+  n="$(grep -vcE '^[[:space:]]*(#|$)' "$f" 2>/dev/null)"
+  printf '%s' "${n:-0}"
+}
+
 _adblock_status(){
   local intent count updated
   intent="$(_adblock_intent)"; [[ "$intent" == 1 ]] || intent=0
@@ -6006,8 +6026,8 @@ try: print(json.load(open(sys.argv[1] + "/meta.json")).get("updated","(无)"))
 except Exception: print("(无)")' "$ADB_STATE_DIR" 2>/dev/null)"
   echo "  启用意图: $([[ "$intent" == 1 ]] && echo 已启用 || echo 未启用)"
   echo "  第三方表: $count 条, 更新于 $updated"
-  echo "  用户 allow: $(grep -vce '^$|^#' "$ADB_USER_ALLOW" 2>/dev/null || echo 0) 条   用户 block: $(grep -vce '^$|^#' "$ADB_USER_BLOCK" 2>/dev/null || echo 0) 条"
-  echo "  生效中的表: block $(grep -vce '^$|^#' "$ADB_STATE_DIR/effective_block.txt" 2>/dev/null || echo 0) 条 / list $(grep -vce '^$|^#' "$ADB_STATE_DIR/effective_list.txt" 2>/dev/null || echo 0) 条"
+  echo "  用户 allow: $(_adb_count_rules "$ADB_USER_ALLOW") 条   用户 block: $(_adb_count_rules "$ADB_USER_BLOCK") 条"
+  echo "  生效中的表: block $(_adb_count_rules "$ADB_STATE_DIR/effective_block.txt") 条 / list $(_adb_count_rules "$ADB_STATE_DIR/effective_list.txt") 条"
   local note; note="$(cat "$ADB_STATE_DIR/infra.note" 2>/dev/null)"
   [[ -n "$note" ]] && c_y "  ⚠️ 基础设施白名单有枚举不到的类别(不猜, 也不放行整个公共域): $note"
   # 点名 provider 类型 —— 但只出**插件名**, 不出 token / 账号 / zone。

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -340,6 +340,7 @@ cmd_status(){
   # mihomo 模式 443/80 由 nft 转到 7893(redir), 故把 7893 一并纳入端口展示
   ports=$(ss -lntu 2>/dev/null | grep -oE ':(53|80|81|443|853|7893|8445|9090)\b' | sed 's/^://' | sort -u | sed "s|^9090$|$p9090|" | tr '\n' ' ')
   echo "  监听端口     $ports"
+  echo "  去广告       $(_adblock_status_line)"
   # 读不到就说读不到 —— 以前 describe 失败(仓库损坏 / dubious ownership)时这里输出一个空值,
   # 看起来像"版本号是空的", 排错方向全歪。
   if [[ -d "$REPO_DIR/.git" ]]; then
@@ -6012,6 +6013,23 @@ _adb_count_rules(){
   printf '%s' "${n:-0}"
 }
 
+# 主状态页那一行。**未启用时也要输出** —— 只在启用时才显示的话, 一台"以为开着其实没开"
+# 的机器在主状态页上看不出任何区别, 而那正是最需要它说话的情形。
+#
+# 报的是**表的大小**, 不是命中次数。本项目没有命中统计(四条实现路径都调查过并否决,
+# 见 HANDOFF), 措辞不许造出一个看着像命中数的数字。
+_adblock_status_line(){
+  local intent lst usr
+  intent="$(_adblock_intent)"
+  if [[ "$intent" != 1 ]]; then
+    printf '未启用'
+    return 0
+  fi
+  lst="$(_adb_count_rules "$ADB_STATE_DIR/effective_list.txt")"
+  usr="$(_adb_count_rules "$ADB_USER_BLOCK")"
+  printf '已启用(第三方表 %s 条 / 自定义 %s 条)' "$lst" "$usr"
+}
+
 _adblock_status(){
   local intent count updated
   intent="$(_adblock_intent)"; [[ "$intent" == 1 ]] || intent=0
@@ -6110,6 +6128,11 @@ cmd_adblock(){
         sed 's/^/    /' <<<"$out" | head -3
         return 1
       fi;;
+    status-line)
+      # 主状态页那一行的**唯一**来源。Bot 也调它 —— 两处各拼一份措辞, 迟早有一处把
+      # "表的大小"说成"命中次数", 而本项目没有命中统计(见 HANDOFF)。
+      _adblock_status_line; echo
+      return 0;;
     rule-add-many)
       # 批量加阻断规则。**一笔事务**: 一次锁、一次改源、一次编译、一次重启。
       # 不做成"在 Bot 里循环调 N 次 rule-add": 那只是把 N 次 mosdns 重启从用户手里搬进代码,
@@ -6416,7 +6439,7 @@ try: d=json.loads(sys.argv[1] or "{}"); print("%s 条, 更新于 %s, 来源 %s" 
 except Exception: print("(读不到元数据)")' "$meta" 2>/dev/null)"
       echo "  使用 LKG  : $([[ -s "$ADB_STATE_DIR/list.lkg" ]] && echo 是 || echo 否)";;
     *)
-      echo "用法: pdg adblock <status|enable|disable|update|check <域名>|source <list|add|del|reset>|rule-add <域名>|rule-del <域名>>";;
+      echo "用法: pdg adblock <status|status-line|enable|disable|update|check <域名>|source <list|add|del|reset>|rule-add <域名>|rule-del <域名>>";;
   esac
 }
 
@@ -6859,5 +6882,5 @@ case "${1:-menu}" in
   link)          shift || true; cmd_link "$@";;
   uninstall|rm)  shift || true; cmd_uninstall "$@";;
   rescue)        shift || true; cmd_rescue "$@";;
-  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|lan <status|list|check|routes|add|rm>|adblock <status|enable|disable|update|check <域名>|rule-add <域名>|rule-del <域名>|source <list [--json]|add <URL>|del <URL>|reset>>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
+  *) echo "用法: pdg [menu|status|doctor [--json|--deep]|update [--dry-run]|snapshot|rollback [n]|token|restart|log [n]|traffic|ios [status|diff|previous|ack|recover|repair](仅 iOS)|report [--redact-ip|--full]|detect-cidr|platform <ios|android>|hijack-mode <all|gfw>|ssh-source [status|tailnet|any|confirm]|link status|link session <start|status|stop>|lan <status|list|check|routes|add|rm>|adblock <status|status-line|enable|disable|update|check <域名>|rule-add <域名>|rule-del <域名>|source <list [--json]|add <URL>|del <URL>|reset>>|migrate|migrate-fw|tx <list|show|recover|abort>|rescue <enable|disable|status|fingerprint|bind <IPv4>|rotate-token|rotate-cert>|uninstall [--purge]]";;
 esac

--- a/tests/test-adblock-status-render.sh
+++ b/tests/test-adblock-status-render.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# `pdg adblock status` 的条数在「0 条」时会断成两行。
+#
+#     用户 allow: 0
+#     0 条   用户 block: 0
+#     0 条
+#
+# 根因是 `grep -c … || echo 0`:**`grep -c` 无匹配时既打印 0、又返回退出码 1**, 于是
+# `|| echo 0` 又追加一个 0, 得到 "0\n0"。也就是说这个 bug **只在某类规则为 0 条时出现** ——
+# 而那正是绝大多数机器的默认状态(没加过自定义规则)。
+#
+# 这一支同时钉住一件更要紧的事: 这几个数字是**表的大小**, 不是命中次数。文案不许让人以为
+# 它是"拦了多少次" —— 本项目没有命中统计(四条实现路径都调查过并否决, 见 HANDOFF)。
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){   echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){  echo "[FAIL] $1"; nfail=$((nfail+1)); }
+PDG="$ROOT/deploy/bot/pdg.sh"
+
+echo "══ 0. 先证明这个陷阱真的存在(否则下面几格证明不了什么)══"
+: > "$WORK/empty.txt"
+n="$(grep -vce '^$|^#' "$WORK/empty.txt" 2>/dev/null || echo 0)"
+lines="$(printf '%s' "$n" | grep -c . )"
+[[ "$lines" == 2 ]] \
+  && ok "\`grep -c … || echo 0\` 在空文件上确实产出两行(实得 $lines 行)" \
+  || bad "复现不出这个陷阱, 这一支的前提不成立(实得 $lines 行)"
+
+echo
+echo "══ 1. 产品里不许再有这个写法 ══"
+body="$(sed -n "/^_adb_count_rules()/,/^}/p;/^_adblock_status()/,/^}/p" "$PDG")"
+[[ -n "$body" ]] && ok "抽得到 _adblock_status" || bad "抽不到函数体, 后面不作数"
+hits="$(grep -c 'grep -vce[^)]*|| echo 0' <<<"$body" || true)"
+[[ "$hits" == 0 ]] \
+  && ok "_adblock_status 里没有 \`grep -c … || echo 0\`" \
+  || bad "还有 $hits 处 \`grep -c … || echo 0\` —— 0 条时会断行"
+
+echo
+echo "══ 2. 真跑一次: 空文件时输出必须是干净的单行 ══"
+CL="$WORK/c.sh"
+{
+  echo 'set -uo pipefail'
+  echo 'c_g(){ echo "$*"; }; c_y(){ echo "CY:$*"; }'
+  echo '_adblock_intent(){ echo 1; }'
+  echo '_pdg_module(){ return 1; }'
+  sed -n "/^_adb_count_rules()/,/^}/p;/^_adblock_status()/,/^}/p" "$PDG"
+} > "$CL"
+bash -n "$CL" || { bad "闭包语法坏了 —— 后面所有断言都不作数"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+mkdir -p "$WORK/state"
+: > "$WORK/allow.txt"; : > "$WORK/block.txt"
+: > "$WORK/state/effective_block.txt"; printf 'a.example\nb.example\n' > "$WORK/state/effective_list.txt"
+out="$(
+  ADB_STATE_DIR="$WORK/state" ADB_USER_ALLOW="$WORK/allow.txt" ADB_USER_BLOCK="$WORK/block.txt" \
+  ACME_HOME="$WORK/acme" PROFILE_ENV="$WORK/p.env" \
+  bash -c "source '$CL'; _adblock_status" 2>/dev/null
+)"
+# 每一行都必须自成一句, 不能出现"孤零零一个数字开头"的行
+orphan="$(grep -cE '^[0-9]+ 条' <<<"$out" || true)"
+[[ "$orphan" == 0 ]] \
+  && ok "没有以裸数字开头的断行(实得 $orphan 行)" \
+  || bad "有 $orphan 行是断出来的: $(grep -E '^[0-9]+ 条' <<<"$out" | head -2 | tr '\n' ' ')"
+grep -qE '用户 allow: 0 条 +用户 block: 0 条' <<<"$out" \
+  && ok "0 条时「用户 allow / block」在同一行且数字正确" \
+  || bad "那一行不对: $(grep '用户 allow' <<<"$out" | head -1)"
+grep -qE '生效中的表: block 0 条 / list 2 条' <<<"$out" \
+  && ok "「生效中的表」两个数都对(block 0 / list 2)" \
+  || bad "那一行不对: $(grep '生效中的表' <<<"$out" | head -1)"
+
+echo
+echo "══ 3. 非空文件仍然数得对(别修坏了)══"
+printf 'x.example\n# 注释\n\ny.example\nz.example\n' > "$WORK/block.txt"
+out2="$(
+  ADB_STATE_DIR="$WORK/state" ADB_USER_ALLOW="$WORK/allow.txt" ADB_USER_BLOCK="$WORK/block.txt" \
+  ACME_HOME="$WORK/acme" PROFILE_ENV="$WORK/p.env" \
+  bash -c "source '$CL'; _adblock_status" 2>/dev/null
+)"
+grep -qE '用户 block: 3 条' <<<"$out2" \
+  && ok "3 条规则数成 3(注释与空行不计)" \
+  || bad "数错了: $(grep '用户 block' <<<"$out2" | head -1)"
+
+echo
+echo "══ 4. 文件不存在时也不能断行 ══"
+out3="$(
+  ADB_STATE_DIR="$WORK/nope" ADB_USER_ALLOW="$WORK/nope.txt" ADB_USER_BLOCK="$WORK/nope2.txt" \
+  ACME_HOME="$WORK/acme" PROFILE_ENV="$WORK/p.env" \
+  bash -c "source '$CL'; _adblock_status" 2>/dev/null
+)"
+orphan3="$(grep -cE '^[0-9]+ 条' <<<"$out3" || true)"
+[[ "$orphan3" == 0 ]] && ok "文件缺失时也没有断行" || bad "文件缺失时断了 $orphan3 行"
+grep -qE '用户 allow: 0 条' <<<"$out3" && ok "文件缺失时报 0 条" || bad "文件缺失时那一行不对"
+# 上面两条在"没有文件存在性判断"时也能过 —— grep 对不存在的文件同样打印 0。所以再直接
+# 测一次那个判断本身: 它是这个函数唯一的早退, 少了它就要靠 grep 的报错行为兜底, 而那
+# 是在依赖别人的实现细节。
+CNT="$WORK/cnt.sh"; sed -n '/^_adb_count_rules()/,/^}/p' "$PDG" > "$CNT"
+bash -n "$CNT" || bad "抽不出 _adb_count_rules"
+gone="$(bash -c "source '$CNT'; _adb_count_rules '$WORK/definitely-not-here.txt'" 2>&1)"
+[[ "$gone" == 0 ]] \
+  && ok "文件不存在时直接返回 0(不依赖 grep 的报错行为; 实得 '$gone')" \
+  || bad "文件不存在时返回了 '$gone'"
+body_cnt="$(cat "$CNT")"
+grep -q '\[\[ -f' <<<"$body_cnt" \
+  && ok "函数里有显式的文件存在性判断" \
+  || bad "没有存在性判断 —— 靠 grep 的行为兜底是在依赖别人的实现细节"
+
+echo
+echo "══ 5. 文案不许把「表的大小」说成「命中次数」 ══"
+# 本项目**没有**命中统计(四条实现路径都调查过并否决)。status 里这些数字全是表的大小,
+# 措辞一旦让人以为是"拦了多少次", 那就是一个看着像数据、其实不是的数字。
+for w in 命中 拦截次数 已拦 阻断次数; do
+  grep -q "$w" <<<"$body" \
+    && bad "status 文案里出现「$w」—— 这些数字是表的大小, 不是次数" \
+    || ok "文案里没有「$w」"
+done
+
+echo
+echo "══ 6. 全仓守卫: 这两个坑不许再出现第三次 ══"
+# 救援平面那边**早就踩过并写下了**这个坑(pdg.sh 里 _rescue_nft_count_kernel 上方那段注释:
+# "grep -c 计数为 0 时退出码是 1 —— 调用处若写了 || echo ?, 就会在数字后面再打一个 ?"),
+# 而去广告这边照样犯了一遍。光写注释挡不住第三次, 所以立一条判据。
+scan(){ grep -rnE "$1" "$ROOT/deploy" "$ROOT/lib" "$ROOT/install.sh" "$ROOT/uninstall.sh" 2>/dev/null \
+        | grep -vE ':[0-9]+: *#' || true; }
+h1="$(scan 'grep -[a-z]*c[a-z]* [^|]*\|\| *echo')"
+[[ -z "$h1" ]] \
+  && ok "没有 \`grep -c … || echo\` 这种会多打一个数字的写法" \
+  || bad "还有: $(head -2 <<<"$h1" | tr '\n' ' ')"
+# 基本正则里 | 是字面竖线, 不是"或" —— 用它排除注释/空行的模式从来不生效
+h2="$(scan "grep -[a-z]*e '[^']*\\^\\\$\\|")"
+[[ -z "$h2" ]] \
+  && ok "没有在基本正则里拿 | 当「或」用的模式" \
+  || bad "还有: $(head -2 <<<"$h2" | tr '\n' ' ')"
+
+echo "────────────────────────────────────────"
+echo "通过 $pass, 失败 $nfail"
+exit $(( nfail > 0 ? 1 : 0 ))

--- a/tests/test-mosdns-version-visibility.py
+++ b/tests/test-mosdns-version-visibility.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""doctor 必须报出 mosdns 的版本, 并与钉死值对照。
+
+现状: doctor 报 mihomo 版本, **不报 mosdns 的**。而这两个组件的处境完全不同 ——
+
+  · mihomo 活跃维护, 版本随项目发布更新, 所以那条判据只报"读到了什么";
+  · mosdns 近乎停摆(最后一次发布 2026-01-11, 最后一次提交 2026-02-27, 近 100 笔提交的
+    时间跨度回到 2023-11)。它是这台机器上**唯一不能坏**的组件, 而上游已经没人在修了。
+
+那么"现在跑的是不是钉死的那一版"就成了一个需要随时看得见的事实: 换核议题(见项目文档里
+那四条触发条件)真被触发时, 第一件要问的就是它。
+
+判据只做**对照**, 不做建议: 版本一致就报绿, 不一致就报出两边的值。它不会告诉你该升还是
+该降 —— 那是人的决定, 而 mosdns 的版本恰恰不该被自动跟随。
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "deploy/bot"))
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+import checks                                                # noqa: E402
+
+SRC = open(os.path.join(ROOT, "deploy/bot/checks.py"), encoding="utf-8").read()
+VERS = open(os.path.join(ROOT, "lib/versions.sh"), encoding="utf-8").read()
+
+print("══ 1. 判据存在, 且钉死值有单一真源 ══")
+(ok if hasattr(checks, "check_mosdns_version") else
+ bad)("checks.py 里有 check_mosdns_version")
+m = re.search(r'^MOSDNS_VER="([^"]+)"', VERS, re.M)
+(ok if m else bad)("lib/versions.sh 里有 MOSDNS_VER(实得 %r)" % (m.group(1) if m else None))
+# **不许在 checks.py 里再写一份版本号** —— 两处手写必然漂, 而漂掉的表现是判据报绿而实际不符
+(ok if m and ('"%s"' % m.group(1)) not in SRC else
+ bad)("checks.py 里没有硬编码的版本号(它要从 lib/versions.sh 读)")
+
+print()
+print("══ 2. 真跑判据 ══")
+if hasattr(checks, "check_mosdns_version"):
+    _run = checks._run
+
+    def stub(seq):
+        def f(cmd, *a, **k):
+            if cmd and "mosdns" in cmd[0]:
+                return seq
+            return _run(cmd, *a, **k)
+        return f
+
+    pinned = m.group(1) if m else "v5.3.4"
+    # ① 版本一致 → ok
+    checks._run = stub((0, "mosdns %s-0-gb732318\n" % pinned, ""))
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] == "ok" else bad)("版本与钉死值一致时判绿(实得 %r)" % (r,))
+    (ok if r and pinned in r[2] else bad)("绿的时候把版本号说出来(实得 %r)" % (r[2] if r else None,))
+
+    # ② 版本不符 → warn, 且**两个值都要报出来**
+    checks._run = stub((0, "mosdns v9.9.9-0-gdeadbee\n", ""))
+    r2 = checks.check_mosdns_version()
+    (ok if r2 and r2[0] == "warn" else bad)("版本不符时判黄(实得 %r)" % (r2,))
+    (ok if r2 and "v9.9.9" in r2[2] and pinned in r2[2] else
+     bad)("不符时把**两边**的值都报出来, 否则不知道该看哪个(实得 %r)" % (r2[2] if r2 else None,))
+
+    # ③ 读不到版本 → warn + 明说无结论, 不能判绿
+    checks._run = stub((1, "", "command not found"))
+    r3 = checks.check_mosdns_version()
+    (ok if r3 and r3[0] != "ok" else
+     bad)("读不到版本时不判绿 —— 那不是「没问题」, 是「不知道」(实得 %r)" % (r3,))
+
+    # ④ 子串不能算命中: 期望 v5.3.4 时跑着 v5.3.40 必须判不符
+    checks._run = stub((0, "mosdns %s0-0-gx\n" % pinned, ""))
+    r4 = checks.check_mosdns_version()
+    (ok if r4 and r4[0] != "ok" else
+     bad)("%s0 不能被当成 %s(子串判断的老坑, 见 test-version-match)(实得 %r)"
+          % (pinned, pinned, r4))
+
+    checks._run = _run
+
+print()
+print("══ 3. 判据只对照, 不替人做决定 ══")
+# mosdns 的版本**不该被自动跟随** —— 上游停摆, 换不换是人的判断。判据里不许出现"请升级"
+# 这类话, 否则它会把一个需要权衡的决定说成一条例行操作。
+body = re.search(r"def check_mosdns_version\(.*?\n(?=\ndef |\n# )", SRC, re.S)
+(ok if body else bad)("抽得到函数体")
+if body:
+    b = body.group(0)
+    bads = [w for w in ("请升级", "建议升级", "自动更新", "apt", "curl") if w in b]
+    (ok if not bads else bad)("判据里没有「去升级」这类建议(实得 %r)" % bads)
+
+print()
+print("══ 4. 接进 doctor 的清单 ══")
+(ok if "check_mosdns_version" in SRC.split("def check_mosdns_version")[0] or
+       SRC.count("check_mosdns_version") >= 2 else
+ bad)("check_mosdns_version 被登记进判据清单(不登记就永远不会跑)")
+
+print("-" * 62)
+print("test-mosdns-version-visibility.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-status-adblock-line.py
+++ b/tests/test-status-adblock-line.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""去广告的状态要出现在**主状态页**上, 不用点进二级菜单。
+
+现状: `pdg status` 与 Telegram 主状态页都不提去广告 —— 一台开着去广告的机器和一台没开的,
+主状态页上看起来一模一样。而这是个会改变解析行为的开关。
+
+这一支同时钉住措辞: 那几个数字是**表的大小**, 不是命中次数。本项目没有命中统计(四条实现
+路径都调查过并否决, 见 HANDOFF), 主状态页更不该造出一个看着像命中数的数字。
+
+**未启用时也要出现。** 只在启用时才显示的话, 一台"以为开着其实没开"的机器在主状态页上
+仍然看不出区别 —— 那正是最需要它说话的情形。
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+PDGSH = open(os.path.join(ROOT, "deploy/bot/pdg.sh"), encoding="utf-8").read()
+BOT = open(os.path.join(ROOT, "deploy/bot/pdg-bot.py"), encoding="utf-8").read()
+
+print("══ 1. CLI 的 pdg status 里有去广告一行 ══")
+m = re.search(r"\ncmd_status\(\)\{(.*?)\n\}", PDGSH, re.S)
+(ok if m else bad)("抽得到 cmd_status")
+if m:
+    body = m.group(1)
+    (ok if "去广告" in body else bad)("cmd_status 里提到去广告")
+    # 判的是性质不是实现方式: cmd_status 里**不许自己数规则**(那会变成第二份计数逻辑),
+    # 它只能调那个唯一的渲染函数。第一版断言写成"函数体里要出现 _adb_count_rules",
+    # 而实际是经 _adblock_status_line 间接调的 —— 那是把断言写死在某一种实现上。
+    (ok if "_adblock_status_line" in body else
+     bad)("cmd_status 调唯一的渲染函数")
+    (ok if "grep -c" not in body and "grep -vc" not in body else
+     bad)("cmd_status 里没有自己数规则的 grep")
+
+print()
+print("══ 2. Telegram 主状态页里也有 ══")
+m2 = re.search(r"\ndef status_text\(\):(.*?)\n\ndef ", BOT, re.S)
+(ok if m2 else bad)("抽得到 status_text")
+if m2:
+    b2 = m2.group(1)
+    (ok if "去广告" in b2 else bad)("status_text 里提到去广告")
+
+print()
+print("══ 3. 措辞: 不许把表的大小说成命中次数 ══")
+for src, name in ((m.group(1) if m else "", "cmd_status"),
+                  (m2.group(1) if m2 else "", "status_text")):
+    hits = [w for w in ("命中", "拦截次数", "已拦", "阻断次数") if w in src]
+    (ok if not hits else bad)("%s 的文案里没有「%s」" % (name, "/".join(hits)))
+    # 也不许出现「N 次」这种形状
+    nums = re.findall(r"\d+\s*次", src)
+    (ok if not nums else bad)("%s 里没有「N 次」这种像命中数的写法(实得 %r)" % (name, nums))
+
+print()
+print("══ 4. 真跑 CLI: 启用与未启用都要说话 ══")
+import shutil                                                # noqa: E402
+import subprocess                                            # noqa: E402
+import tempfile                                              # noqa: E402
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import tmpguard                                              # noqa: E402
+
+W = tmpguard.mkdtemp(prefix="pdg-statusline.")
+os.makedirs(os.path.join(W, "state"), exist_ok=True)
+open(os.path.join(W, "allow.txt"), "w").close()
+open(os.path.join(W, "block.txt"), "w").write("a.example\nb.example\n")
+open(os.path.join(W, "state", "effective_block.txt"), "w").close()
+open(os.path.join(W, "state", "effective_list.txt"), "w").write(
+    "".join("x%d.example\n" % i for i in range(1234)))
+
+# 只抽那一行所依赖的函数, 单独跑 —— 整个 cmd_status 要 systemctl, 跑不动
+need = ["_adb_count_rules", "_adblock_intent", "_adblock_status_line"]
+missing = [f for f in need if ("\n%s()" % f) not in PDGSH]
+(ok if not missing else bad)("依赖的函数都在(缺: %r)" % missing)
+if not missing:
+    cl = os.path.join(W, "c.sh")
+    with open(cl, "w", encoding="utf-8") as f:
+        f.write("set -uo pipefail\n")
+        for fn in need:
+            f.write(subprocess.run(["sed", "-n", "/^%s()/,/^}/p" % fn,
+                                    os.path.join(ROOT, "deploy/bot/pdg.sh")],
+                                   capture_output=True, text=True).stdout + "\n")
+    env = dict(os.environ,
+               ADB_STATE_DIR=os.path.join(W, "state"),
+               ADB_USER_ALLOW=os.path.join(W, "allow.txt"),
+               ADB_USER_BLOCK=os.path.join(W, "block.txt"),
+               PROFILE_ENV=os.path.join(W, "profile.env"))
+    # 未启用
+    open(env["PROFILE_ENV"], "w").write("PDG_ADBLOCK_ENABLED=0\n")
+    r = subprocess.run(["bash", "-c", "source %s; _adblock_status_line" % cl],
+                       capture_output=True, text=True, env=env)
+    out_off = (r.stdout or "").strip()
+    (ok if out_off else bad)("未启用时也输出一行(实得 %r)" % out_off)
+    (ok if "未启用" in out_off or "关闭" in out_off else
+     bad)("未启用时说清楚是关着的(实得 %r)" % out_off)
+    (ok if "\n" not in out_off else bad)("未启用那行是单行(实得 %r)" % out_off)
+    # 已启用
+    open(env["PROFILE_ENV"], "w").write("PDG_ADBLOCK_ENABLED=1\n")
+    r2 = subprocess.run(["bash", "-c", "source %s; _adblock_status_line" % cl],
+                        capture_output=True, text=True, env=env)
+    out_on = (r2.stdout or "").strip()
+    (ok if "1234" in out_on else bad)("已启用时报出生效表的条数(实得 %r)" % out_on)
+    (ok if "2" in out_on else bad)("已启用时报出用户规则数(实得 %r)" % out_on)
+    (ok if "\n" not in out_on else bad)("已启用那行是单行(实得 %r)" % out_on)
+    (ok if not re.findall(r"\d+\s*次", out_on) else
+     bad)("那一行里没有「N 次」(实得 %r)" % out_on)
+
+print()
+print("══ 5. Bot 调的那个子命令必须真的存在 ══")
+# 上一轮 `source list --json` 就是这么假绿的: 测试里 sh 是打桩的, 无论传什么都回结果,
+# 于是从没验过 CLI 认不认这个参数(而当时它不认)。这一格拿 Bot 真正会发的 argv 去对
+# pdg.sh 的 case 分支。
+m3 = re.search(r"def _adblock_line\(\):(.*?)\n\ndef ", BOT, re.S)
+(ok if m3 else bad)("抽得到 _adblock_line")
+if m3:
+    sub = re.findall(r'"adblock",\s*"([a-z-]+)"', m3.group(1))
+    (ok if sub else bad)("抽得到它调的子命令(实得 %r)" % sub)
+    for name in sub:
+        (ok if re.search(r"\n    %s\)" % re.escape(name), PDGSH) else
+         bad)("pdg.sh 的 cmd_adblock 里有 `%s)` 分支 —— 没有的话 Bot 拿到的是用法串" % name)
+    # 用法串也要列出来(加了子命令忘了写用法, 那条命令就存在但没人知道)。
+    # 注意有**多处** "用法: pdg adblock" —— 子命令各有各的。要找的是那条列着 status/enable
+    # 的**主**用法串, 不是第一处(第一处是 `source` 的, 第一版就取错了)。
+    usages = re.findall(r'用法: pdg adblock <[^"]*', PDGSH)
+    main = [u for u in usages if "status|" in u]
+    (ok if main else bad)("找得到 adblock 的主用法串(实得 %d 条候选)" % len(usages))
+    for name in sub:
+        (ok if main and name in main[0] else
+         bad)("主用法串里列了 %s(实得 %r)" % (name, main[0][:80] if main else None))
+
+print("-" * 62)
+print("test-status-adblock-line.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
三件小的,一起走。

## ① doctor 报出 mosdns 版本并与钉死值对照

doctor 报 mihomo 版本,**不报 mosdns 的**。两个组件的处境完全不同:mihomo 活跃维护、版本随项目发布更新;**mosdns 近乎停摆**(最后一次发布 `2026-01-11`,最后一次提交 `2026-02-27`,近 100 笔提交的时间跨度回到 `2023-11`),而它是这台机器上唯一不能坏的组件。

```
🟢 mosdns 版本: v5.3.4 ✓(钉死值; 上游近乎停摆, 有意不自动跟随)
```

四条边界:**精确匹配**不用子串(`v5.3.40` 不能算命中 `v5.3.4`)、读不到判 warn 而非 ok、不符时两边的值都报出来、**判据里不许说「请升级」**(换不换是需要权衡的决定,说成例行操作等于替人做了那个决定)。钉死值从 `lib/versions.sh` 读,不写第二份。

## ② 修 `adblock status` 的条数渲染 —— 两个 bug 叠在一起

用户贴出来的真实输出:

```
  用户 allow: 0
0 条   用户 block: 0
0 条
```

- **`grep -c` 无匹配时既打印 `0` 又返回退出码 1**,`|| echo 0` 又追加一个 `0` → `"0\n0"`,断行。**只在某类规则为 0 条时出现**,也就是绝大多数机器的默认状态
- **`grep -e` 是基本正则,`|` 是字面竖线不是「或」** —— 那个模式**从来没排除过注释和空行**。3 条规则被数成 5 条

①让人以为只是显示问题,②让人以为数字本来就该那么大。

**救援平面那边早就踩过 ① 并写下了注释**(`_rescue_nft_count_kernel` 上方),去广告这边照样犯了一遍 —— 所以加了一条**全仓守卫**,禁掉这两种写法。

## ③ 主状态页加去广告一行

一台开着去广告的机器和一台没开的,主状态页上看起来一模一样。

```
去广告       已启用(第三方表 214982 条 / 自定义 0 条)
去广告       未启用
```

**未启用时也要出现** —— 只在启用时显示的话,「以为开着其实没开」的机器仍然看不出区别,而那正是最需要它说话的情形。

渲染只有一份实现,经新的 `pdg adblock status-line` 暴露给 Bot。

## 措辞上的一条硬规矩

②③ 都加了判据禁掉「命中 / 拦截次数 / 已拦 / 阻断次数」与「N 次」这种形状 —— 这些数字是**表的大小**,不是命中次数。本项目**没有命中统计**(四条实现路径都调查过并否决,见 HANDOFF),造一个看着像命中数的数字比没有更坏。

## 验证

三个测试文件,合计 53 格。负控 12 条,每条精确翻掉对应断言。全量回归 205 支 vs 基线:**零新增红灯**。

§5 那格当场抓到一个真问题:Bot 调的 `status-line` 子命令**根本不存在**(原本写在已删掉的 `feat/adblock-stats` 分支上)。这正是上一轮 `source list --json` 假绿的同一形态 —— 测试里 `sh` 打了桩,从没验过 CLI 认不认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
