### PR TITLE
fix(update): harden release and mosdns integrity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,9 @@ jobs:
       - name: "update 关键步骤故障注入 (git reset/必需文件/迁移/内核/daemon-reload 失败均回滚且不谎报成功)"
         run: bash tests/test-update-faults.sh
 
+      - name: "update 与最新发布的关系四态 (相同幂等/落后升级/领先拒绝/分叉拒绝; 真 git 判祖先)"
+        run: bash tests/test-update-release-relation.sh
+
       - name: "全局锁继承八格 (父锁复用/独立取锁/BUSY/环境变量伪造/错文件/inode 变更/并发/释放)"
         run: bash tests/test-lock-inherit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,71 @@ permissions:
   contents: read
 
 jobs:
+  # ── mosdns 取件的唯一入口 ──────────────────────────────────────────────────
+  # 为什么单独立一个 job: 官方 Release 的取件曾经散在六个 job 里, 而 e2e 是 matrix ——
+  # 每格一个独立容器, 于是"备在 job 层"恰恰就是"每个用例一次": 21 格 = 21 次下载。
+  # 整个 run 对 GitHub Release 发了 28 次请求(还不算 e2e-serial 在夹具里悄悄发的那次)。
+  #
+  # 现在改成: 每 run、每架构**只取一次**, 校验四层, 再经本次 workflow 的短期 artifact
+  # 扇出给所有消费者。artifact 的上下行是同一次 workflow 内部的传递, 不是消费者重新去
+  # 访问官方 Release。
+  #
+  # 不用 actions/cache、不跨 run 复用、不烘进长期镜像、不把二进制提交进 Git —— 那几条
+  # 要么让"这一版是不是官方那一份"失去每次重新证明的机会, 要么把版本维护分叉成两处。
+  prepare-mosdns-fixture:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        # 目前所有 runner 都是 x86_64 → 只有 amd64 一格。将来真出现 arm64 runner 时
+        # 这里加一格即可: 消费者各自按自己的架构算 artifact 名, 不会拿错。
+        arch: [amd64]
+    name: "取件 mosdns (${{ matrix.arch }}, 每 run 每架构仅此一次)"
+    steps:
+      - uses: actions/checkout@v5
+      # 不把 runner 上偶然存在的 mosdns 当隐式输入: 先清干净, 这一步才真的证明了完整取件。
+      - name: "隔离 runner 上偶然存在的 mosdns"
+        run: |
+          set -euo pipefail
+          sudo rm -f /usr/local/bin/mosdns
+          ! command -v mosdns >/dev/null 2>&1 || { echo "PATH 上仍有 mosdns: $(command -v mosdns)"; exit 1; }
+      - name: "推导 artifact 名(由 lib/versions.sh 的钉值生成)"
+        id: name
+        run: echo "artifact=$(bash tests/mosdns-artifact-name.sh ${{ matrix.arch }})" >> "$GITHUB_OUTPUT"
+      # 取件走仓库既有流程: 它自己校验归档 SHA256, 解压后再核一次自报版本。
+      - name: "从官方 Release 取件并校验(归档 SHA + 自报版本)"
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          PDG_TEST_MOSDNS="$PWD/artifact/mosdns" bash tests/prepare-mosdns.sh
+      - name: "校验最终二进制 SHA + 生产判据 + 生成 manifest"
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck source=lib/versions.sh
+          source lib/versions.sh
+          ARCH='${{ matrix.arch }}'
+          WANT="${PDG_SHA256[mosdns-bin-$ARCH]}"
+          GOT="$(sha256sum artifact/mosdns | awk '{print $1}')"
+          [ "$GOT" = "$WANT" ] || { echo "二进制 SHA256 不符: $GOT != $WANT"; exit 1; }
+          # 生产判据 —— 与 install.sh 的严格短路、doctor 的完整性判据同一个函数
+          pdg_mosdns_binary_ok "$ARCH" "$MOSDNS_VER" "$PWD/artifact/mosdns"
+          # manifest 只记可公开的溯源事实: 无 token、无 runner 路径、无生产地址
+          printf '{"version":"%s","arch":"%s","archive_sha256":"%s","binary_sha256":"%s","source_release":"%s","producer_commit":"%s"}\n' \
+            "$MOSDNS_VER" "$ARCH" "${PDG_SHA256[mosdns-$ARCH]}" "$GOT" \
+            "https://github.com/IrineSistiana/mosdns/releases/tag/$MOSDNS_VER" \
+            "$GITHUB_SHA" > artifact/manifest.json
+          cat artifact/manifest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.name.outputs.artifact }}
+          path: artifact/
+          # 平台允许的最短保留期: 它只服务本次 run, 留久了就成了跨 run 复用的入口。
+          retention-days: 1
+          if-no-files-found: error
+
   lint:
+    needs: prepare-mosdns-fixture
     runs-on: ubuntu-latest
     env:
       # 严格模式: 缺钉死版内核 = 失败。开发者本机单跑时不设它, 那时缺二进制记 [SKIP]。
@@ -40,8 +104,19 @@ jobs:
       # REFUSED。这条以前没有 —— 本地一直绿是因为开发机上有早前 E2E 留下的 mosdns, 而
       # CI 的 lint job 里没有, 于是 test-cidr-transaction 一串失败。v1.7.0 发布前的
       # 第一次真实 CI 就是栽在这里。
-      - name: "准备钉死版 mosdns (事务候选校验要真启动它; 版本与 SHA256 走 lib/versions.sh)"
-        run: sudo -E bash tests/prepare-mosdns.sh
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: sudo -E bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
 
 
       - name: Python 语法 (py_compile)
@@ -383,6 +458,9 @@ jobs:
         run: |
           python3 -c 'import yaml' 2>/dev/null || sudo apt-get install -y -q python3-yaml
           python3 tests/test-ci-mosdns-topology.py
+
+      - name: "mosdns artifact 往返 (两个消费者各自四层复核 / 改一字节与改 manifest 均硬失败 / 消费者不联网)"
+        run: bash tests/test-mosdns-artifact-roundtrip.sh
 
       - name: "全局锁继承八格 (父锁复用/独立取锁/BUSY/环境变量伪造/错文件/inode 变更/并发/释放)"
         run: bash tests/test-lock-inherit.sh
@@ -805,6 +883,7 @@ jobs:
         run: python3 tests/test-platform-isolation.py
 
   functional:
+    needs: prepare-mosdns-fixture
     # 真功能测试: 下载钉死 SHA256 的 sing-box / mosdns, 真起一遍, 验证两层核心链路。
     runs-on: ubuntu-latest
     steps:
@@ -813,8 +892,19 @@ jobs:
       # `command -v mosdns` —— 装到 PATH 上才算数。**必须紧跟在 checkout 之后**: 放在失败的
       # 那一步后面就永远不会执行(v1.7.0 发布前踩过一次)。顺带让两次 dns-policy 复用同一份
       # 二进制, 不必各下一遍。
-      - name: "准备钉死版 mosdns (负控脚本按 PATH 判前提; 版本与 SHA256 走 lib/versions.sh)"
-        run: sudo -E bash tests/prepare-mosdns.sh
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: sudo -E bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: 流量层 (真起 sing-box 验证按 SNI 分到不同出口 + final 兜底)
         run: bash tests/functional-test.sh
       - name: DNS 层 (真起 mosdns 验证 A 劫持 / AAAA·HTTPS 置空 / 国内直连 / 按来源门控)
@@ -853,6 +943,7 @@ jobs:
         run: bash tests/test-hijack-shape.sh
 
   e2e:
+    needs: prepare-mosdns-fixture
     # 端到端: 在真实绝对路径上跑真正的 migrate / switch-core / bot 代码, 配合真内核与真 mosdns。
     # 单测都在函数级别打桩, 跨组件的接缝没人看着 —— 这几条查出过 GMS 重复插入、backend 标记
     # 从不落地、分流规则不进 mosdns、不可转换出站被静默丢弃等接缝 bug。
@@ -916,11 +1007,19 @@ jobs:
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 tar gzip unzip dnsutils git coreutils openssl iproute2 >/dev/null
-      # 与 lint / functional 用的是**同一份**脚本(版本与 SHA256 走 lib/versions.sh)。
-      # 备在 job 这一层而不是每个用例各取一次: 夹具于是直接复用已经就位的那一份, 自己
-      # 一次网络请求都不发。校验不过就让这一步失败, 不允许"下不到就跳过"。
-      - name: "准备钉死版 mosdns (健康夹具要真二进制: 短路与 doctor 都比 SHA256)"
-        run: bash tests/prepare-mosdns.sh
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: "跑 ${{ matrix.script }}"
         env: { PDG_E2E_ISOLATED: "1" }
         run: bash tests/${{ matrix.script }}
@@ -928,6 +1027,7 @@ jobs:
   # 6.2A DoT 证据源的真链路 E2E。单独成 job 而不是并进上面的矩阵: 这两支要真 mosdns
   # 二进制, 而上面那步不装它 —— 塞进共享矩阵等于给每一个 E2E job 都加一次下载。
   e2e-dot:
+    needs: prepare-mosdns-fixture
     runs-on: ubuntu-latest
     container:
       image: debian:12
@@ -949,26 +1049,19 @@ jobs:
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 unzip openssl iproute2 coreutils procps psmisc >/dev/null
-      # 版本与哈希都取自 lib/versions.sh —— 与 install.sh 用的是同一个信任锚。
-      # 校验不过就让这一步失败, 不允许"下不到就跳过"。
-      #
-      # `shell: bash` 不是装饰: 这个 job 跑在 debian:12 容器里, GitHub 对 run: 的默认 shell
-      # 是 `sh`(在 Debian 上就是 dash), 而 dash 不认 `-o pipefail` —— 整步直接以
-      # "set: Illegal option -o pipefail" 退出 2, 和被测代码毫无关系。下面凡是用了 pipefail
-      # 的步骤都要显式声明 bash; 不能反过来把 pipefail 摘掉迁就 dash, 那样 curl 失败会被
-      # 管道尾巴的退出码盖住, sha256 校验就形同虚设。
-      - name: "装钉定 mosdns (SHA256 必须命中)"
-        shell: bash
-        run: |
-          set -euo pipefail
-          # shellcheck source=lib/versions.sh
-          source lib/versions.sh
-          curl -fsSL -o /tmp/mosdns.zip \
-            "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-amd64.zip"
-          echo "${PDG_SHA256[mosdns-amd64]}  /tmp/mosdns.zip" | sha256sum -c -
-          unzip -oq /tmp/mosdns.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/mosdns
-          mosdns version
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: "记录共享桩基线(测试不许动这些真程序)"
         shell: bash
         run: |
@@ -1117,6 +1210,7 @@ jobs:
   #   · P0 用 dot.p0ci.test —— 它必须从 dotwitness.env 推导域名, 用非缺省值才证明得了
   #     推导真的在跑。
   dot-systemd-e2e:
+    needs: prepare-mosdns-fixture
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -1179,20 +1273,19 @@ jobs:
           test "$(stat -c %U "$PDG_DOTE2E_SNAP")" = root
           test -f "$PDG_DOTE2E_SNAP/tests/e2e-lib.sh"
           test -f "$PDG_DOTE2E_SNAP/tests/helpers/ci-dot-fixture.sh"
-      # 版本与哈希都取自 lib/versions.sh —— 与 install.sh 同一个信任锚。校验不过就失败,
-      # 不允许"下不到就跳过"。
-      - name: "装钉定 mosdns (SHA256 必须命中)"
-        shell: bash
-        run: |
-          set -euo pipefail
-          # shellcheck source=lib/versions.sh
-          source lib/versions.sh
-          curl -fsSL -o /tmp/mosdns.zip \
-            "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-amd64.zip"
-          echo "${PDG_SHA256[mosdns-amd64]}  /tmp/mosdns.zip" | sha256sum -c -
-          sudo unzip -oq /tmp/mosdns.zip -d /usr/local/bin
-          sudo chmod +x /usr/local/bin/mosdns
-          mosdns version
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: "记录共享程序与临时目录基线"
         shell: bash
         run: |
@@ -1268,6 +1361,7 @@ jobs:
           exit "$fail"
 
   e2e-rescue-lock-ios:
+    needs: prepare-mosdns-fixture
     runs-on: ubuntu-latest
     container:
       image: debian:12
@@ -1288,11 +1382,19 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 tar gzip unzip dnsutils git coreutils openssl \
             iproute2 psmisc procps >/dev/null
-      # 与 lint / functional 用的是**同一份**脚本(版本与 SHA256 走 lib/versions.sh)。
-      # 备在 job 这一层而不是每个用例各取一次: 夹具于是直接复用已经就位的那一份, 自己
-      # 一次网络请求都不发。校验不过就让这一步失败, 不允许"下不到就跳过"。
-      - name: "准备钉死版 mosdns (健康夹具要真二进制: 短路与 doctor 都比 SHA256)"
-        run: bash tests/prepare-mosdns.sh
+      # 取本次 run 的钉定 mosdns —— 不再自己去 GitHub Release。名字由 lib/versions.sh 的
+      # 钉值算出来, 与 producer 上传时用的是同一份生成器, 于是"上传的叫什么"与"要什么"
+      # 没有第二个答案。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      # 服务端摘要只证明"传输没坏", 不证明"内容是官方那一份"。这里按当前 checkout 的
+      # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: "跑 e2e-rescue-migration-lock.sh (iOS)"
         env:
           PDG_E2E_ISOLATED: "1"
@@ -1300,6 +1402,7 @@ jobs:
         run: bash tests/e2e-rescue-migration-lock.sh
 
   e2e-serial:
+    needs: prepare-mosdns-fixture
     runs-on: ubuntu-latest
     container:
       image: debian:12
@@ -1319,6 +1422,17 @@ jobs:
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 tar gzip unzip dnsutils git coreutils openssl iproute2 >/dev/null
+      # e2e-serial 串行跑 e2e-install / e2e-update 等, 它们的夹具要真 mosdns。
+      # 以前这个 job 没有取件步骤 —— 那次下载发生在夹具内部、被脚本的输出捕获吞掉,
+      # job 日志上一个字都看不见(审计时才发现它也是消费者)。现在与别的消费者同路。
+      - name: "推导 mosdns artifact 名"
+        run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+      - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
       - name: "E2E 串行 hermetic (同一容器里按原顺序连着跑, 每个都必须全绿)"
         env:
           PDG_E2E_ISOLATED: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,9 @@ jobs:
       - name: "update 前置 mosdns 完整性预检 (缺失/命令非零/版本不符/摘要不符均在第一次副作用前停下)"
         run: bash tests/test-update-mosdns-preflight.sh
 
+      - name: "E2E 夹具必须播真 mosdns (shell 假桩被生产判据拒绝 / 真钉定二进制被接受 / 夹具不联网)"
+        run: python3 tests/test-e2e-mosdns-fixture.py
+
       - name: "全局锁继承八格 (父锁复用/独立取锁/BUSY/环境变量伪造/错文件/inode 变更/并发/释放)"
         run: bash tests/test-lock-inherit.sh
 
@@ -908,6 +911,11 @@ jobs:
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 tar gzip unzip dnsutils git coreutils openssl iproute2 >/dev/null
+      # 与 lint / functional 用的是**同一份**脚本(版本与 SHA256 走 lib/versions.sh)。
+      # 备在 job 这一层而不是每个用例各取一次: 夹具于是直接复用已经就位的那一份, 自己
+      # 一次网络请求都不发。校验不过就让这一步失败, 不允许"下不到就跳过"。
+      - name: "准备钉死版 mosdns (健康夹具要真二进制: 短路与 doctor 都比 SHA256)"
+        run: bash tests/prepare-mosdns.sh
       - name: "跑 ${{ matrix.script }}"
         env: { PDG_E2E_ISOLATED: "1" }
         run: bash tests/${{ matrix.script }}
@@ -1275,6 +1283,11 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             bash curl ca-certificates python3 tar gzip unzip dnsutils git coreutils openssl \
             iproute2 psmisc procps >/dev/null
+      # 与 lint / functional 用的是**同一份**脚本(版本与 SHA256 走 lib/versions.sh)。
+      # 备在 job 这一层而不是每个用例各取一次: 夹具于是直接复用已经就位的那一份, 自己
+      # 一次网络请求都不发。校验不过就让这一步失败, 不允许"下不到就跳过"。
+      - name: "准备钉死版 mosdns (健康夹具要真二进制: 短路与 doctor 都比 SHA256)"
+        run: bash tests/prepare-mosdns.sh
       - name: "跑 e2e-rescue-migration-lock.sh (iOS)"
         env:
           PDG_E2E_ISOLATED: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,11 @@ jobs:
       - name: "E2E 夹具必须播真 mosdns (shell 假桩被生产判据拒绝 / 真钉定二进制被接受 / 夹具不联网)"
         run: python3 tests/test-e2e-mosdns-fixture.py
 
+      - name: "CI 取件拓扑 (官方 Release 每 run 每架构只取一次 / 消费者靠 artifact 且自己复核 / action 钉定)"
+        run: |
+          python3 -c 'import yaml' 2>/dev/null || sudo apt-get install -y -q python3-yaml
+          python3 tests/test-ci-mosdns-topology.py
+
       - name: "全局锁继承八格 (父锁复用/独立取锁/BUSY/环境变量伪造/错文件/inode 变更/并发/释放)"
         run: bash tests/test-lock-inherit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,9 @@ jobs:
       - name: "update 与最新发布的关系四态 (相同幂等/落后升级/领先拒绝/分叉拒绝; 真 git 判祖先)"
         run: bash tests/test-update-release-relation.sh
 
+      - name: "update 前置 mosdns 完整性预检 (缺失/命令非零/版本不符/摘要不符均在第一次副作用前停下)"
+        run: bash tests/test-update-mosdns-preflight.sh
+
       - name: "全局锁继承八格 (父锁复用/独立取锁/BUSY/环境变量伪造/错文件/inode 变更/并发/释放)"
         run: bash tests/test-lock-inherit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,6 +827,12 @@ jobs:
 
       - name: "主状态页有去广告一行(未启用也要说话 / 措辞不许说成命中次数 / Bot 调的子命令真存在)"
         run: python3 tests/test-status-adblock-line.py
+
+      - name: "去广告状态三态(enabled/disabled/unknown; 读不到不许说成未启用 / 缺文件不许显示 0 条 / 严格只读)"
+        run: python3 tests/test-adblock-status-tristate.py
+
+      - name: "mosdns 证据闭包(退出码 + 固定执行路径 + 解压后二进制摘要; 同版本异内容不许短路)"
+        run: python3 tests/test-mosdns-binary-evidence.py
       - name: 出站 schema (锁定版 sing-box check 各协议 parse_link 输出)
         run: bash tests/test-outbound-schema.sh
       - name: 劫持形态 (真起 mosdns 验证 all=排除式劫持 / gfw=白名单放行)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,6 +825,9 @@ jobs:
       - name: "adblock status 的条数渲染(0 条不许断行 / 注释空行不计 / 全仓守卫)"
         run: bash tests/test-adblock-status-render.sh
 
+      - name: "规则计数的 locale 语义(C 与 UTF-8 对拍同数 / 优化只在那一次调用上 / 不引入计数缓存)"
+        run: bash tests/test-adblock-count-locale.sh
+
       - name: "主状态页有去广告一行(未启用也要说话 / 措辞不许说成命中次数 / Bot 调的子命令真存在)"
         run: python3 tests/test-status-adblock-line.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -872,6 +872,7 @@ jobs:
           - e2e-install-nft.sh
           - e2e-platform-switch.sh
           - e2e-update.sh
+          - e2e-update-ahead-of-release.sh
           - e2e-update-preserve-userdata.sh
           - e2e-upgrade-from-release.sh
           - e2e-wloc.sh

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """PrivDNS Gateway 只读检查库。doctor.py 跑全部, healthcheck.py 跑子集。
 每个 check() 返回 (level, label, detail), level ∈ 'ok'|'warn'|'fail'|'info'。只读, 不改任何东西。"""
-import os, re, json, ipaddress, subprocess, sys, urllib.request
+import os, re, json, hashlib, ipaddress, platform, subprocess, sys, urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import nftscan  # noqa: E402  与迁移前置门共用的 input 链冲突判据(单一来源)
@@ -335,19 +335,40 @@ def check_core_version():
 
 # mosdns 的钉死版本。**从 lib/versions.sh 读**, 不在这里写第二份 —— 两处手写必然漂,
 # 而漂掉的表现是这条判据报绿、实际跑的却不是钉死那版。
-def _pinned_mosdns_ver():
+# systemd 的 ExecStart 写的就是这个绝对路径。判据必须问**同一个文件** —— 问 PATH 上的
+# `mosdns` 只能告诉你"某个 mosdns 是什么版本", 而不是"这台网关在跑的那个是什么版本"。
+MOSDNS_BIN = "/usr/local/bin/mosdns"
+
+
+def _versions_sh():
+    """lib/versions.sh 的正文。钉死值只有这一个真源, checks.py 里不再写第二份。"""
     for base in (os.environ.get("PDG_REPO_ROOT"), "/opt/privdns-gateway",
                  os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))):
         if not base:
             continue
         try:
             with open(os.path.join(base, "lib/versions.sh"), encoding="utf-8") as f:
-                m = re.search(r'^MOSDNS_VER="([^"]+)"', f.read(), re.M)
-            if m:
-                return m.group(1)
+                return f.read()
         except OSError:
             continue
     return ""
+
+
+def _pinned_mosdns_ver():
+    m = re.search(r'^MOSDNS_VER="([^"]+)"', _versions_sh(), re.M)
+    return m.group(1) if m else ""
+
+
+def _pinned_mosdns_bin_shas():
+    """{架构: 解压后二进制的 SHA256}。架构不在这张表里 = 本项无从对照, 不是"没问题"。"""
+    return dict(re.findall(r'\[mosdns-bin-(\w+)\]="([0-9a-f]{64})"', _versions_sh()))
+
+
+def _host_arch():
+    rc, out, _ = _run(["dpkg", "--print-architecture"])
+    if rc == 0 and out.strip():
+        return out.strip()
+    return {"x86_64": "amd64", "aarch64": "arm64"}.get(platform.machine(), platform.machine())
 
 
 def check_mosdns_version():
@@ -366,10 +387,18 @@ def check_mosdns_version():
     """
     name = "mosdns 版本"
     pinned = _pinned_mosdns_ver()
-    rc, out, err = _run(["mosdns", "version"])
-    m = re.search(r"v\d+\.\d+\.\d+", (out or "") + (err or ""))
+    rc, out, err = _run([MOSDNS_BIN, "version"])
+    # 退出码是证据的一部分。以前把 stdout 与 stderr 拼起来正则找版本号, 找到就算数 ——
+    # 于是 rc=1 / stdout="mosdns v5.3.4-…" / stderr="fatal: broken" 这组输入被判成 ✓。
+    # 一个起不来的 mosdns 照样能打印自己的版本, 那不是"版本对得上", 那是"它崩之前说了句话"。
+    if rc != 0:
+        return ("warn", name,
+                "%s version 退出码非 0(rc=%s)—— 本项无结论。命令失败时它打印的版本号不算证据。"
+                % (MOSDNS_BIN, rc))
+    # 只认 stdout: 版本号出现在 stderr 里, 说明它是在报错的路上顺带说的, 同样不是成功证据。
+    m = re.search(r"v\d+\.\d+\.\d+", out or "")
     if not m:
-        return ("warn", name, "读不到版本(rc=%s) —— 本项无结论" % rc)
+        return ("warn", name, "解析不出版本(stdout 里没有版本串)—— 本项无结论")
     cur = m.group(0)
     if not pinned:
         return ("warn", name, "跑的是 %s, 但读不到 lib/versions.sh 里的钉死值 —— 无从对照" % cur)
@@ -380,6 +409,47 @@ def check_mosdns_version():
     return ("warn", name,
             "跑的是 %s, 钉死的是 %s —— 两边不一致。不自动处理: mosdns 换不换版本是需要"
             "权衡的决定, 不是例行操作。" % (cur, pinned))
+
+
+def check_mosdns_binary(_bin=None, _pin=None, _arch=None):
+    """跑着的 mosdns 二进制**内容**是不是官方那一份。
+
+    为什么版本判据不够: 版本是二进制自报的。安装器的短路条件曾经只看版本, 于是一个内容
+    不同、自报 v5.3.4 的文件会让整段安装被跳过 —— 连带跳过 SHA256 供应链校验。而项目原先
+    钉的是下载**压缩包**的哈希: 一旦跳过下载, 那个钉值就再也没有机会被用上。
+
+    所以钉值改成"解压后二进制本身"(lib/versions.sh 的 PDG_SHA256[mosdns-bin-<arch>]),
+    安装器与 doctor 共用同一份。
+
+    钉值读不到 / 架构不在表里 → warn + 无结论。那不是"没问题", 是"无从对照"。
+
+    三个下划线参数只给测试用(注入沙箱里的路径与钉值), 生产调用不传。
+    """
+    name = "mosdns 二进制"
+    b = _bin or MOSDNS_BIN
+    arch = _arch if _arch is not None else _host_arch()
+    shas = _pinned_mosdns_bin_shas()
+    if arch not in shas:
+        return ("warn", name, "架构 %s 不在钉值表里(已钉: %s)—— 本项无结论"
+                % (arch, "/".join(sorted(shas)) or "无"))
+    pin = _pin if _pin is not None else shas.get(arch, "")
+    if not pin:
+        return ("warn", name, "读不到 %s 的二进制钉死摘要 —— 本项无结论" % arch)
+    try:
+        h = hashlib.sha256()
+        with open(b, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        got = h.hexdigest()
+    except OSError as e:
+        # mosdns 是必需运行组件: 它的二进制读不到不是"存疑", 是这台机器有问题。
+        return ("fail", name, "读不到 %s(%s)" % (b, e.strerror or e.errno))
+    if got == pin:
+        return ("ok", name, "内容与官方钉值一致 ✓(sha256 %s…)" % got[:12])
+    # 只出短前缀: 完整摘要在 lib/versions.sh 里, doctor 上并排两串 64 位十六进制没人会去比。
+    return ("fail", name,
+            "二进制内容与官方钉值**不一致**: 实得 %s…, 钉死 %s… —— "
+            "同一个版本号下内容被换过(或安装时跳过了校验)。" % (got[:12], pin[:12]))
 
 
 def check_dot_arecord():
@@ -2470,7 +2540,7 @@ def check_deep_lan_acl():
             pass
 
 
-ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_mosdns_version, check_dot_arecord, check_dot_domain_sync,
+ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_mosdns_version, check_mosdns_binary, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue, check_tailnet_direct_port,
        check_lan_routes, check_lan_whitelist, check_lan_proxy_routes, check_lan_cert,

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1728,6 +1728,65 @@ _update_release_relation(){
   esac
 }
 
+# _update_mosdns_preflight → 0 = 现在这台机器的 mosdns 二进制合法, 可以开始更新
+#
+# 为什么要在更新**之前**问: doctor 的 check_mosdns_binary 判 fail 是对的 —— mosdns 是核心
+# 运行文件, 缺失或内容与钉值不符是确定性故障, 不是"无结论"。但 cmd_update 的自检门跑在
+# 更新**做完之后**, 于是一台 mosdns 已经不对的机器会先建快照、reset、装文件、跑迁移、
+# 重启服务, 走完全程, 最后被自检判红再整个回滚 —— 动了一遍又回到起点, 而且每跑一次
+# `pdg update` 就重复一遍。真正该做的是在动手之前就停下。
+#
+# 裁决**只由生产共用判据给出**: lib/versions.sh 的 pdg_mosdns_binary_ok, 与 install.sh 的
+# 严格短路是同一个函数、同一份钉值。下面那几次探测只负责把"为什么不合法"说成人话, 不参与
+# 判定 —— 两套判断并存的话, 它们迟早会在某个边角上给出不同答案。
+#
+# 读不到 versions.sh / 架构不在钉值表里 → 一样拒绝。这里是 fail-closed: 判不出来就不该
+# 在这台机器上开始一次会改动系统的操作。(doctor 那条对同样情形判 warn 是另一回事 ——
+# 它在报告状态, 这里在决定要不要动手。)
+# $1 可选: 要检查的二进制路径, 默认就是 systemd 真正执行的那个。留这个参数是为了让测试
+# 能在沙箱里造出"缺失 / 执行不了 / 版本不符 / 摘要不符"四种形态 —— 生产调用点不传参,
+# 走的永远是写死的绝对路径。**不是**环境变量后门: 没有任何 env 能改变生产行为。
+# shellcheck disable=SC2120  # 这个可选参数只由 tests/test-update-mosdns-preflight.sh 传,
+# 生产调用点(下面 cmd_update 里那一处)有意不传 —— shellcheck 看不到测试里的调用。
+_update_mosdns_preflight(){
+  local bin="${1:-/usr/local/bin/mosdns}" march rc=0
+  (
+    # 放子 shell: versions.sh 定义的 MOSDNS_VER / PDG_SHA256 不该泄漏进 cmd_update 后面
+    # 那些步骤的作用域。
+    # shellcheck source=lib/versions.sh
+    source "$REPO_DIR/lib/versions.sh" 2>/dev/null || exit 10
+    march=$(dpkg --print-architecture 2>/dev/null); [[ "$march" == arm64 ]] || march=amd64
+    pdg_mosdns_binary_ok "$march" "$MOSDNS_VER" "$bin" && exit 0
+    # 到这里就是"不合法"。下面只为把原因说清楚, 判定已经做完了。
+    [[ -e "$bin" ]] || exit 1                       # 文件不存在
+    [[ -x "$bin" ]] || exit 2                       # 在那儿但执行不了
+    "$bin" version >/dev/null 2>&1  || exit 3       # version 命令非零
+    local got; got="$("$bin" version 2>/dev/null | head -1)"
+    [[ "$got" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] || exit 4      # 输出里读不出版本
+    [[ "${BASH_REMATCH[1]}" == "${MOSDNS_VER#v}" ]] || exit 5 # 自报版本不符
+    [[ -n "${PDG_SHA256[mosdns-bin-$march]:-}" ]] || exit 11  # 该架构没有钉值
+    exit 6                                          # 版本对得上, 那就是内容摘要不符
+  )
+  rc=$?
+  [[ "$rc" == 0 ]] && return 0
+  march=$(dpkg --print-architecture 2>/dev/null); [[ "$march" == arm64 ]] || march=amd64
+  c_y "❌ 更新前自检: mosdns 二进制不合法, 拒绝开始更新。"
+  case "$rc" in
+    1)  echo "  $bin **不存在**(缺失 —— 核心解析器不在, 这台机器现在是坏的)";;
+    2)  echo "  $bin 在那儿但**执行不了**(权限 / 不是可执行文件)";;
+    3)  echo "  $bin version **命令非零**(它起不来, 打印出来的版本号不算数)";;
+    4)  echo "  $bin version 的输出里**读不出版本号**";;
+    5)  echo "  自报**版本不符**: 跑的是 ${BASH_REMATCH[1]:-未知}, 钉死的另有其值";;
+    6)  echo "  **SHA256 摘要不符**: 版本号对得上, 但文件**内容**不是官方那一份";;
+    10) echo "  读不到 $REPO_DIR/lib/versions.sh —— 无从对照, 不在存疑时动手";;
+    11) echo "  本架构($march)在钉值表里没有条目 —— 无从对照, 不在存疑时动手";;
+    *)  echo "  判据未通过(rc=$rc)";;
+  esac
+  echo "  先修好它再更新: sudo pdg doctor 会指出同一项。"
+  echo "  没动任何文件: 未建快照, 未 reset, 未装文件, 未迁移, 未重启服务。"
+  return 1
+}
+
 cmd_update(){
   need_root update
   # --dry-run 只查看: 不装 git、不迁移、不写任何东西。任一步失败都要返回非 0 并说清是哪一步 ——
@@ -1806,6 +1865,12 @@ cmd_update(){
           echo "  没动任何文件: 未建快照, 未 reset, 未重启服务。"
           return 1;;
       esac
+      # ── 真实更新前的 mosdns 完整性预检 ───────────────────────────────────
+      # 只挂在 behind(真的要往前走)这一路上: same 走下面的短路, ahead/diverged 已经在
+      # 上面被关系门拒了, dry-run 压根到不了这里 —— 那三条的既有契约一个字都不动。
+      if [[ "$_rel" == behind ]] && ! _update_mosdns_preflight; then
+        return 1
+      fi
       # ── 「已是最新」短路 ──────────────────────────────────────────────────
       # 重复跑 `pdg update` 不该有副作用, 以前每次都照走全程: 多留一份快照(挤占 SNAP_DIR)、
       # 两次 daemon-reload、重启 pdg-bot(iOS 还要加 probe81/mitm), 并把所有已装文件的 mtime

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -5964,6 +5964,52 @@ ADB_MARK_SQ=">>> pdg-adblock managed block (internal_sequence)"
 # profile.env 里的启用意图(读不到 = 空 = 未启用)
 _adblock_intent(){ sed -n 's/^[[:space:]]*PDG_ADBLOCK_ENABLED=//p' "$PROFILE_ENV" 2>/dev/null | tail -1; }
 
+# _adblock_read_state → enabled | disabled | unknown  (窄的**只读**三态读取器)
+#
+# 为什么不直接改 _adblock_intent: enable / disable / apply / 迁移都依赖它现有的语义,
+# 动它等于把行为面扩到那些写路径上去。这一个只服务"显示状态"这一件事。
+#
+# 三态不是形式主义。线上 profile.env 是 0600 root:root, 同一台**已启用**的机器上:
+#     root   → 已启用(第三方表 214982 条 / 自定义 0 条)
+#     nobody → 未启用
+# 一个**权限问题**在屏幕上长得和"这台机器没开去广告"一模一样 —— 而后者会让人去点"启用"。
+#
+# 最后一次赋值不是 0/1 时报 unknown, 不退回更早的合法值: 有人往启用位里写了看不懂的东西,
+# 说"未启用"是在替他下结论, 而我们并不知道他要什么。
+_adblock_read_state(){
+  local raw last
+  [[ -e "$PROFILE_ENV" ]] || { printf 'unknown'; return 0; }
+  # 先确认**读得出来**。sed 非零就是打不开(权限 / 路径是目录 / IO 错误)—— 那不是"没启用",
+  # 而是"不知道"。以前这一步的 2>/dev/null 把两者一起吞了。
+  if ! raw="$(sed -n 's/^[[:space:]]*PDG_ADBLOCK_ENABLED=[[:space:]]*//p' "$PROFILE_ENV" 2>/dev/null)"; then
+    printf 'unknown'; return 0
+  fi
+  # 键一次都没出现 = 从没开过。与"值读不出来"分开: 上一步已经证明文件可读。
+  if ! grep -q '^[[:space:]]*PDG_ADBLOCK_ENABLED=' "$PROFILE_ENV" 2>/dev/null; then
+    printf 'disabled'; return 0
+  fi
+  last="$(printf '%s\n' "$raw" | tail -1)"
+  # profile.env 是 shell 片段: 值可能带引号, 后面也可能跟行内注释。
+  last="${last%%[[:space:]]*}"
+  last="${last%\"}"; last="${last#\"}"; last="${last%\'}"; last="${last#\'}"
+  case "$last" in
+    1) printf 'enabled';;
+    0) printf 'disabled';;
+    *) printf 'unknown';;
+  esac
+}
+
+# 规则文件**读得出来吗**。`-r` 只看权限位, 真正的判据是能不能打开 —— 路径是目录、
+# IO 错误、ACL 都只在打开那一步现形。
+# 为什么要单立一条: 缺文件与"0 条"是两件不同的事。0 条是一个具体事实(表在, 里面没东西);
+# 文件不在是另一回事(mosdns 会 FATAL 退出)。显示成同一句话, 现场就没法区分。
+_adb_rules_readable(){
+  local f="${1:-}"
+  [[ -f "$f" ]] || return 1
+  { : < "$f"; } 2>/dev/null || return 1
+  return 0
+}
+
 # 四个 domain_set 文件必须常驻(空文件可以)。缺一个 mosdns 直接 FATAL 退出 —— 这是
 # "规则文件为空是可接受的降级, 规则文件缺失是致命的"那条老规矩。
 _adblock_ensure_files(){
@@ -6105,10 +6151,16 @@ _adb_count_rules(){
 # 报的是**表的大小**, 不是命中次数。本项目没有命中统计(四条实现路径都调查过并否决,
 # 见 HANDOFF), 措辞不许造出一个看着像命中数的数字。
 _adblock_status_line(){
-  local intent lst usr
-  intent="$(_adblock_intent)"
-  if [[ "$intent" != 1 ]]; then
-    printf '未启用'
+  local st lst usr
+  st="$(_adblock_read_state)"
+  case "$st" in
+    disabled) printf '未启用'; return 0;;
+    unknown)  printf '状态未知(启用位读不到: 文件缺失或不可读)—— 请运行 sudo pdg doctor'; return 0;;
+  esac
+  # 启用位是开着的, 但表读不出来 —— 这里**不能**掉回 0 条: 那会把"证据缺失"说成一个事实。
+  if ! _adb_rules_readable "$ADB_STATE_DIR/effective_list.txt" \
+     || ! _adb_rules_readable "$ADB_USER_BLOCK"; then
+    printf '已启用, 但规则文件缺失或不可读; 请运行 sudo pdg doctor'
     return 0
   fi
   lst="$(_adb_count_rules "$ADB_STATE_DIR/effective_list.txt")"
@@ -6117,8 +6169,10 @@ _adblock_status_line(){
 }
 
 _adblock_status(){
-  local intent count updated
-  intent="$(_adblock_intent)"; [[ "$intent" == 1 ]] || intent=0
+  local state count updated
+  # 与 status-line 走**同一个**读取器。两处各读各的话, 迟早会一个说开着一个说关着,
+  # 而用户看到哪一个取决于他敲了哪条命令。
+  state="$(_adblock_read_state)"
   # 路径经 **argv** 传进去, 不再插进 Python 字符串字面量。
   # 今天 ADB_STATE_DIR 是固定常量, 插值不可利用 —— 但那正是"变量一旦可变就变成注入"的
   # 形状, 而这个文件里其它地方都已经走 argv 了, 留一处例外只会让下一个人照抄。
@@ -6128,7 +6182,11 @@ except Exception: print(0)' "$ADB_STATE_DIR" 2>/dev/null)"
   updated="$(python3 -c 'import json,sys
 try: print(json.load(open(sys.argv[1] + "/meta.json")).get("updated","(无)"))
 except Exception: print("(无)")' "$ADB_STATE_DIR" 2>/dev/null)"
-  echo "  启用意图: $([[ "$intent" == 1 ]] && echo 已启用 || echo 未启用)"
+  case "$state" in
+    enabled)  echo "  启用意图: 已启用";;
+    disabled) echo "  启用意图: 未启用";;
+    *)        c_y "  启用意图: 状态未知(启用位读不到: 文件缺失或不可读)—— 请运行 sudo pdg doctor";;
+  esac
   echo "  第三方表: $count 条, 更新于 $updated"
   echo "  用户 allow: $(_adb_count_rules "$ADB_USER_ALLOW") 条   用户 block: $(_adb_count_rules "$ADB_USER_BLOCK") 条"
   echo "  生效中的表: block $(_adb_count_rules "$ADB_STATE_DIR/effective_block.txt") 条 / list $(_adb_count_rules "$ADB_STATE_DIR/effective_list.txt") 条"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -6141,7 +6141,13 @@ _adblock_apply(){
 _adb_count_rules(){
   local f="${1:-}" n
   [[ -f "$f" ]] || { printf '0'; return 0; }
-  n="$(grep -vcE '^[[:space:]]*(#|$)' "$f" 2>/dev/null)"
+  # LC_ALL=C 只加在**这一次调用**上, 不 export: 规则文件的内容契约是纯 ASCII
+  # (adblock.py 的 _DOMAIN_RE 只放行 [a-z0-9_-] 与点), 而 UTF-8 locale 下 grep 要为每个
+  # 字节做多字节解码, 二十多万行的表上这笔开销是白花的。语义不变 —— 这个模式里没有任何
+  # 依赖 locale 的字符类语义(见 tests/test-adblock-count-locale.sh 的双 locale 对拍)。
+  # 不做计数缓存、不改文件格式、不拿 meta.json 里的数字冒充磁盘真实条数: 那三样都会让
+  # "现在盘上到底有多少条"这个问题失去唯一答案。
+  n="$(LC_ALL=C grep -vcE '^[[:space:]]*(#|$)' "$f" 2>/dev/null)"
   printf '%s' "${n:-0}"
 }
 

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1686,6 +1686,48 @@ _update_in_sync(){                      # 0 = 已装文件逐个等于仓库版�
   )
 }
 
+# _update_release_relation <仓库> <tag> → stdout 四态之一; 判不出来返回非 0 且不输出
+#
+#   same      HEAD 就是那个 tag 指向的提交
+#   behind    HEAD 是 tag 的祖先        → 正常升级
+#   ahead     tag 是 HEAD 的祖先        → 机器上跑着**尚未发布**的提交
+#   diverged  两边互不为祖先            → 无法安全地"更新"过去
+#
+# 为什么要单独立一个函数: 以前的判据只有"HEAD 是否等于 tag", 相等就短路、不等就
+# `git reset --hard <tag>`。`reset --hard` 对方向一视同仁 —— 于是 ahead 这一态被当成
+# 升级执行了, 未发布的提交被静默退回上一个 Release。判据必须先分清方向, 才轮到动作。
+#
+# dry-run 与正式 update **共用这一份**。各写一份的话两边迟早会漂: 一边修好了另一边还在降级,
+# 而 dry-run 恰恰是用户用来"先看看会发生什么"的那条路径。
+#
+# 判不出来一律非 0(fail-closed): 上游拿它当"要不要拒绝"的依据, 那就绝不能在存疑时
+# 退回某个默认关系 —— 默认成 behind 就等于把"判不出来"变成了"那就 reset 吧"。
+_update_release_relation(){
+  local repo="${1:-}" tag="${2:-}" cur tgt rc
+  [[ -n "$repo" && -d "$repo/.git" && -n "$tag" ]] || return 1
+  cur="$(git -C "$repo" rev-parse --verify -q "HEAD^{commit}" 2>/dev/null)" || return 1
+  # `^{commit}` 是必要的: 附注 tag 的对象哈希是 tag 自己而不是它指向的提交, 直接比会永远
+  # 不相等 —— 相等判据静默失效, 而且没有任何迹象。
+  tgt="$(git -C "$repo" rev-parse --verify -q "${tag}^{commit}" 2>/dev/null)" || return 1
+  [[ -n "$cur" && -n "$tgt" ]] || return 1
+  [[ "$cur" == "$tgt" ]] && { printf 'same\n'; return 0; }
+  # `merge-base --is-ancestor` 的退出码分三档: 0=是祖先, 1=不是, 其它=git 自己出错
+  # (对象缺失 / 仓库损坏)。第三档必须与"不是祖先"区分开, 否则一次读坏的仓库会被判成分叉,
+  # 而分叉的处置是拒绝 —— 看着像安全, 实则把"仓库坏了"这条真正的诊断藏起来了。
+  git -C "$repo" merge-base --is-ancestor "$cur" "$tgt" 2>/dev/null; rc=$?
+  case "$rc" in
+    0) printf 'behind\n'; return 0;;
+    1) :;;
+    *) return 1;;
+  esac
+  git -C "$repo" merge-base --is-ancestor "$tgt" "$cur" 2>/dev/null; rc=$?
+  case "$rc" in
+    0) printf 'ahead\n';    return 0;;
+    1) printf 'diverged\n'; return 0;;
+    *) return 1;;
+  esac
+}
+
 cmd_update(){
   need_root update
   # --dry-run 只查看: 不装 git、不迁移、不写任何东西。任一步失败都要返回非 0 并说清是哪一步 ——
@@ -1704,38 +1746,82 @@ cmd_update(){
     tgt="$(git -C "$REPO_DIR" tag -l 'v*' --sort=-v:refname 2>/dev/null | head -1)"
     [[ -n "$tgt" ]] || { c_y "❌ 仓库里没有任何发布 tag(v*)→ 无法确定目标版本"; return 1; }
     echo "当前: $cur_desc   最新发布: $tgt"
-    echo "待更新提交(HEAD..$tgt):"
-    git -C "$REPO_DIR" log --oneline "HEAD..$tgt" 2>/dev/null || echo "  (已是最新或无法比较)"
+    # 关系先判、再决定说什么。以前无论什么关系都打印一段 "待更新提交(HEAD..$tgt):" ——
+    # HEAD 领先 tag 时那个区间是**空的**, 于是屏幕上只剩一个标题, 读起来正好是"没有待更新
+    # 的提交, 已经最新了"。而真相相反: 正式 update 会把机器退回 $tgt。
+    local rel
+    if ! rel="$(_update_release_relation "$REPO_DIR" "$tgt")"; then
+      c_y "❌ 判不出当前提交与 $tgt 的关系(仓库损坏 / 对象缺失)→ 正式 update 也会拒绝执行"; return 1
+    fi
+    case "$rel" in
+      same)   echo "已是最新发布 —— 无需更新。";;
+      behind) echo "待更新提交(HEAD..$tgt):"
+              git -C "$REPO_DIR" log --oneline "HEAD..$tgt" 2>/dev/null || echo "  (读不到区间)";;
+      ahead)  c_y "当前跑的是**尚未发布**的提交, 领先 $tgt $(git -C "$REPO_DIR" rev-list --count "${tgt}..HEAD" 2>/dev/null) 笔:"
+              git -C "$REPO_DIR" log --oneline "${tgt}..HEAD" 2>/dev/null | sed 's/^/  /'
+              c_y "正式 pdg update 会**拒绝**执行, 不会自动降级回 $tgt。"
+              echo "  真要退回该版本, 走 pdg rollback 或重装那一版 —— update 不兼作降级工具。";;
+      diverged)
+              c_y "当前提交与 $tgt 已经**分叉**(互不为祖先)。"
+              c_y "正式 pdg update 会**拒绝**执行: 两个方向都不是「更新」, 而它不猜方向。";;
+    esac
     return 0
   fi
   command -v git >/dev/null || { apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git; }
   _lock   # 取锁(嵌套的 cmd_snapshot 不会重复锁)
-  # ── 「已是最新」短路 ────────────────────────────────────────────────────────
-  # 重复跑 `pdg update` 不该有副作用, 以前每次都照走全程: 多留一份快照(挤占 SNAP_DIR)、
-  # 两次 daemon-reload、重启 pdg-bot(iOS 还要加 probe81/mitm), 并把所有已装文件的 mtime
-  # 刷新一遍。用户数据零损伤, 但"什么都没变"的一次操作在现场看起来像动过全身 —— 事后
-  # 按 mtime 找"这次更新到底改了什么", 得到的是全部文件。
+  # 不是仓库 / 拉不到 tag / 网络不通 → 这一整块都跳过, 照常走完整流程, 让后面各步给出
+  # 自己明确的失败理由。上面的 fetch 静默正是这个意思: 它失败只表示"这里判断不了",
+  # 真正的报错留给下面那次带提示的 fetch。
   #
-  # 判据要求**两件事同时成立**: HEAD 正好落在最新发布 tag 上, 且工作树干净。
-  #   · 只比 tag 不看工作树 → 有人手改坏了仓库文件时, 短路会把 `pdg update` 这条修复路径
-  #     一起堵死, 而那正是最需要它能跑的时候;
-  #   · 不是仓库 / 拉不到 tag / 网络不通 → **不短路**, 照常走完整流程, 让后面各步给出自己
-  #     明确的失败理由。短路是优化, 不能变成第二处会拒绝执行的门。
-  # 这里的 fetch 静默: 它失败只意味着"判断不了, 那就别短路", 真正的报错留给下面那次。
-  if [[ -z "${PDG_UPDATE_FORCE:-}" && -d "${REPO_DIR:-}/.git" ]] \
-     && pdg_fetch_release_tags "$REPO_DIR" >/dev/null 2>&1; then
-    local _cur_sha _tgt_tag _tgt_sha
+  # ── 方向判据: 必须在快照 / 迁移 / 装文件 / 重启**之前** ────────────────────
+  # `git reset --hard` 对方向一视同仁, 所以"这次到底是不是在往前走"必须在动任何东西之前
+  # 先被回答一次。ahead 与 diverged 两态就地返回: 一个生产文件都不动, 不建快照, 不 reset,
+  # 不重启服务。
+  #
+  # 这一段**不受 PDG_UPDATE_FORCE 影响**: 那个开关的语义是"强制重装同一版本", 不是
+  # "允许降级"。让它兼作降级后门的话, 现场只要有人凭印象带上它, 未发布的提交就没了 ——
+  # 而那正是最需要拦住的时刻。
+  #
+  # .git 缺失时不判: 那条路是"重新 clone"的自愈: 一个不是 git 仓库的目录里, 也不可能有
+  # 未发布的本地提交需要保护。
+  if [[ -d "${REPO_DIR:-}/.git" ]] && pdg_fetch_release_tags "$REPO_DIR" >/dev/null 2>&1; then
+    local _tgt_tag _rel
     _tgt_tag="$(git -C "$REPO_DIR" tag -l 'v*' --sort=-v:refname 2>/dev/null | head -1)"
-    _cur_sha="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null)"
-    # `^{commit}` 是必要的: 附注 tag 的对象哈希是 tag 自己, 不是它指向的提交, 直接比会
-    # 永远不相等 —— 短路静默失效, 而且没有任何迹象。
-    _tgt_sha="$(git -C "$REPO_DIR" rev-parse "${_tgt_tag}^{commit}" 2>/dev/null)"
-    if [[ -n "$_tgt_tag" && -n "$_cur_sha" && "$_cur_sha" == "$_tgt_sha" ]] \
-       && git -C "$REPO_DIR" diff --quiet HEAD -- 2>/dev/null \
-       && _update_in_sync "$REPO_DIR"; then
-      c_g "已是最新发布 $_tgt_tag, 且已装文件逐个与仓库一致 —— 无需更新(未建快照, 未重启任何服务)。"
-      echo "  要强制重装同一版本: PDG_UPDATE_FORCE=1 pdg update"
-      return 0
+    if [[ -n "$_tgt_tag" ]]; then
+      if ! _rel="$(_update_release_relation "$REPO_DIR" "$_tgt_tag")"; then
+        c_y "❌ 判不出当前提交与最新发布 $_tgt_tag 的关系(仓库损坏 / 对象缺失), 中止更新。"
+        echo "  没动任何文件: 未建快照, 未 reset, 未重启服务。"
+        return 1
+      fi
+      case "$_rel" in
+        ahead)
+          c_y "❌ 当前跑的是**尚未发布**的提交(领先 $_tgt_tag $(git -C "$REPO_DIR" rev-list --count "${_tgt_tag}..HEAD" 2>/dev/null) 笔), 拒绝更新。"
+          echo "  update 只往前走。退回 $_tgt_tag 是**降级**, 不该由一条例行命令顺手做掉 ——"
+          echo "  真要退回, 走 pdg rollback 或重装那一版。"
+          echo "  没动任何文件: 未建快照, 未 reset, 未重启服务。"
+          return 1;;
+        diverged)
+          c_y "❌ 当前提交与最新发布 $_tgt_tag 已**分叉**(互不为祖先), 拒绝更新。"
+          echo "  两个方向都不是「更新」, 而 update 不猜方向。"
+          echo "  没动任何文件: 未建快照, 未 reset, 未重启服务。"
+          return 1;;
+      esac
+      # ── 「已是最新」短路 ──────────────────────────────────────────────────
+      # 重复跑 `pdg update` 不该有副作用, 以前每次都照走全程: 多留一份快照(挤占 SNAP_DIR)、
+      # 两次 daemon-reload、重启 pdg-bot(iOS 还要加 probe81/mitm), 并把所有已装文件的 mtime
+      # 刷新一遍。用户数据零损伤, 但"什么都没变"的一次操作在现场看起来像动过全身 —— 事后
+      # 按 mtime 找"这次更新到底改了什么", 得到的是全部文件。
+      #
+      # 判据要求**两件事同时成立**: 关系是 same, 且工作树干净、已装文件与仓库一致。
+      # 只比 tag 不看工作树 → 有人手改坏了仓库文件时, 短路会把 `pdg update` 这条修复路径
+      # 一起堵死, 而那正是最需要它能跑的时候。
+      if [[ -z "${PDG_UPDATE_FORCE:-}" && "$_rel" == same ]] \
+         && git -C "$REPO_DIR" diff --quiet HEAD -- 2>/dev/null \
+         && _update_in_sync "$REPO_DIR"; then
+        c_g "已是最新发布 $_tgt_tag, 且已装文件逐个与仓库一致 —— 无需更新(未建快照, 未重启任何服务)。"
+        echo "  要强制重装同一版本: PDG_UPDATE_FORCE=1 pdg update"
+        return 0
+      fi
     fi
   fi
   c_g "更新前留快照…"

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1776,7 +1776,10 @@ _update_mosdns_preflight(){
     2)  echo "  $bin 在那儿但**执行不了**(权限 / 不是可执行文件)";;
     3)  echo "  $bin version **命令非零**(它起不来, 打印出来的版本号不算数)";;
     4)  echo "  $bin version 的输出里**读不出版本号**";;
-    5)  echo "  自报**版本不符**: 跑的是 ${BASH_REMATCH[1]:-未知}, 钉死的另有其值";;
+    5)  local _got _want
+        _got="$("$bin" version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+        _want="$(sed -n 's/^MOSDNS_VER="\(.*\)"/\1/p' "$REPO_DIR/lib/versions.sh" 2>/dev/null | head -1)"
+        echo "  自报**版本不符**: 跑的是 v${_got:-未知}, 钉死的是 ${_want:-未知}";;
     6)  echo "  **SHA256 摘要不符**: 版本号对得上, 但文件**内容**不是官方那一份";;
     10) echo "  读不到 $REPO_DIR/lib/versions.sh —— 无从对照, 不在存疑时动手";;
     11) echo "  本架构($march)在钉值表里没有条目 —— 无从对照, 不在存疑时动手";;

--- a/install.sh
+++ b/install.sh
@@ -446,10 +446,14 @@ apt-get install -y -qq curl tar unzip zstd nftables iproute2 python3 openssl cer
 systemctl enable --now vnstat >/dev/null 2>&1 || true   # 网卡流量统计(轻量, ~3MB)
 
 # ── 2. mosdns ──
-# 按**钉死版本**判定, 不是"装了就算数": 机器上原有的 mosdns(第三方装的/早年老版)会让
-# `command -v mosdns` 成立而整段跳过 —— 既不升到钉死版, 也跳过 SHA256 供应链校验,
-# 安装日志上连"下载 mosdns"这行都不会出现(现场就这么发现的)。
-if ! pdg_mosdns_is_version "$MOSDNS_VER"; then
+# 按**钉死版本 + 二进制内容**判定, 不是"装了就算数", 也不是"自报版本对就算数":
+#   · `command -v mosdns` 成立就跳过 → 既不升到钉死版, 也跳过 SHA256 校验, 安装日志上
+#     连"下载 mosdns"这行都不会出现(现场踩过);
+#   · 只比自报版本就跳过 → 一个**内容不同、自报 v5.3.4** 的二进制同样能让整段被跳过,
+#     而项目原先钉的是下载压缩包的哈希 —— 跳过下载, 那个钉值就永远用不上了。
+# pdg_mosdns_binary_ok 要求版本相同**且** /usr/local/bin/mosdns 的 SHA256 等于该架构的
+# 二进制钉值; 任一不成立就照常走"备份 → 下载 → ZIP 校验 → 解压 → 安装"。
+if ! pdg_mosdns_binary_ok "$MARCH" "$MOSDNS_VER" /usr/local/bin/mosdns; then
   c_g "下载 mosdns $MOSDNS_VER ($MARCH)…"
   t=$(mktemp -d)
   curl -fsSL "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-${MARCH}.zip" -o "$t/m.zip"
@@ -457,6 +461,11 @@ if ! pdg_mosdns_is_version "$MOSDNS_VER"; then
     || { rm -rf "$t"; die "mosdns 二进制校验未通过 → 拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)"; }
   _stash_bin /usr/local/bin/mosdns || die "备份既有 mosdns 失败 → 中止(不在无法回退的前提下覆盖二进制)。"
   (cd "$t" && unzip -q m.zip && install -m755 mosdns /usr/local/bin/mosdns)
+  # 落盘之后再核一次内容。ZIP 校验通过只说明"下载对了", 解压与安装之间还有磁盘、
+  # 有 install、有别的进程 —— 而这个二进制正是下次短路判据要比对的那个文件。
+  pdg_verify_sha256 /usr/local/bin/mosdns "${PDG_SHA256[mosdns-bin-$MARCH]:-}" \
+    "mosdns $MOSDNS_VER 二进制 ($MARCH)" \
+    || { rm -rf "$t"; die "mosdns 二进制内容与钉值不符 → 拒绝继续(ZIP 校验已过, 说明问题出在解压/落盘这一段)"; }
   # shellcheck disable=SC2034  # 保留为"装成功了吗"的标记并保持 trap 前初始化;
   # 回滚已改看 BIN_TXN 事务台账(它才代表"这次碰过目标没有")。
   MOSDNS_INSTALLED=1

--- a/lib/versions.sh
+++ b/lib/versions.sh
@@ -28,6 +28,20 @@ ACME_SH_COMMIT="3661fd86b6304115e42f43910e6dd452ab9866d6"
 declare -A PDG_SHA256=(
   [mosdns-amd64]="3abcc73080789eb1ccca78dab5049b85ac1e9b8f865ab60158a527b77cd72e85"
   [mosdns-arm64]="82d80a1a21606fca0bc6b65ac6f90d30cff6bb4a19a6ab6a246cf247dbb78bc0"
+  # ── mosdns: **解压后二进制**本身的 SHA256 ──────────────────────────────────
+  # 上面两行钉的是下载压缩包。它只在"真的下载了"那条路上起作用 —— 而安装器的短路条件是
+  # "自报版本相同就跳过下载", 于是一个内容不同、自报 v5.3.4 的二进制会让整段安装被跳过,
+  # 连带跳过 ZIP 校验; 落盘的那个文件本身, 项目从来没有钉过。
+  #
+  # 取值步骤(可复现, 换个人来照做应得到同一串):
+  #   1) curl -fsSL https://github.com/IrineSistiana/mosdns/releases/download/v5.3.4/mosdns-linux-<arch>.zip -o m.zip
+  #   2) 先用上面的 [mosdns-<arch>] 校验归档: sha256sum m.zip
+  #   3) 校验通过后才解压: unzip -q m.zip
+  #   4) sha256sum mosdns
+  # 顺序不能颠倒: 先解压再算哈希, 等于给一个来路未经确认的文件盖章(TOFU)。
+  # 版本 v5.3.4, 上游发布日 2026-01-11; 两个架构各自独立下载、独立校验、独立计算。
+  [mosdns-bin-amd64]="5357fbb83c89f0a7acad275b72c33aa70d4c720cb5590525660132b10cee8af9"
+  [mosdns-bin-arm64]="5e651992dbec784df43e0e483428319b0f2892f5fadfd4e39a1462a5d62cb495"
   # mihomo(流量内核): 官方 release 的 mihomo-linux-<arch>-<ver>.gz
   [mihomo-amd64]="60de76a35a6cbf7b4fa4a20f5c257c24345d1d635ab1aa3877022a1997ef413c"
   [mihomo-arm64]="9a868b5e4e0ad91d9d71e1b41b0cfce78aaba44360c30df74a723f8e3926a86c"
@@ -73,6 +87,27 @@ pdg_mosdns_is_version(){
   local want="${1#v}" got
   got="$(pdg_mosdns_version)"; got="${got#v}"
   [[ -n "$got" && "$got" == "$want" ]]
+}
+
+# pdg_mosdns_binary_ok <架构> [期望版本] [二进制路径]
+#   → 0 **仅当**语义版本相同 **且** 该文件的 SHA256 等于该架构的二进制钉值。
+#
+# 安装器拿它当"可以跳过下载吗"的唯一判据。以前那个判据只问版本, 而版本是二进制**自报**的:
+# 换掉内容、保留版本串, 就能让安装器跳过整段下载与校验, 而安装日志上连"下载 mosdns"
+# 这一行都不会出现(这个坑早年在 `command -v mosdns` 上踩过一次, 形态一模一样)。
+#
+# 版本读的是**这个文件**而不是 PATH 上的 mosdns: 问的是"要不要换掉这个文件", 那就必须
+# 问它本人。任何一步存疑一律返回非 0 —— 宁可多装一次, 不能存疑就跳过。
+pdg_mosdns_binary_ok(){
+  local arch="${1:-}" want="${2:-${MOSDNS_VER:-}}" bin="${3:-/usr/local/bin/mosdns}" got exp
+  [[ -n "$arch" && -n "$want" && -x "$bin" ]] || return 1
+  exp="${PDG_SHA256[mosdns-bin-$arch]:-}"
+  [[ -n "$exp" ]] || return 1
+  got="$("$bin" version 2>/dev/null | head -1)" || return 1
+  [[ "$got" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  [[ "${BASH_REMATCH[1]}" == "${want#v}" ]] || return 1
+  got="$(sha256sum "$bin" 2>/dev/null | awk '{print $1}')"
+  [[ -n "$got" && "$got" == "$exp" ]]
 }
 
 # pdg_verify_sha256 <文件> <期望hash> [名称]  → 不符返回非 0 并打印期望/实际

--- a/tests/e2e-install.sh
+++ b/tests/e2e-install.sh
@@ -37,7 +37,12 @@ S
   esac
   chmod 755 "/usr/local/bin/$c"
 done
-# 内核/解析器二进制: 装机会下载并校验 SHA, 这里用桩替代下载(下载与 SHA 校验有专门单测)
+# mosdns 用**真实钉定二进制**播种, 且必须赶在下面把 curl 打桩之前 —— 取件流程要用真 curl。
+# 这样安装器走的是"已有合法二进制 → 严格短路"这条路: 版本与 SHA256 同时命中才跳过下载。
+# 以前这里写的是只会 echo 版本号的 shell 桩: 旧短路只比自报版本所以够用; 现在短路还要比
+# 内容摘要, 桩必然不符 → 进入下载分支 → 撞上下面那个假 curl → 整次装机 die。
+e2e_seed_mosdns_bin || { echo "[FAIL] 播种钉定 mosdns 失败"; exit 1; }
+# 内核二进制: 装机会下载并校验 SHA, 这里用桩替代下载(下载与 SHA 校验有专门单测)
 . "$E2E_ROOT/lib/versions.sh"
 cat > /usr/local/bin/curl <<S
 #!/bin/sh
@@ -53,16 +58,6 @@ esac
 exit 0
 S
 chmod 755 /usr/local/bin/curl
-# 让"已是钉死版本"成立 → 跳过下载分支(下载本身另有单测覆盖)。
-# 宿主已有真二进制时直接用真的(userns 里也改不动它)。
-if ! command -v mosdns >/dev/null 2>&1; then
-cat > /usr/local/bin/mosdns <<S
-#!/bin/sh
-case "\$1" in version) echo "v$MOSDNS_VER";; start) sleep 3600;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mosdns
-fi
 if ! command -v mihomo >/dev/null 2>&1; then
 cat > /usr/local/bin/mihomo <<S
 #!/bin/sh

--- a/tests/e2e-lib.sh
+++ b/tests/e2e-lib.sh
@@ -850,15 +850,39 @@ e2e_fetch_mihomo(){
   gunzip -c "$E2E_TMP/m.gz" > /usr/local/bin/mihomo 2>/dev/null || return 1
   chmod 755 /usr/local/bin/mihomo
 }
+# 播种**真实钉定**的 mosdns 二进制, 并用生产判据复核。
+#
+# 为什么不能用 shell 桩: 一台"装好的网关"按定义就有这个文件, 而安装器的短路与 doctor 的
+# 完整性判据现在都要求它的 SHA256 等于 lib/versions.sh 的钉值。只会 echo 版本号的桩
+# 自报版本是对的、内容是错的 —— 正是这两条判据要抓的形态。夹具里放一个这样的桩,
+# 等于让夹具替被测代码说谎(exact-head CI 33235374627 的六支红灯就是这么来的)。
+#
+# 取件顺序: 已经就位(CI 的 job 用同一份 prepare-mosdns.sh 备好了)→ 直接用, 一次网络请求
+# 都不发; 不在就走那份**既有准备流程**(它自己会核 ZIP 的 SHA256)。让每个用例各下一次
+# 才是真的"新增公网依赖", 所以先复用、后取件。
+#
+# 拿不到就**响亮地失败**, 不 skip: 静默跳过等于把这条夹具契约变回一句空话。
+e2e_seed_mosdns_bin(){
+  local bin=/usr/local/bin/mosdns march
+  march="$(dpkg --print-architecture 2>/dev/null)"; [[ "$march" == arm64 ]] || march=amd64
+  _e2e_mosdns_ok(){
+    # shellcheck source=/dev/null
+    ( . "$E2E_ROOT/lib/versions.sh" 2>/dev/null \
+      && pdg_mosdns_binary_ok "$march" "$MOSDNS_VER" "$bin" )
+  }
+  _e2e_mosdns_ok && return 0
+  rm -f "$bin" 2>/dev/null || true          # 桩清干净再取件
+  hash -r 2>/dev/null || true
+  bash "$E2E_ROOT/tests/prepare-mosdns.sh" >/dev/null 2>&1 || true
+  _e2e_mosdns_ok && return 0
+  echo "[FAIL] 夹具拿不到钉死版 mosdns($march) —— 一台「装好的网关」按定义就有它。" >&2
+  echo "       CI 由 job 的「准备钉死版 mosdns」步骤备好; 本地先跑 sudo bash tests/prepare-mosdns.sh" >&2
+  return 1
+}
+
+# 旧名保留(六支用例在用), 但不再各走各的: 它以前直接 curl 且**不核 SHA256**。
 e2e_fetch_mosdns(){
-  command -v mosdns >/dev/null 2>&1 && return 0
-  # shellcheck source=/dev/null
-  . "$E2E_ROOT/lib/versions.sh"
-  curl -fsSL --retry 2 -m 120 \
-    "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-amd64.zip" \
-    -o "$E2E_TMP/mos.zip" 2>/dev/null || return 1
-  (cd "$E2E_TMP" && unzip -qo mos.zip mosdns) 2>/dev/null || return 1
-  install -m755 "$E2E_TMP/mosdns" /usr/local/bin/mosdns 2>/dev/null || return 1
+  e2e_seed_mosdns_bin
 }
 
 # ── 造现场 ──────────────────────────────────────────────────────────────────
@@ -893,6 +917,10 @@ e2e_reset_botdir(){
 }
 
 e2e_seed_install(){
+  # 一台"已经装好的机器"必须有真实的 mosdns 二进制 —— 没有它, doctor 的完整性判据判 fail,
+  # 而 cmd_update 的自检门看到 fail 就整个回滚。以前这些夹具压根不播种它, 于是
+  # "更新成功"这条正常路径在 CI 上根本走不通, 红的却不是被测代码。
+  e2e_seed_mosdns_bin || return 1
   mkdir -p /opt/pdg-bot /etc/mosdns/rules /etc/privdns-gateway
   cp -a "$E2E_ROOT" /opt/privdns-gateway
   install -m755 "$E2E_ROOT/deploy/bot/pdg.sh" /usr/local/bin/pdg

--- a/tests/e2e-update-ahead-of-release.sh
+++ b/tests/e2e-update-ahead-of-release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 端到端: HEAD **领先**最新发布时, `pdg update` 必须拒绝, 且一个字节都不动。
+#
+# 单测(test-update-release-relation.sh)是把 cmd_update 抽出来打桩跑的 —— 它能证明"没调
+# reset、没调 cmd_snapshot", 但证明不了"盘上真的没变"。快照目录、已装文件的 mode/owner、
+# 受管配置、服务的 InvocationID 这几样, 只有拿装在机器上的那份脚本对着真仓库跑才看得出来。
+#
+# 造的现场就是线上那个: 两台生产机跑着 v1.11.4-7-g86aac93c, 即最新 Release 之后又有 7 笔
+# 已合并但未发布的提交。以前一次普通的 `pdg update` 会把它们静默退回 v1.11.4。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+E2E_ROOT="${E2E_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# shellcheck source=tests/e2e-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/e2e-lib.sh"
+e2e_enter "$@"
+
+command -v git >/dev/null 2>&1 || e2e_skip "无 git"
+e2e_stub_system
+e2e_seed_install
+printf 'android\n' > /etc/privdns-gateway/platform
+printf 'mihomo\n'  > /etc/privdns-gateway/backend
+mkdir -p /var/lib/privdns-gateway
+
+REPO=/opt/privdns-gateway
+ORIGIN=$E2E_TMP/e2e-ahead-origin.git
+rm -rf "$REPO/.git" "$ORIGIN"
+git -C "$REPO" init -q -b main
+e2e_guard_repo "$REPO" || exit 1
+e2e_git "$REPO" config user.email t@t; e2e_git "$REPO" config user.name t
+e2e_git "$REPO" config commit.gpgsign false
+e2e_git "$REPO" add -A >/dev/null 2>&1
+e2e_git "$REPO" commit -qm base >/dev/null 2>&1
+# **附注** tag: 轻量 tag 的对象哈希就是提交, 少写 `^{commit}` 也能碰巧相等 —— 那样这一支
+# 就测不出真正的错误形态了。
+e2e_git "$REPO" tag -a v9.9.8 -m v9.9.8 >/dev/null 2>&1
+# 已合并但**尚未发布**的两笔 —— 线上那 7 笔的同构最小版
+for n in 1 2; do
+  echo "# UNRELEASED-$n" >> "$REPO/deploy/bot/checks.py"
+  e2e_git "$REPO" add -A >/dev/null 2>&1
+  e2e_git "$REPO" commit -qm "unreleased-$n" >/dev/null 2>&1
+done
+git clone -q --bare "$REPO" "$ORIGIN"
+e2e_git "$REPO" remote add origin "$ORIGIN"
+
+HEAD0="$(git -C "$REPO" rev-parse HEAD)"
+{ [[ "$(git -C "$REPO" tag -l 'v*' --sort=-v:refname | head -1)" == v9.9.8 ]] \
+  && [[ "$(git -C "$REPO" rev-list --count v9.9.8..HEAD)" == 2 ]]; } \
+  && ok "现场就位: 最新发布 v9.9.8, HEAD 领先它 2 笔(未发布提交)" \
+  || bad "现场没造对: tag=$(git -C "$REPO" tag -l), 领先 $(git -C "$REPO" rev-list --count v9.9.8..HEAD) 笔"
+
+# ── 前像 ────────────────────────────────────────────────────────────────────
+digest_bot(){ find /opt/pdg-bot -type f -exec sha256sum {} + 2>/dev/null | sort | sha256sum; }
+modes_bot(){ find /opt/pdg-bot -type f -printf '%p %m %u:%g\n' 2>/dev/null | sort | sha256sum; }
+snap_count(){ find /var/lib/privdns-gateway/backups -name snap.tar.gz 2>/dev/null | wc -l; }
+inv_of(){ systemctl show -p InvocationID --value "$1" 2>/dev/null; }
+
+# 给两个受管服务一个可辨识的 InvocationID, 重启才会变
+printf 'INV-MOSDNS-0\n' > "$E2E_TMP/e2e-svc/mosdns.inv"
+printf 'INV-BOT-0\n'    > "$E2E_TMP/e2e-svc/pdg-bot.inv"
+
+B_BOT="$(digest_bot)"; B_MODE="$(modes_bot)"; B_SNAP="$(snap_count)"
+B_CFG="$(sha256sum /etc/mosdns/config.yaml 2>/dev/null | cut -d' ' -f1)"
+B_INV_M="$(inv_of mosdns)"; B_INV_B="$(inv_of pdg-bot)"
+# 只数**会改变系统状态**的那些 verb。show / is-active / is-enabled 是只读查询, 而这一支
+# 自己就要靠 `systemctl show -p InvocationID` 取前像 —— 把它们也数进去, 判据会被自己的
+# 测量动作污染(第一版就是这么红的)。
+mut_calls(){ grep -cE '^systemctl (daemon-reload|restart|start|stop|enable|disable|reset-failed)'                "$E2E_TMP/e2e-calls.log" 2>/dev/null || true; }
+B_CALLS="$(mut_calls)"; B_CALLS="${B_CALLS:-0}"
+
+# ── 正式 update: 必须拒绝 ───────────────────────────────────────────────────
+echo; echo "── 正式 update ──"
+out=$(bash /usr/local/bin/pdg update 2>&1); rc=$?
+[[ "$rc" != 0 ]] && ok "rc 非 0(实得 $rc)" \
+  || bad "领先最新发布却 rc=0 —— 静默降级: $(tail -3 <<<"$out")"
+grep -qE '未发布|领先' <<<"$out" && ok "说清了当前跑的是未发布提交" \
+  || bad "没说原因: $(tail -3 <<<"$out")"
+grep -q '✅ 已更新' <<<"$out" && bad "谎报成功" || ok "没谎报成功"
+
+echo; echo "── 零副作用逐项 ──"
+[[ "$(git -C "$REPO" rev-parse HEAD)" == "$HEAD0" ]] \
+  && ok "git HEAD 未动(仍是 ${HEAD0:0:12})" \
+  || bad "HEAD 变成了 $(git -C "$REPO" rev-parse HEAD) —— 未发布提交被退回了"
+[[ "$(digest_bot)" == "$B_BOT" ]] && ok "/opt/pdg-bot 内容逐字节不变" || bad "已装文件被改了"
+[[ "$(modes_bot)" == "$B_MODE" ]] && ok "/opt/pdg-bot 的 mode/属主不变" || bad "mode/属主被改了"
+[[ "$(sha256sum /etc/mosdns/config.yaml 2>/dev/null | cut -d' ' -f1)" == "$B_CFG" ]] \
+  && ok "受管配置 /etc/mosdns/config.yaml 不变" || bad "配置被改了"
+[[ "$(snap_count)" == "$B_SNAP" ]] \
+  && ok "快照份数不变(仍 $B_SNAP 份 —— 拒绝路径不该留快照)" \
+  || bad "快照从 $B_SNAP 变成 $(snap_count) —— 拒绝路径不该建快照"
+[[ "$(inv_of mosdns)" == "$B_INV_M" ]] && ok "mosdns InvocationID 不变(没被重启)" \
+  || bad "mosdns 被重启了: $B_INV_M → $(inv_of mosdns)"
+[[ "$(inv_of pdg-bot)" == "$B_INV_B" ]] && ok "pdg-bot InvocationID 不变(没被重启)" \
+  || bad "pdg-bot 被重启了: $B_INV_B → $(inv_of pdg-bot)"
+# systemctl 一次都不该被调到(daemon-reload / restart / enable 全在拒绝之后)
+A_CALLS="$(mut_calls)"; A_CALLS="${A_CALLS:-0}"
+[[ "$A_CALLS" == "$B_CALLS" ]] \
+  && ok "整次拒绝没有调过任何会改状态的 systemctl(仍 $B_CALLS 次)" \
+  || bad "调了 $((A_CALLS - B_CALLS)) 次会改状态的 systemctl: $(grep -E '^systemctl (daemon-reload|restart|start|stop|enable|disable|reset-failed)' "$E2E_TMP/e2e-calls.log" | tail -3 | tr '\n' ' ')"
+
+# ── dry-run 也要说清, 且同样零副作用 ────────────────────────────────────────
+echo; echo "── dry-run ──"
+B2="$(digest_bot)"; S2="$(snap_count)"
+out2=$(bash /usr/local/bin/pdg update --dry-run 2>&1)
+grep -qE '未发布|领先' <<<"$out2" && ok "dry-run 说清当前是未发布提交" || bad "dry-run 没说: $out2"
+grep -qE '拒绝|不会自动降级' <<<"$out2" && ok "dry-run 说清正式 update 会拒绝" || bad "dry-run 没说会拒绝"
+grep -q 'HEAD\.\.' <<<"$out2" && bad "dry-run 仍显示空的 HEAD..tag 区间" || ok "不再显示会被误读的空区间"
+{ [[ "$(digest_bot)" == "$B2" ]] && [[ "$(snap_count)" == "$S2" ]]; } \
+  && ok "dry-run 零副作用" || bad "dry-run 改了东西"
+
+# ── 反向对照: 退回 v9.9.8 之后, 同一条命令必须能正常升级 ────────────────────
+# 少了这一格, 把判据写成"永远拒绝"也能全绿, 而那会让 pdg update 彻底失效。
+echo; echo "── 反向对照: 落后时照常升级 ──"
+e2e_git "$REPO" checkout -q v9.9.8
+e2e_git "$REPO" tag -a v9.9.9 -m v9.9.9 main >/dev/null 2>&1
+out3=$(bash /usr/local/bin/pdg update 2>&1); rc3=$?
+grep -qE '未发布|领先|分叉' <<<"$out3" \
+  && bad "落后时也被当成领先/分叉挡住了 —— 判据误伤了正常升级: $(tail -3 <<<"$out3")" \
+  || ok "落后时没有被方向判据挡住"
+# 判据的位置也要对: 它在快照**之前**, 所以"过了这道门"的可观测证据就是这次真的去建快照了。
+# 这一步之后 update 可能因为别的原因失败(沙箱里 mosdns 绑不了 :53), 那与本支无关 ——
+# 本支只负责证明方向判据没有误伤正常升级。
+grep -q '更新前留快照' <<<"$out3" \
+  && ok "落后时真的走进了快照阶段(证明确实越过了方向判据这道门, 而不是恰好也失败了)" \
+  || bad "落后时没走到快照阶段(rc=$rc3): $(tail -3 <<<"$out3")"
+
+e2e_summary

--- a/tests/install-mosdns-artifact.sh
+++ b/tests/install-mosdns-artifact.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# 消费者侧: 把 producer 上传的 mosdns artifact 装到位, 并**自己重新验一遍**。
+#
+# 为什么不能信 artifact 服务端给的摘要: 那是"传输没坏"的证明, 不是"内容是官方那一份"的证明。
+# 这个脚本按当前 checkout 的 lib/versions.sh 重算 SHA256、重核自报版本, 最后再走一次生产判据
+# pdg_mosdns_binary_ok —— 与 install.sh 的严格短路、doctor 的完整性判据是同一个函数。
+#
+# 这里**没有任何联网动作**: 取不到或验不过就硬失败。加"下不到就 curl 一把"的回退, 等于把
+# 每 run 一次取件的约束又放开成每 job 一次(而那正是这一轮要修的东西)。
+# 也不 SKIP —— 静默跳过会让"夹具用了真二进制"这条契约变回一句空话。
+#
+# 用法: install-mosdns-artifact.sh <artifact 解包目录> [架构] [安装目标]
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+DIR="${1:?用法: install-mosdns-artifact.sh <目录> [架构] [目标]}"
+DEST="${3:-/usr/local/bin/mosdns}"
+die(){ echo "[FAIL] $*" >&2; exit 1; }
+
+# shellcheck source=lib/versions.sh
+source "$ROOT/lib/versions.sh" || die "读不到 lib/versions.sh"
+arch="${2:-}"
+if [[ -z "$arch" ]]; then
+  arch="$(dpkg --print-architecture 2>/dev/null)" || arch=""
+  [[ -n "$arch" ]] || case "$(uname -m)" in
+    x86_64) arch=amd64;; aarch64|arm64) arch=arm64;; *) die "不支持的架构 $(uname -m)";;
+  esac
+fi
+want_sha="${PDG_SHA256[mosdns-bin-$arch]:-}"
+[[ -n "$want_sha" ]] || die "lib/versions.sh 里没有 mosdns-bin-$arch 的钉值"
+
+BIN="$DIR/mosdns"
+[[ -f "$BIN" ]] || die "artifact 里没有 mosdns($BIN)"
+
+# ① 自己算摘要 —— 不认服务端摘要, 也不认 manifest 里的数字
+got_sha="$(sha256sum "$BIN" | awk '{print $1}')"
+[[ "$got_sha" == "$want_sha" ]] \
+  || die "artifact 二进制 SHA256 与 lib/versions.sh 钉值不符: 实得 ${got_sha:0:12}…, 钉死 ${want_sha:0:12}…"
+
+# ② manifest 只做交叉核对, 不能替代上面那一步。它说的和我们算的不一致 = 供应链有问题。
+MAN="$DIR/manifest.json"
+if [[ -f "$MAN" ]]; then
+  m_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("binary_sha256",""))' "$MAN" 2>/dev/null)"
+  m_ver="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$MAN" 2>/dev/null)"
+  m_arch="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("arch",""))' "$MAN" 2>/dev/null)"
+  [[ "$m_sha"  == "$got_sha"     ]] || die "manifest 记的摘要与实算不符($m_sha ≠ $got_sha)"
+  [[ "$m_ver"  == "$MOSDNS_VER"  ]] || die "manifest 记的版本与钉值不符($m_ver ≠ $MOSDNS_VER)"
+  [[ "$m_arch" == "$arch"        ]] || die "manifest 记的架构与本机不符($m_arch ≠ $arch)"
+else
+  die "artifact 里没有 manifest.json"
+fi
+
+# ③ 装到位, 再核一次自报版本
+chmod 755 "$BIN" 2>/dev/null || true
+install -m 755 "$BIN" "$DEST" || die "安装到 $DEST 失败"
+got_ver="$("$DEST" version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+[[ "v${got_ver:-}" == "$MOSDNS_VER" ]] \
+  || die "$DEST 自报版本 v${got_ver:-未知} 与钉值 $MOSDNS_VER 不符"
+
+# ④ 最后走生产判据 —— 与 install.sh 的短路、doctor 的完整性判据同一个函数
+pdg_mosdns_binary_ok "$arch" "$MOSDNS_VER" "$DEST" \
+  || die "生产判据 pdg_mosdns_binary_ok 未通过($arch $MOSDNS_VER $DEST)"
+
+echo "[OK] $DEST  $MOSDNS_VER  $arch  sha256 ${got_sha:0:12}…(自算 + manifest 交叉 + 自报版本 + 生产判据 四层过)"

--- a/tests/mosdns-artifact-name.sh
+++ b/tests/mosdns-artifact-name.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# 打印本次 run 用来传递 mosdns 二进制的 artifact 名。
+#
+#   mosdns-<版本>-<架构>-<最终二进制 SHA256 前 12 位>
+#   例: mosdns-v5.3.4-amd64-5357fbb83c89
+#
+# 三段都从 lib/versions.sh 现读, 这里**不写死任何版本号或摘要** —— 名字里带摘要的意义
+# 就在于它由钉值生成: 钉值一改, 名字自动跟着变, 旧 artifact 不可能被错认成新的。
+# producer 与每个 consumer 都调这一份, 于是「上传的叫什么」和「下载的要什么」没有第二个答案。
+#
+# 用法: mosdns-artifact-name.sh [架构]   架构缺省按 dpkg/uname 推断
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+# shellcheck source=lib/versions.sh
+source "$ROOT/lib/versions.sh" || { echo "读不到 lib/versions.sh" >&2; exit 1; }
+
+arch="${1:-}"
+if [[ -z "$arch" ]]; then
+  arch="$(dpkg --print-architecture 2>/dev/null)" || arch=""
+  [[ -n "$arch" ]] || case "$(uname -m)" in
+    x86_64) arch=amd64;; aarch64|arm64) arch=arm64;;
+    *) echo "不支持的架构 $(uname -m)" >&2; exit 1;;
+  esac
+fi
+sha="${PDG_SHA256[mosdns-bin-$arch]:-}"
+[[ -n "$sha" ]] || { echo "lib/versions.sh 里没有 mosdns-bin-$arch 的钉值" >&2; exit 1; }
+printf 'mosdns-%s-%s-%s\n' "$MOSDNS_VER" "$arch" "${sha:0:12}"

--- a/tests/negctl/mosdns-artifact-negative-controls.py
+++ b/tests/negctl/mosdns-artifact-negative-controls.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""负控: mosdns 单次取件 + artifact 扇出这套判据有没有牙。
+
+被盯的是三个文件 —— .github/workflows/ci.yml 的 producer/consumer 拓扑、
+tests/install-mosdns-artifact.sh 的消费者四层复核、tests/mosdns-artifact-name.sh 的
+名字生成。这一支回答: **如果它们退化了, 我们会不会知道?**
+
+做法与本目录其它负控一致: 逐格把代码改坏(只改沙箱副本, 正式树一个字节不动), 再跑两支
+聚焦测试, 看具名失败集合相对基线有没有新增。基线 = 未改坏的同一份副本, 必须全绿。
+
+每格五步, 缺一不算有效: 锚点恰好命中 / YAML 真解析仍过 / 失败集合有具名新增 /
+反向对照零新增 / 正式树 sha256 与 mode 逐字节恢复。
+
+十格:
+  ① 给一个 E2E consumer 恢复直接官方下载
+  ② 消费者加回"下不到就 curl"的联网回退
+  ③ 摘掉消费者的 SHA 校验
+  ④ 摘掉消费者的版本校验
+  ⑤ 摘掉 needs
+  ⑥ artifact 名去掉摘要段
+  ⑦ producer 不再调生产判据
+  ⑧ 改用 actions/cache
+  ⑨ action 改成浮动引用 @main
+  ⑩ 只加无关注释(反向对照)
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ".github/workflows/ci.yml"
+INS = "tests/install-mosdns-artifact.sh"
+NAM = "tests/mosdns-artifact-name.sh"
+TOUCHED = [ROOT / f for f in (CI, INS, NAM)]
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def run(cmd, cwd=None, timeout=900):
+    # errors="replace": 被测脚本可能吐出非 UTF-8 字节(比如 `cut -c` 把一个中文字符切成半个),
+    # 而负控在这里崩掉的话, 后面每一格都不会跑 —— 那是最难查的一种"负控自己坏了"。
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                          timeout=timeout, errors="replace")
+
+
+def failures(out):
+    s = set()
+    for line in out.splitlines():
+        if not line.startswith("[FAIL]"):
+            continue
+        t = re.sub(r"/tmp/[^\s,)\]]+", "/tmp/X", line.strip())
+        t = re.sub(r"\b[0-9a-f]{7,64}\b", "H", t)
+        s.add(t)
+    return s
+
+
+T_TOPO = [sys.executable, "tests/test-ci-mosdns-topology.py"]
+T_TRIP = ["bash", "tests/test-mosdns-artifact-roundtrip.sh"]
+
+
+def suite(wd, cmds):
+    out = ""
+    for c in cmds:
+        out += (lambda r: r.stdout + r.stderr)(run(c, cwd=wd))
+    return failures(out)
+
+
+CONSUMER_DL = '''      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.MOSDNS_ARTIFACT }}
+          path: /tmp/mosdns-fixture
+'''
+MUT = [
+    ("① consumer 恢复直接官方下载", CI,
+     [(CONSUMER_DL,
+       '      - name: "直接下载"\n        run: |\n'
+       '          curl -fsSL -o /tmp/m.zip '
+       '"https://github.com/IrineSistiana/mosdns/releases/download/v5.3.4/mosdns-linux-amd64.zip"\n', 7)],
+     [T_TOPO]),
+    ("② 消费者加回联网 fallback", INS,
+     [('[[ -f "$BIN" ]] || die "artifact 里没有 mosdns($BIN)"',
+       '[[ -f "$BIN" ]] || curl -fsSL -o "$BIN" '
+       '"https://github.com/IrineSistiana/mosdns/releases/download/$MOSDNS_VER/x.zip"', 1)],
+     [T_TOPO, T_TRIP]),
+    ("③ 摘掉消费者 SHA 校验", INS,
+     [('[[ "$got_sha" == "$want_sha" ]] \\\n  || die', 'true \\\n  || die', 1)], [T_TRIP]),
+    ("④ 摘掉消费者版本校验", INS,
+     [('[[ "v${got_ver:-}" == "$MOSDNS_VER" ]] \\\n  || die', 'true \\\n  || die', 1)],
+     [T_TOPO, T_TRIP]),
+    ("⑤ 摘掉 needs", CI,
+     [("    needs: prepare-mosdns-fixture\n", "", 7)], [T_TOPO]),
+    ("⑥ artifact 名去掉摘要段", NAM,
+     [("printf 'mosdns-%s-%s-%s\\n' \"$MOSDNS_VER\" \"$arch\" \"${sha:0:12}\"",
+       "printf 'mosdns-%s-%s\\n' \"$MOSDNS_VER\" \"$arch\"", 1)], [T_TRIP]),
+    ("⑦ producer 不再调生产判据", CI,
+     [('          pdg_mosdns_binary_ok "$ARCH" "$MOSDNS_VER" "$PWD/artifact/mosdns"\n', "", 1)],
+     [T_TOPO]),
+    ("⑧ 改用 actions/cache", CI,
+     [("      - uses: actions/upload-artifact@v4\n",
+       "      - uses: actions/cache@v4\n", 1)], [T_TOPO]),
+    ("⑨ action 改成浮动引用", CI,
+     [("      - uses: actions/download-artifact@v4\n",
+       "      - uses: actions/download-artifact@main\n", 7)], [T_TOPO]),
+    ("⑩ 只加一行无关注释(反向对照)", INS,
+     [("die(){ echo", "# (负控的空转对照, 不改变任何行为)\ndie(){ echo", 1)], [T_TOPO, T_TRIP]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+
+wd = tmpguard.mkdtemp(prefix="pdg-artifact-negctl.")
+try:
+    for sub in ("tests", "lib", "deploy"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True,
+                        symlinks=True, ignore=shutil.ignore_patterns("__pycache__"))
+    os.makedirs(Path(wd) / ".github/workflows", exist_ok=True)
+    shutil.copy2(ROOT / CI, Path(wd) / CI)
+    pristine = {rel: (Path(wd) / rel).read_text(encoding="utf-8") for rel in (CI, INS, NAM)}
+
+    print("══ 基线(未改坏的同一份副本)══")
+    base = set()
+    for tag, cmds in (("topo", [T_TOPO]), ("trip", [T_TRIP])):
+        f = suite(wd, cmds)
+        (ok if not f else bad)("基线 %s 全绿(失败 %d)" % (tag, len(f)))
+        base |= f
+    if base:
+        bad("基线不绿 —— 后面每一格的「新增」都算不出来")
+        for x in sorted(base)[:4]:
+            print("       %s" % x[:150])
+
+    for tag, rel, edits, cmds in MUT:
+        print()
+        print("── %s ──" % tag)
+        text = pristine[rel]
+        good = True
+        for anchor, repl, want in edits:
+            hits = text.count(anchor)
+            print("   锚点命中 %d 次(期望 %d)" % (hits, want))
+            if hits != want:
+                bad("%s: 锚点命中 %d 次, 期望 %d —— 产品换写法了, 这一格没测到东西"
+                    % (tag, hits, want))
+                good = False
+                break
+            text = text.replace(anchor, repl, want)
+        if not good:
+            continue
+        (Path(wd) / rel).write_text(text, encoding="utf-8")
+        # YAML / bash 语法门: 改坏后必须仍能解析, 否则红的是语法不是判据
+        if rel.endswith(".yml"):
+            try:
+                import yaml
+                yaml.safe_load((Path(wd) / rel).read_text(encoding="utf-8"))
+                print("   YAML 真解析: 过")
+            except Exception as e:                                   # noqa: BLE001
+                bad("%s: 改坏后 YAML 解析不了(%s)" % (tag, str(e)[:80]))
+                (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+                continue
+        else:
+            r = run(["bash", "-n", rel], cwd=wd)
+            print("   bash -n: %s" % ("过" if r.returncode == 0 else "不过"))
+            if r.returncode != 0:
+                bad("%s: 改坏后 bash -n 不过" % tag)
+                (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+                continue
+        got = set()
+        for c in cmds:
+            got |= suite(wd, [c])
+        newf = got - base
+        if tag.startswith("⑩"):
+            (ok if not newf else
+             bad)("反向对照: 无关注释新增失败 %d 条(应为 0)%s"
+                  % (len(newf), (" —— " + "; ".join(sorted(newf))[:150]) if newf else ""))
+        else:
+            (ok if newf else
+             bad)("%s → 新增具名失败 %d 条%s"
+                  % (tag, len(newf), (": " + sorted(newf)[0][:105]) if newf else " —— 0 条转红, 这一格无效"))
+        (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+print()
+print("══ 正式树逐字节恢复 ══")
+for p in TOUCHED:
+    (ok if sha(p) == before[p] else bad)("%s sha256 未变" % Path(p).name)
+    (ok if os.stat(p).st_mode == modes[p] else bad)("%s mode 未变" % Path(p).name)
+
+print("-" * 62)
+print("mosdns-artifact-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/negctl/mosdns-preflight-negative-controls.py
+++ b/tests/negctl/mosdns-preflight-negative-controls.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""负控: mosdns 前置预检与 E2E 夹具契约这两组判据有没有牙。
+
+被盯的是三个文件 —— pdg.sh 的更新前预检、checks.py 的 doctor 分级、lib/versions.sh 的
+严格判据; 外加 tests/e2e-lib.sh 与 tests/e2e-install.sh 这两份夹具。这一支回答的是
+另一个问题: **如果它们退化了, 我们会不会知道?**
+
+做法与本目录其它负控一致: 逐格把代码改坏(只改沙箱副本, 正式树一个字节不动), 再跑对应的
+聚焦测试, 看具名失败集合相对基线有没有新增。基线 = 未改坏的同一份副本, 必须全绿。
+
+每格五步, 缺一不算有效:
+  · 锚点在整份文件里**恰好命中**预期次数;
+  · 替换确实落进了文件;
+  · 改坏后语法门仍过(bash -n / py_compile)—— 语法错造成的红不算"判据抓住了";
+  · 失败集合有**具名新增**(0 条转红 = 这一格无效, 判 FAIL);
+  · 恢复后正式树 sha256 与 mode 逐字节一致。
+
+七格:
+  ① 删掉更新前的完整性预检      —— 回到"做完一遍再回滚"的循环
+  ② 把预检挪到快照之后          —— 位置错了等于没有(副作用已经发生)
+  ③ 缺文件从 fail 降成 warn     —— doctor 不再把"核心文件不在"当故障
+  ④ check_mosdns_binary 移出 ALL —— 判据还在, 但永远不会跑
+  ⑤ shell 假桩重新被接受        —— 短路只比自报版本, 内容无人管
+  ⑥ 摘掉 SHA256 那一步          —— 判据只剩版本
+  ⑦ 更新后判红不再回滚          —— 那道安全门被放松
+  ⑧ 只加一行无关注释            —— 反向对照, 不该有任何新失败
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+PDG = "deploy/bot/pdg.sh"
+CHK = "deploy/bot/checks.py"
+VER = "lib/versions.sh"
+ELIB = "tests/e2e-lib.sh"
+EINS = "tests/e2e-install.sh"
+TOUCHED = [ROOT / f for f in (PDG, CHK, VER, ELIB, EINS)]
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def run(cmd, cwd=None, timeout=900):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+
+
+def failures(out):
+    s = set()
+    for line in out.splitlines():
+        if not line.startswith("[FAIL]"):
+            continue
+        t = re.sub(r"/tmp/[^\s,)\]]+", "/tmp/X", line.strip())
+        t = re.sub(r"\b[0-9a-f]{7,64}\b", "H", t)
+        t = re.sub(r"\b\d{4,}\b", "N", t)
+        s.add(t)
+    return s
+
+
+T_PRE = ["bash", "tests/test-update-mosdns-preflight.sh"]
+T_FIX = ["python3", "tests/test-e2e-mosdns-fixture.py"]
+T_MOS = ["python3", "tests/test-mosdns-binary-evidence.py"]
+T_REL = ["bash", "tests/test-update-release-relation.sh"]
+
+
+def suite(wd, cmds):
+    out = ""
+    for c in cmds:
+        r = run(c, cwd=wd)
+        out += r.stdout + r.stderr
+    return failures(out)
+
+
+PRE_CALL = '''      if [[ "$_rel" == behind ]] && ! _update_mosdns_preflight; then
+        return 1
+      fi
+'''
+MUT = [
+    ("① 删掉更新前的完整性预检", PDG, [(PRE_CALL, "", 1)], [T_PRE]),
+    # 位置错了等于没有: 副作用已经发生, 剩下的只是"做完再退回来"
+    ("② 把预检挪到快照之后", PDG,
+     [(PRE_CALL, "", 1),
+      ('  c_g "更新前留快照…"\n',
+       '  c_g "更新前留快照…"\n  _update_mosdns_preflight || return 1\n', 1)], [T_PRE]),
+    ("③ 缺文件从 fail 降成 warn", CHK,
+     [('        return ("fail", name, "读不到 %s(%s)" % (b, e.strerror or e.errno))',
+       '        return ("warn", name, "读不到 %s(%s)" % (b, e.strerror or e.errno))', 1)],
+     [T_MOS]),
+    ("④ check_mosdns_binary 移出 ALL", CHK,
+     [("check_mosdns_version, check_mosdns_binary,", "check_mosdns_version,", 1)], [T_MOS]),
+    ("⑤ shell 假桩重新被接受(短路只比自报版本)", VER,
+     [('  got="$(sha256sum "$bin" 2>/dev/null | awk \'{print $1}\')"\n'
+       '  [[ -n "$got" && "$got" == "$exp" ]]',
+       '  return 0', 1)], [T_MOS, T_FIX]),
+    ("⑥ 摘掉预检里的 SHA256 裁决", PDG,
+     [('    pdg_mosdns_binary_ok "$march" "$MOSDNS_VER" "$bin" && exit 0',
+       '    [[ -x "$bin" ]] && exit 0', 1)], [T_PRE]),
+    # 变异要真的把回滚拿掉。第一版只替换了那句提示文案, 而下一行的 cmd_rollback 照跑 ——
+    # 于是"新增失败 0 条", 看着像判据没牙, 实际是变异没打中(负控自己空转了)。
+    ("⑦ 更新后判红不再回滚", PDG,
+     [('    c_y "自检发现 $nfail 项失败, 回滚到更新前快照:"\n'
+       "    sed -n '2,/^@@WARN@@$/p' <<<\"$summary\" | sed '/^@@WARN@@$/d'\n"
+       '    cmd_rollback --dir "$snap_dir" --git "$pre_sha"; return 1',
+       '    c_y "自检发现 $nfail 项失败(变异: 不回滚)"\n'
+       '    return 1', 1)],
+     [T_PRE]),
+    ("⑧ 只加一行无关注释(反向对照)", PDG,
+     [("_update_mosdns_preflight(){",
+       "# (负控的空转对照, 不改变任何行为)\n_update_mosdns_preflight(){", 1)],
+     [T_PRE, T_FIX, T_MOS, T_REL]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+
+wd = tmpguard.mkdtemp(prefix="pdg-mospre-negctl.")
+try:
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True,
+                        symlinks=True, ignore=shutil.ignore_patterns("__pycache__"))
+    shutil.copy2(ROOT / "install.sh", Path(wd) / "install.sh")
+    os.makedirs(Path(wd) / ".github/workflows", exist_ok=True)
+    shutil.copy2(ROOT / ".github/workflows/ci.yml", Path(wd) / ".github/workflows/ci.yml")
+    pristine = {rel: (Path(wd) / rel).read_text(encoding="utf-8")
+                for rel in (PDG, CHK, VER, ELIB, EINS)}
+
+    print("══ 基线(未改坏的同一份副本)══")
+    base = {}
+    for tag, cmds in (("pre", [T_PRE]), ("fix", [T_FIX]), ("mos", [T_MOS]), ("rel", [T_REL])):
+        base[tag] = suite(wd, cmds)
+        (ok if not base[tag] else bad)("基线 %s 全绿(失败 %d)" % (tag, len(base[tag])))
+    base_all = set().union(*base.values())
+    if base_all:
+        bad("基线不绿 —— 后面每一格的「新增」都算不出来, 本轮负控结果不可信")
+        for f in sorted(base_all)[:4]:
+            print("       %s" % f[:150])
+
+    for tag, rel, edits, cmds in MUT:
+        print()
+        print("── %s ──" % tag)
+        text = pristine[rel]
+        good = True
+        for anchor, repl, want in edits:
+            hits = text.count(anchor)
+            print("   锚点命中 %d 次(期望 %d)" % (hits, want))
+            if hits != want:
+                bad("%s: 锚点命中 %d 次, 期望 %d —— 产品换写法了, 这一格没测到东西"
+                    % (tag, hits, want))
+                good = False
+                break
+            text = text.replace(anchor, repl, want)
+        if not good:
+            continue
+        (Path(wd) / rel).write_text(text, encoding="utf-8")
+        if (Path(wd) / rel).read_text(encoding="utf-8") == pristine[rel]:
+            bad("%s: 替换没落进文件" % tag)
+            (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+            continue
+        syn = (run(["bash", "-n", rel], cwd=wd) if rel.endswith(".sh")
+               else run(["python3", "-m", "py_compile", rel], cwd=wd))
+        print("   语法门: %s" % ("过" if syn.returncode == 0 else "不过"))
+        if syn.returncode != 0:
+            bad("%s: 改坏后语法门不过 —— 语法错造成的红不算判据抓住了(%s)"
+                % (tag, (syn.stderr or "").strip()[:120]))
+            (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+            continue
+        got = set()
+        for c in cmds:
+            got |= suite(wd, [c])
+        newf = got - base_all
+        if tag.startswith("⑧"):
+            (ok if not newf else
+             bad)("反向对照: 无关注释新增失败 %d 条(应为 0)%s"
+                  % (len(newf), (" —— " + "; ".join(sorted(newf))[:160]) if newf else ""))
+        else:
+            (ok if newf else
+             bad)("%s → 新增具名失败 %d 条%s"
+                  % (tag, len(newf), (": " + sorted(newf)[0][:110]) if newf else " —— 0 条转红, 这一格无效"))
+        (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+print()
+print("══ 正式树逐字节恢复 ══")
+for p in TOUCHED:
+    (ok if sha(p) == before[p] else bad)("%s sha256 未变" % Path(p).name)
+    (ok if os.stat(p).st_mode == modes[p] else bad)("%s mode 未变" % Path(p).name)
+
+print("-" * 62)
+print("mosdns-preflight-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/negctl/release-diagnostic-negative-controls.py
+++ b/tests/negctl/release-diagnostic-negative-controls.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""负控:发布安全与诊断诚实性这几条判据有没有牙。
+
+被盯的是四个生产文件 —— pdg.sh 的更新方向判据与去广告只读状态、checks.py 的 mosdns 证据、
+lib/versions.sh 的二进制钉值、install.sh 的安装短路。这一支回答的是另一个问题:
+**如果它们退化了, 我们会不会知道?**
+
+做法与本目录其它负控一致: 逐格把生产代码改坏(只改沙箱副本, 正式树一个字节不动), 再跑
+对应的聚焦测试, 看具名失败集合相对基线有没有新增。基线 = 未改坏的同一份副本, 必须全绿。
+
+每格五步, 缺一不算有效:
+  · 锚点在整份文件里**恰好命中**预期次数;
+  · 替换确实落进了文件;
+  · 改坏后语法门仍过(bash -n / py_compile)—— 语法错造成的红不算"判据抓住了";
+  · 失败集合有**具名新增**(0 条转红 = 这一格无效, 判 FAIL);
+  · 恢复后正式树 sha256 与 before-image 逐字节一致。
+
+十四格:
+  ① 摘掉"当前领先"硬门          —— 未发布提交会被静默退回上一个 Release
+  ② 祖先方向写反                —— 正常升级会被误判成降级而拒绝
+  ③ 分叉被当成可以更新          —— reset 打在一条没人要的方向上
+  ④ dry-run 退回旧的空区间文案  —— 屏幕上只剩标题, 读起来正好是"已是最新"
+  ⑤ mosdns 判据不看退出码       —— 崩溃前打印的版本号被当成成功证据
+  ⑥ mosdns 判据跟着 PATH 走     —— 报的不是 systemd 在跑的那个文件
+  ⑦ 二进制判据永远说一致        —— 同版本换内容不再有人管
+  ⑧ 二进制钉值被改坏            —— 钉值本身要有守卫
+  ⑨ 安装短路改回只看自报版本    —— 跳过下载 = 跳过供应链校验
+  ⑩ 去广告 unknown 折回 disabled —— 权限问题被显示成"这台机器没开"
+  ⑪ 缺规则文件仍显示 0 条       —— 证据缺失被说成一个事实
+  ⑫ 自定义计数恒 0(假牙那一格)  —— 子串断言抓不到, 具名断言必须抓到
+  ⑬ 只加无关注释                —— 反向对照, 不该有任何新失败
+  ⑭ 行为探针(不改代码): PATH 前面搁假 mosdns / ZIP 对但二进制不对必须拒装
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+PDG = "deploy/bot/pdg.sh"
+CHK = "deploy/bot/checks.py"
+VER = "lib/versions.sh"
+INS = "install.sh"
+TOUCHED = [ROOT / PDG, ROOT / CHK, ROOT / VER, ROOT / INS]
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+def run(cmd, cwd=None, timeout=900, env=None):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                          timeout=timeout, env=env)
+
+
+def failures(out):
+    """具名失败集合, 归一化掉临时目录 / 哈希 / 大数。"""
+    s = set()
+    for line in out.splitlines():
+        if not line.startswith("[FAIL]"):
+            continue
+        t = re.sub(r"/tmp/[^\s,)\]]+", "/tmp/X", line.strip())
+        t = re.sub(r"\b[0-9a-f]{12,64}\b", "H", t)
+        t = re.sub(r"\b\d{4,}\b", "N", t)
+        s.add(t)
+    return s
+
+
+T_REL = ["bash", "tests/test-update-release-relation.sh"]
+T_MOS = ["python3", "tests/test-mosdns-binary-evidence.py"]
+T_TRI = ["python3", "tests/test-adblock-status-tristate.py"]
+T_LINE = ["python3", "tests/test-status-adblock-line.py"]
+
+
+def suite(wd, cmds):
+    out = ""
+    for c in cmds:
+        r = run(c, cwd=wd)
+        out += r.stdout + r.stderr
+    return failures(out)
+
+
+# 每格 = (标签, 文件, [(锚点, 替换, 预期命中数)], 跑哪几支)
+MUT = [
+    ("① 摘掉「当前领先」硬门", PDG,
+     [("        ahead)\n", "        __never_ahead__)\n", 1)], [T_REL]),
+    ("② 祖先方向写反", PDG,
+     [("    0) printf 'behind\\n'; return 0;;", "    0) printf 'ahead\\n'; return 0;;", 1)], [T_REL]),
+    ("③ 分叉被当成可以更新", PDG,
+     [("    1) printf 'diverged\\n'; return 0;;", "    1) printf 'behind\\n'; return 0;;", 1)], [T_REL]),
+    ("④ dry-run 退回旧的空区间文案", PDG,
+     [('      ahead)  c_y "当前跑的是**尚未发布**的提交, 领先 $tgt',
+       '      ahead)  echo "待更新提交(HEAD..$tgt):"; c_y "领并 $tgt', 1)], [T_REL]),
+    ("⑤ mosdns 判据不看退出码", CHK,
+     [('    if rc != 0:\n        return ("warn", name,\n'
+       '                "%s version 退出码非 0(rc=%s)',
+       '    if False:\n        return ("warn", name,\n'
+       '                "%s version 退出码非 0(rc=%s)', 1)],
+     [T_MOS]),
+    ("⑥ mosdns 判据跟着 PATH 走", CHK,
+     [('rc, out, err = _run([MOSDNS_BIN, "version"])', 'rc, out, err = _run(["mosdns", "version"])', 1)],
+     [T_MOS]),
+    ("⑦ 二进制判据永远说一致", CHK,
+     [("    if got == pin:\n", "    if True:\n", 1)], [T_MOS]),
+    ("⑧ 二进制钉值被改坏", VER,
+     [("  [mosdns-bin-amd64]=\"", "  [mosdns-bin-amd64]=\"0", 1)], [T_MOS]),
+    ("⑨ 安装短路改回只看自报版本", INS,
+     [('if ! pdg_mosdns_binary_ok "$MARCH" "$MOSDNS_VER" /usr/local/bin/mosdns; then',
+       'if ! pdg_mosdns_is_version "$MOSDNS_VER"; then', 1)], [T_MOS]),
+    ("⑩ 去广告 unknown 折回 disabled", PDG,
+     [("    *) printf 'unknown';;\n  esac\n}", "    *) printf 'disabled';;\n  esac\n}", 1)], [T_TRI]),
+    ("⑪ 缺规则文件仍显示 0 条", PDG,
+     [("  if ! _adb_rules_readable \"$ADB_STATE_DIR/effective_list.txt\" \\\n"
+       "     || ! _adb_rules_readable \"$ADB_USER_BLOCK\"; then",
+       "  if false; then", 1)], [T_TRI]),
+    ("⑫ 自定义计数恒 0(假牙那一格)", PDG,
+     [('  usr="$(_adb_count_rules "$ADB_USER_BLOCK")"', "  usr=0", 1)], [T_LINE]),
+    ("⑬ 只加一行无关注释(反向对照)", PDG,
+     [("_adb_rules_readable(){", "# (负控的空转对照, 不改变任何行为)\n_adb_rules_readable(){", 1)],
+     [T_REL, T_TRI, T_LINE]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+
+wd = tmpguard.mkdtemp(prefix="pdg-relsafe-negctl.")
+try:
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True,
+                        symlinks=True, ignore=shutil.ignore_patterns("__pycache__"))
+    shutil.copy2(ROOT / INS, Path(wd) / INS)
+    pristine = {rel: (Path(wd) / rel).read_text(encoding="utf-8")
+                for rel in (PDG, CHK, VER, INS)}
+
+    print("══ 基线(未改坏的同一份副本)══")
+    base = {}
+    for tag, cmds in (("rel", [T_REL]), ("mos", [T_MOS]), ("tri", [T_TRI]), ("line", [T_LINE])):
+        base[tag] = suite(wd, cmds)
+        (ok if not base[tag] else bad)("基线 %s 全绿(失败 %d)" % (tag, len(base[tag])))
+    base_all = set().union(*base.values())
+    if base_all:
+        bad("基线不绿 —— 后面每一格的「新增」都算不出来, 本轮负控结果不可信")
+
+    for tag, rel, edits, cmds in MUT:
+        print()
+        print("── %s ──" % tag)
+        text = pristine[rel]
+        good = True
+        for anchor, repl, want in edits:
+            hits = text.count(anchor)
+            if hits != want:
+                bad("%s: 锚点命中 %d 次, 期望 %d —— 产品换写法了, 这一格没测到东西"
+                    % (tag, hits, want))
+                good = False
+                break
+            text = text.replace(anchor, repl, want)
+        if not good:
+            continue
+        (Path(wd) / rel).write_text(text, encoding="utf-8")
+        if (Path(wd) / rel).read_text(encoding="utf-8") == pristine[rel]:
+            bad("%s: 替换没落进文件" % tag)
+            (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+            continue
+        syn = (run(["bash", "-n", rel], cwd=wd) if rel.endswith(".sh")
+               else run(["python3", "-m", "py_compile", rel], cwd=wd))
+        if syn.returncode != 0:
+            bad("%s: 改坏后语法门不过 —— 语法错造成的红不算判据抓住了(%s)"
+                % (tag, (syn.stderr or "").strip()[:120]))
+            (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+            continue
+        got = set()
+        for c in cmds:
+            got |= suite(wd, [c])
+        newf = got - base_all
+        if tag.startswith("⑬"):
+            (ok if not newf else
+             bad)("反向对照: 无关注释新增失败 %d 条(应为 0)%s"
+                  % (len(newf), (" —— " + "; ".join(sorted(newf))[:160]) if newf else ""))
+        else:
+            (ok if newf else
+             bad)("%s → 新增具名失败 %d 条%s"
+                  % (tag, len(newf), (": " + sorted(newf)[0][:110]) if newf else " —— 0 条转红, 这一格无效"))
+        (Path(wd) / rel).write_text(pristine[rel], encoding="utf-8")
+
+    # ── ⑭ 行为探针: 不改代码, 直接问产品 ──────────────────────────────────
+    print()
+    print("── ⑭ 行为探针 ──")
+    # (a) PATH 最前面搁一个假 mosdns: 判据必须仍然去问 /usr/local/bin/mosdns
+    sb = Path(wd) / "fakebin"
+    sb.mkdir(exist_ok=True)
+    (sb / "mosdns").write_text('#!/bin/sh\necho "mosdns v0.0.1-fake"\n')
+    os.chmod(sb / "mosdns", 0o755)
+    probe = (
+        "import sys, os; sys.path.insert(0, %r)\n"
+        "import checks\n"
+        "seen = []\n"
+        "orig = checks._run\n"
+        "def f(cmd, *a, **k):\n"
+        "    seen.append(cmd[0]); return (0, 'mosdns v0.0.1-fake\\n', '')\n"
+        "checks._run = f\n"
+        "checks.check_mosdns_version()\n"
+        "print(seen[0])\n" % str(Path(wd) / "deploy/bot"))
+    env = dict(os.environ, PATH="%s:%s" % (sb, os.environ.get("PATH", "")),
+               PDG_REPO_ROOT=str(wd))
+    r = run(["python3", "-c", probe], cwd=wd, env=env)
+    called = (r.stdout or "").strip()
+    (ok if called == "/usr/local/bin/mosdns" else
+     bad)("PATH 前面搁假 mosdns, 判据仍问 /usr/local/bin/mosdns(实得 %r)" % called)
+
+    # (b) ZIP 摘要对、解压出来的二进制不对 → 必须拒装
+    # 抽出 install.sh 的 mosdns 段, 把外部副作用全打桩, 用一个"ZIP 哈希对得上、
+    # 但解压出来的内容是别的"的现场喂它。
+    seg = re.search(r"# ── 2\. mosdns ──.*?(?=# ── 3\.)",
+                    (Path(wd) / INS).read_text(encoding="utf-8"), re.S)
+    if not seg:
+        bad("抽不到 install.sh 的 mosdns 安装段 —— 这一格没测到东西")
+    else:
+        box = Path(wd) / "instbox"
+        shutil.rmtree(box, ignore_errors=True)
+        box.mkdir()
+        (box / "seg.sh").write_text(seg.group(0), encoding="utf-8")
+        zip_sha = hashlib.sha256(b"the-archive").hexdigest()
+
+        def drive(bin_sha_matches):
+            """跑一次安装段。bin_sha_matches=False 表示「ZIP 对、落盘二进制不对」。"""
+            wrong = "0" * 64
+            # 拒装那条路会 `rm -rf "$t"` 清掉临时目录, 而 $t 正是这个沙箱(mktemp 被打桩成
+            # 它)。所以每次都重建, 否则第二次调用连驱动脚本都写不进去。
+            shutil.rmtree(box, ignore_errors=True)
+            box.mkdir(parents=True)
+            (box / "seg.sh").write_text(seg.group(0), encoding="utf-8")
+            drv = f'''
+set -uo pipefail
+source "{wd}/lib/versions.sh"
+MARCH=amd64
+PDG_SHA256[mosdns-amd64]="{zip_sha}"
+BIN_PIN="${{PDG_SHA256[mosdns-bin-amd64]}}"
+c_g(){{ echo "$*"; }}
+die(){{ echo "DIE: $*"; exit 9; }}
+_stash_bin(){{ return 0; }}
+curl(){{ printf 'the-archive' > "{box}/m.zip"; return 0; }}
+mktemp(){{ echo "{box}"; }}
+unzip(){{ printf 'x' > "{box}/mosdns"; return 0; }}
+install(){{ return 0; }}
+pdg_mosdns_binary_ok(){{ return 1; }}   # 强制进入下载分支
+# 关键: 探针不能去核**本机真实的** /usr/local/bin/mosdns —— 这台机器上它恰好就是官方
+# 原版, 于是那一步永远通过, 而这一格本来要测的正是它不通过时会怎样。
+sha256sum(){{
+  case "$1" in
+    *m.zip)               echo "{zip_sha}  $1";;
+    /usr/local/bin/mosdns) echo "{{BINSHA}}  $1";;
+    *)                    command sha256sum "$@";;
+  esac
+}}
+cd "{box}"
+source "{box}/seg.sh"
+echo "REACHED-END"
+'''
+            drv = drv.replace("{BINSHA}", "$BIN_PIN" if bin_sha_matches else wrong)
+            (box / "drv.sh").write_text(drv, encoding="utf-8")
+            return run(["bash", str(box / "drv.sh")], cwd=str(box))
+
+        rr = drive(False)
+        outs = (rr.stdout or "") + (rr.stderr or "")
+        refused = ("DIE:" in outs) and ("REACHED-END" not in outs)
+        (ok if refused else
+         bad)("ZIP 摘要对但落盘二进制不对 → 拒装(rc=%s, 输出 %r)"
+              % (rr.returncode, outs.strip()[:180]))
+        # 反向对照: 两个摘要都对时必须走完, 否则上面那格的红说明不了任何事
+        rr2 = drive(True)
+        outs2 = (rr2.stdout or "") + (rr2.stderr or "")
+        (ok if "REACHED-END" in outs2 and "DIE:" not in outs2 else
+         bad)("反向对照: 两个摘要都对时应装完(rc=%s, 输出 %r)"
+              % (rr2.returncode, outs2.strip()[:180]))
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+print()
+print("══ 正式树逐字节恢复 ══")
+for p in TOUCHED:
+    same = sha(p) == before[p]
+    (ok if same else bad)("%s sha256 未变" % Path(p).name)
+    (ok if os.stat(p).st_mode == modes[p] else bad)("%s mode 未变" % Path(p).name)
+
+print("-" * 62)
+print("release-diagnostic-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/p2-revpatch.py
+++ b/tests/p2-revpatch.py
@@ -58,14 +58,14 @@ def main(argv):
     old_start = '    [[ "$ac0" == active  ]] && { systemctl start  "$T" >/dev/null 2>&1 || _rbad=1; }'
     src = rev(src, new_start, old_start, "_restore 的 start 那行")
 
-    # ③ cmd_update: 整段拿掉「已是最新」短路(从注释头到 "更新前留快照" 那行之前)
-    head = '  # ── 「已是最新」短路 '
-    tail = '  c_g "更新前留快照…"'
-    if src.count(head) != 1 or src.count(tail) != 1:
-        raise SystemExit("反向补丁打空: 定位不到「已是最新」短路段")
-    i = src.index(head)
-    j = src.index(tail, i)
-    src = src[:i] + src[j:]
+    # ③ cmd_update: 让「已是最新」短路永远不成立。
+    #    以前是"从注释头整段切到 '更新前留快照' 那行", 但短路现在嵌在方向判据(same/behind/
+    #    ahead/diverged)那个 if 里 —— 按行区间切会把外层的 fi 一起带走, 得到的 $OLD 语法就坏了。
+    #    一份跑不起来的"旧版"当然不会建快照, 于是对照格看着与新版一致, 安静地失去判别力
+    #    (那正是本文件开头说的最糟情形)。改成动条件本身: 最小、局部, 且 $OLD 仍是可执行的。
+    new_sc = '[[ -z "${PDG_UPDATE_FORCE:-}" && "$_rel" == same ]]'
+    old_sc = '[[ -z "${PDG_UPDATE_FORCE:-}" && "$_rel" == __no_shortcircuit__ ]]'
+    src = rev(src, new_sc, old_sc, "「已是最新」短路的条件")
 
     io.open(argv[2], "w", encoding="utf-8").write(src)
     return 0

--- a/tests/test-adblock-count-locale.sh
+++ b/tests/test-adblock-count-locale.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 规则计数只做**局部** ASCII 优化: LC_ALL=C 只挂在 _adb_count_rules 那一次 grep 上。
+#
+# 由来: 二十多万条的第三方表上, UTF-8 locale 里 `grep -vcE '^[[:space:]]*(#|$)'` 要为每个
+# 字节做多字节解码, 而规则文件的内容契约是**纯 ASCII**(adblock.py 的 _DOMAIN_RE 只放行
+# [a-z0-9_-] 与点)。那笔解码开销是白花的。
+#
+# 但"快"不是这一支要钉的东西 —— 时间阈值会随机器和 grep 版本抖, 钉在 CI 里只会变成一条
+# 定期误报的判据。这里钉的是**语义**: 同一份输入, C 与 UTF-8 两种 locale 下必须数出同一个
+# 数; 以及优化没有偷偷换掉计数口径(不缓存、不改格式、不拿 meta.json 冒充盘上真实条数)。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-adbloc.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+SRC="$ROOT/deploy/bot/pdg.sh"
+sed -n '/^_adb_count_rules(){/,/^}/p' "$SRC" > "$WORK/cnt.sh"
+
+echo "══ 1. 优化是局部的 ══"
+if grep -q "LC_ALL=C grep" "$WORK/cnt.sh"; then
+  ok "_adb_count_rules 的 grep 前挂了 LC_ALL=C"
+else
+  bad "_adb_count_rules 的 grep 没有 LC_ALL=C"
+fi
+# 要禁的是**赋值/导出**(它会改掉后面所有命令), 不是命令前缀 `LC_ALL=C <cmd>`(只影响那一条)。
+# 第一版正则把 `LC_ALL=C sort -u …` 这种前缀也算进去了 —— 那是 pdg.sh 里早就有的同一个
+# 惯用法, 判它红等于禁掉正确写法。判据要看 `LC_ALL=…` 后面还有没有命令。
+if grep -qE '^[[:space:]]*(export[[:space:]]+LC_ALL=|LC_ALL=[^[:space:]]*[[:space:]]*$)' "$SRC"; then
+  bad "pdg.sh 里出现了全局 LC_ALL 赋值/导出 —— 那会改掉整个脚本里所有命令的 locale"
+else
+  ok "没有全局 LC_ALL 赋值/导出(只有命令前缀形式, 影响范围就是那一条命令)"
+fi
+# 计数口径不许被换成别的来源
+# 只扫**代码**: 注释里提到 meta.json 是在说明"不拿它冒充", 不是在用它。
+sed 's/#.*//' "$WORK/cnt.sh" > "$WORK/cnt.code"
+if grep -qE 'meta\.json|_ADB_COUNT_CACHE|cache' "$WORK/cnt.code"; then
+  bad "计数函数里出现了缓存/meta.json —— 盘上到底有多少条必须只有一个答案"
+else
+  ok "没有引入计数缓存, 也没拿 meta.json 冒充盘上条数"
+fi
+
+echo
+echo "══ 2. 输入契约确实是 ASCII ══"
+# 优化成立的前提。契约不在这里, 优化就不成立 —— 所以先证明它。
+if grep -qE '_DOMAIN_RE = re\.compile\(r"\^\(\?=\.\{1,253\}\$\)\[a-z0-9_\]' "$ROOT/deploy/bot/adblock.py"; then
+  ok "adblock.py 的 _DOMAIN_RE 只放行 ASCII 字符类(落盘的每一条都过它)"
+else
+  bad "找不到 ASCII 字符集契约 —— 没有它, LC_ALL=C 这一步就没有依据"
+fi
+
+echo
+echo "══ 3. 双 locale 对拍: 同一份输入必须数出同一个数 ══"
+# 可用的 UTF-8 locale。一个都没有就说清楚"这一格没验到", 不冒充通过。
+UTF=""
+for c in en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+  if LC_ALL="$c" true 2>/dev/null && LC_ALL="$c" locale charmap 2>/dev/null | grep -qi utf; then UTF="$c"; break; fi
+done
+
+mk(){ printf '%b' "$2" > "$WORK/$1"; }
+mk plain        'a.example\nb.example\n'
+mk comments     '# head\n\na.example\n   # indented comment\n\nb.example\n'
+mk leading_ws   '  a.example\n\t b.example\n'
+mk crlf         'a.example\r\nb.example\r\n'
+mk no_final_nl  'a.example\nb.example'
+mk only_comment '# just a comment\n'
+mk empty        ''
+mk hash_inside  'a.example\nb.example#notacomment\n'
+: > "$WORK/big"
+{ echo '# comment'; echo; for i in $(seq 1 20000); do echo "x$i.example.com"; done; } > "$WORK/big"
+
+count_with(){ LC_ALL="$1" bash -c "source '$WORK/cnt.sh'; _adb_count_rules '$2'"; }
+
+# 期望值写死: 这一格同时是"计数口径没被优化改掉"的正控
+declare -A WANT=( [plain]=2 [comments]=2 [leading_ws]=2 [crlf]=2 [no_final_nl]=2
+                  [only_comment]=0 [empty]=0 [hash_inside]=2 [big]=20000 )
+for f in plain comments leading_ws crlf no_final_nl only_comment empty hash_inside big; do
+  c=$(count_with C "$WORK/$f")
+  if [[ "$c" == "${WANT[$f]}" ]]; then ok "计数口径不变 [$f] = ${WANT[$f]}"
+  else bad "计数口径变了 [$f]: 期望 ${WANT[$f]}, 实得 $c"; fi
+  if [[ -n "$UTF" ]]; then
+    u=$(count_with "$UTF" "$WORK/$f")
+    if [[ "$c" == "$u" ]]; then ok "双 locale 一致 [$f]: C=$c $UTF=$u"
+    else bad "双 locale 不一致 [$f]: C=$c $UTF=$u —— 这个模式依赖了 locale"; fi
+  fi
+done
+if [[ -z "$UTF" ]]; then
+  bad "本机没有可用的 UTF-8 locale —— 对拍那一半没验到(不是通过)。装一个 en_US.UTF-8 再跑。"
+else
+  ok "对拍用的 UTF-8 locale: $UTF"
+fi
+
+echo
+echo "══ 4. 缺文件 / 不是文件 仍然走既有分支, 不受 locale 影响 ══"
+for L in C ${UTF:-C}; do
+  c=$(count_with "$L" "$WORK/no-such-file")
+  [[ "$c" == 0 ]] && ok "[$L] 缺文件 → 0(既有语义)" || bad "[$L] 缺文件实得 $c"
+done
+# `grep -c` 数到 0 时**退出码是 1**。以前这里跟着一个 `|| echo 0`, 于是输出变成两行 "0"
+# (状态页上就是那两行 0)。这一格钉住它不会回来。
+out=$(count_with C "$WORK/only_comment")
+[[ "$out" == "0" && "$(printf '%s' "$out" | wc -l)" == 0 ]] \
+  && ok "全是注释 → 单个 0, 不是两行(grep -c 返回 1 那个老坑)" \
+  || bad "实得 %q: $(printf '%q' "$out")"
+
+echo "────────────────────────────────────────"
+echo "test-adblock-count-locale.sh: 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-adblock-lock-closure.sh
+++ b/tests/test-adblock-lock-closure.sh
@@ -37,7 +37,10 @@ extract(){
 }
 CLOSURE="$WORK/closure.sh"; : > "$CLOSURE"
 # **真的 _lock**(连同 _lock_inherited)—— 这一支验的就是锁本身, 不能桩掉。
+# _adblock_read_state / _adb_rules_readable / _adb_count_rules 是只读状态那条链:
+# _adblock_status 现在经它们读启用位与条数, 不抽出来就是 command-not-found。
 for fn in c_g c_y _profile_set _pdg_module _lock_inherited _lock _adblock_intent \
+          _adblock_read_state _adb_rules_readable _adb_count_rules \
           _adblock_ensure_files _adblock_gen_infra _adblock_apply _adblock_status cmd_adblock; do
   extract "$fn" >> "$CLOSURE" || { bad "生产函数闭包抽取失败: $fn"; echo "通过 $pass, 失败 $nfail"; exit 1; }
   echo >> "$CLOSURE"

--- a/tests/test-adblock-status-tristate.py
+++ b/tests/test-adblock-status-tristate.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""去广告的只读状态必须是**三态**, 不能把"读不到"说成"关闭"。
+
+实测的缺陷(线上 profile.env 是 0600 root:root, 同一台**已启用**的机器):
+
+    root   → 已启用(第三方表 214982 条 / 自定义 0 条)
+    nobody → 未启用
+
+根因: _adblock_intent 把四件不同的事折成同一个空值 —— 文件不存在、文件不可读、值非法、
+真的没启用。空值再被 `!= 1` 一判, 全都变成"未启用"。于是一个**权限问题**在屏幕上长得
+和"这台机器没开去广告"一模一样, 而后者是会让人去点"启用"的。
+
+第二个形态: 启用位是 1、但规则文件缺失或读不到时, 当前显示
+
+    已启用(第三方表 0 条 / 自定义 0 条)
+
+那不是"0 条", 那是**证据缺失**。0 条是一个具体的事实(表在, 里面没东西), 缺文件是另一回事
+(表根本不在, mosdns 起不来)——两者显示成同一句话, 现场就没法区分。
+
+契约(只给**只读**状态用, 不动写路径依赖的 _adblock_intent 语义):
+    profile 可读 + 最后一次赋值是 1            → enabled
+    profile 可读 + 键不存在 / 最后一次赋值是 0 → disabled
+    文件不存在 / 读不出来 / 值不是 0 或 1      → unknown
+
+"最后一次赋值不是 0/1 就 unknown"是有意的: 有人往启用位里写了看不懂的东西时, 说"未启用"
+是在替他下结论, 而我们并不知道他要什么。
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import tmpguard                                              # noqa: E402
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+PDGSH = os.path.join(ROOT, "deploy/bot/pdg.sh")
+SRC = open(PDGSH, encoding="utf-8").read()
+W = tmpguard.mkdtemp(prefix="pdg-adbtri.")
+
+# 抽出只读状态那条链。整个 cmd_adblock 跑不动(要 systemctl / 锁 / root), 而这几个函数
+# 恰好就是"只读"的全部 —— 抽得出来本身也是契约的一部分。
+NEED = ["_adblock_read_state", "_adb_count_rules", "_adb_rules_readable",
+        "_adblock_intent", "_adblock_status_line"]
+missing = [f for f in NEED if ("\n%s()" % f) not in SRC]
+print("══ 0. 三态读取器存在 ══")
+(ok if "_adblock_read_state" not in missing else
+ bad)("pdg.sh 里有 _adblock_read_state(窄的只读三态读取器)")
+(ok if "_adb_rules_readable" not in missing else
+ bad)("pdg.sh 里有 _adb_rules_readable(区分「读不到」与「0 条」)")
+# 写路径的既有语义不该被这次改动带走
+(ok if "_adblock_intent" not in missing else
+ bad)("_adblock_intent 仍在(写操作依赖它, 不扩大行为面)")
+
+CHUNK = os.path.join(W, "chunk.sh")
+with open(CHUNK, "w", encoding="utf-8") as f:
+    f.write("set -uo pipefail\n")
+    # 只读态里不该出现的副作用: 全部拦下来并留痕, 而不是让它们真的发生。
+    f.write('install(){ echo "SIDE install $*" >&2; command install "$@"; }\n')
+    f.write('mkdir(){ echo "SIDE mkdir $*" >&2; command mkdir "$@"; }\n')
+    f.write('touch(){ echo "SIDE touch $*" >&2; command touch "$@"; }\n')
+    f.write('chmod(){ echo "SIDE chmod $*" >&2; command chmod "$@"; }\n')
+    f.write('chown(){ echo "SIDE chown $*" >&2; command chown "$@"; }\n')
+    f.write('systemctl(){ echo "SIDE systemctl $*" >&2; return 0; }\n')
+    f.write('flock(){ echo "SIDE flock $*" >&2; return 0; }\n')
+    f.write('_lock(){ echo "SIDE _lock" >&2; }\n')
+    for fn in NEED:
+        if fn in missing:
+            continue
+        f.write(subprocess.run(["sed", "-n", "/^%s()/,/^}/p" % fn, PDGSH],
+                               capture_output=True, text=True).stdout + "\n")
+
+
+def snap(root):
+    """整棵沙箱的形态指纹: 路径 + mode + size + mtime_ns。只读态必须一字不改。"""
+    out = []
+    for dp, dns, fns in os.walk(root):
+        for n in sorted(dns) + sorted(fns):
+            p = os.path.join(dp, n)
+            try:
+                st = os.lstat(p)
+                out.append("%s %o %d %d" % (p, st.st_mode, st.st_size, st.st_mtime_ns))
+            except OSError as e:
+                out.append("%s ERR %s" % (p, e.errno))
+    return "\n".join(sorted(out))
+
+
+def run(fn, case, env_extra=None):
+    """在 case 目录上跑一个函数; 返回 (stdout, stderr, rc, 沙箱是否被改动)"""
+    d = os.path.join(W, case)
+    env = dict(os.environ,
+               PROFILE_ENV=os.path.join(d, "profile.env"),
+               ADB_STATE_DIR=os.path.join(d, "state"),
+               ADB_USER_ALLOW=os.path.join(d, "allow.txt"),
+               ADB_USER_BLOCK=os.path.join(d, "block.txt"))
+    env.update(env_extra or {})
+    before = snap(d)
+    r = subprocess.run(["bash", "-c", "source %s; %s" % (CHUNK, fn)],
+                       capture_output=True, text=True, env=env)
+    return r.stdout.strip(), r.stderr.strip(), r.returncode, (snap(d) != before)
+
+
+def mkcase(name, profile=None, list_n=1234, block_lines="a.example\nb.example\n",
+           drop_list=False, drop_block=False):
+    d = os.path.join(W, name)
+    os.makedirs(os.path.join(d, "state"), exist_ok=True)
+    if profile is not None:
+        open(os.path.join(d, "profile.env"), "w").write(profile)
+    open(os.path.join(d, "allow.txt"), "w").close()
+    if not drop_block:
+        open(os.path.join(d, "block.txt"), "w").write(block_lines)
+    if not drop_list:
+        open(os.path.join(d, "state", "effective_list.txt"), "w").write(
+            "".join("x%d.example\n" % i for i in range(list_n)))
+    open(os.path.join(d, "state", "effective_block.txt"), "w").close()
+    return d
+
+
+print()
+print("══ 1. 三态矩阵 ══")
+CASES = [
+    ("enabled",      "PDG_ADBLOCK_ENABLED=1\n",                        "enabled",  "真的开着"),
+    ("disabled",     "PDG_ADBLOCK_ENABLED=0\n",                        "disabled", "真的关着"),
+    ("nokey",        "PDG_OTHER=1\n",                                  "disabled", "键不存在(从没开过)"),
+    ("override",     "PDG_ADBLOCK_ENABLED=1\nPDG_ADBLOCK_ENABLED=0\n", "disabled", "后一条赋值覆盖前一条"),
+    ("override2",    "PDG_ADBLOCK_ENABLED=0\nPDG_ADBLOCK_ENABLED=1\n", "enabled",  "后一条赋值覆盖前一条(反向)"),
+    ("badval",       "PDG_ADBLOCK_ENABLED=yes\n",                      "unknown",  "值不是 0/1"),
+    ("badval2",      "PDG_ADBLOCK_ENABLED=1\nPDG_ADBLOCK_ENABLED=x\n", "unknown",  "最后一条是非法值"),
+    ("nofile",       None,                                             "unknown",  "profile 不存在"),
+]
+for name, prof, want, desc in CASES:
+    mkcase(name, prof)
+    got, err, rc, changed = run("_adblock_read_state", name)
+    (ok if got == want else
+     bad)("%-28s → %s(实得 %r)" % (desc, want, got))
+    (ok if not changed else bad)("%-28s: 沙箱零改动" % desc)
+    (ok if "SIDE " not in err else
+     bad)("%-28s: 没有副作用调用(实得 %r)" % (desc, err))
+
+# 不可读: 两种都造。chmod 000 对 root 无效, 所以额外造一个"路径是目录"的 —— open 那一步
+# 连 root 也会拿到 EISDIR。夹具没生效时判**测试自己**失败, 不许当成产品通过。
+mkcase("unreadable", "PDG_ADBLOCK_ENABLED=1\n")
+os.chmod(os.path.join(W, "unreadable", "profile.env"), 0)
+really_unreadable = not os.access(os.path.join(W, "unreadable", "profile.env"), os.R_OK)
+if really_unreadable:
+    got, err, rc, changed = run("_adblock_read_state", "unreadable")
+    (ok if got == "unknown" else bad)("profile 存在但 mode 000 → unknown(实得 %r)" % got)
+    (ok if not changed else bad)("mode 000: 沙箱零改动")
+else:
+    print("[NOTE] 以 root 跑, chmod 000 拦不住 —— 该形态改由下面的 EISDIR 夹具覆盖")
+mkcase("isdir")
+os.remove(os.path.join(W, "isdir", "profile.env")) if os.path.exists(
+    os.path.join(W, "isdir", "profile.env")) else None
+os.makedirs(os.path.join(W, "isdir", "profile.env"), exist_ok=True)
+got, err, rc, changed = run("_adblock_read_state", "isdir")
+(ok if got == "unknown" else
+ bad)("profile 路径读不出内容(EISDIR)→ unknown, 不许说成未启用(实得 %r)" % got)
+(ok if not changed else bad)("EISDIR: 沙箱零改动")
+
+print()
+print("══ 2. status-line 的措辞 ══")
+mkcase("L_on", "PDG_ADBLOCK_ENABLED=1\n")
+out, err, rc, changed = run("_adblock_status_line", "L_on")
+# 严格结构匹配, 不用子串: "1234" 里就含着 "2", 于是 `"2" in out` 这种写法在
+# "自定义 0 条"的产品缺陷下照样绿(上一轮 23/23 全绿就是这么来的)。
+m = re.search(r"第三方表\s*(\d+)\s*条\s*/\s*自定义\s*(\d+)\s*条", out)
+(ok if m else bad)("已启用那行结构可解析(实得 %r)" % out)
+if m:
+    (ok if m.group(1) == "1234" else bad)("具名字段 第三方表 = 1234(实得 %s)" % m.group(1))
+    (ok if m.group(2) == "2" else bad)("具名字段 自定义 = 2(实得 %s)" % m.group(2))
+(ok if "\n" not in out else bad)("单行")
+(ok if not changed else bad)("status-line 已启用: 沙箱零改动")
+
+mkcase("L_off", "PDG_ADBLOCK_ENABLED=0\n")
+out, err, rc, changed = run("_adblock_status_line", "L_off")
+(ok if "未启用" in out else bad)("disabled → 未启用(实得 %r)" % out)
+
+for case, prof, desc in (("L_unk", None, "profile 不存在"),
+                         ("L_unk2", "PDG_ADBLOCK_ENABLED=zzz\n", "值非法")):
+    mkcase(case, prof)
+    out, err, rc, changed = run("_adblock_status_line", case)
+    (ok if "状态未知" in out else
+     bad)("%s → 明说「状态未知」(实得 %r)" % (desc, out))
+    (ok if "未启用" not in out else
+     bad)("%s → **不许**出现「未启用」, 那是另一件事(实得 %r)" % (desc, out))
+    (ok if not re.search(r"\d+\s*条", out) else
+     bad)("%s → 不许报条数(读不到启用位时那些数字没有意义)(实得 %r)" % (desc, out))
+    (ok if not changed else bad)("%s: 沙箱零改动" % desc)
+
+print()
+print("══ 3. 已启用但规则文件缺失/不可读 → 不许显示成 0 条 ══")
+for case, kw, desc in (("M_list",  dict(drop_list=True),  "生效表缺失"),
+                       ("M_block", dict(drop_block=True), "用户 block 缺失")):
+    mkcase(case, "PDG_ADBLOCK_ENABLED=1\n", **kw)
+    out, err, rc, changed = run("_adblock_status_line", case)
+    (ok if "0 条" not in out else
+     bad)("%s → 不许显示成「0 条」, 那是证据缺失不是事实(实得 %r)" % (desc, out))
+    (ok if "规则文件" in out else
+     bad)("%s → 明说是规则文件的问题(实得 %r)" % (desc, out))
+    (ok if "doctor" in out else
+     bad)("%s → 指向 sudo pdg doctor(实得 %r)" % (desc, out))
+    (ok if "已启用" in out else
+     bad)("%s → 仍然说清启用位是开着的(实得 %r)" % (desc, out))
+    (ok if not changed else bad)("%s: 沙箱零改动" % desc)
+
+# 文件在但读不出来(mode 000): 与"缺失"同一处置, 且**不能**掉回 0 条
+mkcase("M_perm", "PDG_ADBLOCK_ENABLED=1\n")
+os.chmod(os.path.join(W, "M_perm", "state", "effective_list.txt"), 0)
+if not os.access(os.path.join(W, "M_perm", "state", "effective_list.txt"), os.R_OK):
+    out, err, rc, changed = run("_adblock_status_line", "M_perm")
+    (ok if "0 条" not in out and "规则文件" in out else
+     bad)("生效表存在但不可读 → 与缺失同样处置, 不许显示 0 条(实得 %r)" % out)
+    (ok if not changed else bad)("不可读: 沙箱零改动")
+else:
+    print("[NOTE] 以 root 跑, mode 000 拦不住 —— 该形态由上面的「缺失」两格覆盖")
+
+print()
+print("══ 4. status 与 status-line 对启用状态的结论必须一致 ══")
+# 两处各读各的话, 迟早会一个说开着一个说关着 —— 而用户看到的是哪一个取决于他敲了哪条命令。
+body = re.search(r"\n_adblock_status\(\)\{(.*?)\n\}", SRC, re.S)
+(ok if body else bad)("抽得到 _adblock_status")
+if body:
+    b = body.group(1)
+    (ok if "_adblock_read_state" in b else
+     bad)("_adblock_status 也走三态读取器(否则两条命令会给出不同结论)")
+
+print()
+print("══ 5. 只读契约: 源码里不许出现写操作 ══")
+for fn in ("_adblock_read_state", "_adb_rules_readable", "_adblock_status_line"):
+    mm = re.search(r"\n%s\(\)\{(.*?)\n\}" % fn, SRC, re.S)
+    if not mm:
+        bad("抽得到 %s" % fn)
+        continue
+    b = mm.group(1)
+    hits = [w for w in ("install -d", "mkdir", "touch", ": >", "systemctl", "flock",
+                        "chmod", "chown", "_lock") if w in b]
+    (ok if not hits else bad)("%s 里没有写操作(实得 %r)" % (fn, hits))
+
+print("-" * 62)
+print("test-adblock-status-tristate.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-ci-mosdns-topology.py
+++ b/tests/test-ci-mosdns-topology.py
@@ -144,6 +144,14 @@ if os.path.exists(os.path.join(ROOT, INSTALLER)):
     (ok if "lib/versions.sh" in src else bad)("期望值从当前 checkout 的 lib/versions.sh 读")
     (ok if "pdg_mosdns_binary_ok" in src else bad)("消费者也走生产判据复核")
     (ok if re.search(r"install\s+-m\s*755", src) else bad)("以 mode 755 安装")
+    # 版本这一层用真二进制造不出反例(SHA 对得上的文件不可能自报别的版本), 所以它的守卫
+    # 只能是结构判据 —— 少了这条, 把版本比对整段摘掉不会有任何一格转红(负控④量到 0 条)。
+    cmp_line = [ln for ln in code(src).splitlines()
+                if "==" in ln and "got_ver" in ln and "MOSDNS_VER" in ln]
+    (ok if cmp_line else
+     bad)("消费者**比较**自报版本与钉值(不是只在失败提示里提到这两个名字)")
+    (ok if re.search(r'want_sha|PDG_SHA256\[mosdns-bin-', src) else
+     bad)("消费者拿 lib/versions.sh 的钉值当权威(而不是 manifest)")
     (ok if not NET.search(code(src)) else bad)("消费者安装脚本里没有任何联网动作")
     (ok if "SKIP" not in code(src) else bad)("不合格时硬失败, 不 SKIP")
 for j in sorted(consumers):

--- a/tests/test-ci-mosdns-topology.py
+++ b/tests/test-ci-mosdns-topology.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""CI 里 mosdns 官方二进制**每 run 每架构只准取件一次**, 之后靠本次 workflow 的 artifact 扇出。
+
+由来是 exact-head run 33244114858: 它 30/30 全绿, 但「准备钉死版 mosdns」这一步在日志里
+写着 `[*] 下载钉死版 mosdns v5.3.4 (amd64)…` —— 真的去 GitHub Release 拉了。而 e2e 是
+**matrix**, 每格一个独立容器, 于是「备在 job 层」恰恰就是「每个用例一次」: 21 格 = 21 次。
+连同 e2e-rescue-lock-ios, 官方下载从 5 次涨到 27 次。把下载从夹具挪到 job 步骤, 一次都没减少。
+
+这一支按 job / step / needs / uses / 命令内容建立结构判据, 不数字符串:
+
+  ① 官方取件入口每架构只有一个 producer;
+  ② matrix 消费者不许自己调 prepare-mosdns.sh;
+  ③ 消费者里不许有 curl/wget/Release URL 这类公网回退;
+  ④ 每个消费者都要 needs 到 producer, 并 download-artifact;
+  ⑤ 消费者拿到 artifact 后要按 lib/versions.sh **自己重算**摘要与版本, 不认服务端摘要;
+  ⑥ artifact 名字要绑版本 + 架构 + 摘要前缀, 且由钉值生成而不是再写死一份;
+  ⑦ 保留期取平台允许的最短值(1 天);
+  ⑧ action 按仓库既有惯例钉定, 不许浮动引用;
+  ⑨ producer 取件后要走生产判据 pdg_mosdns_binary_ok 复核。
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CI = os.path.join(ROOT, ".github/workflows/ci.yml")
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+try:
+    import yaml
+except ImportError:
+    print("[FAIL] 缺 pyyaml —— 这一支必须真解析 workflow, 不做退化的字符串计数。"
+          "装一份: sudo apt-get install -y python3-yaml")
+    sys.exit(1)
+
+D = yaml.safe_load(open(CI, encoding="utf-8"))
+JOBS = D["jobs"]
+TEXT = open(CI, encoding="utf-8").read()
+PRODUCER = "prepare-mosdns-fixture"
+# 官方 Release 的取件动作长什么样(两种既有形态)
+FETCH = re.compile(r"prepare-mosdns\.sh|mosdns-linux-\w+\.zip")
+NET = re.compile(r"\bcurl\b|\bwget\b|releases/download")
+
+
+def steps(j):
+    return JOBS[j].get("steps") or []
+
+
+def inst(j):
+    mx = ((JOBS[j].get("strategy") or {}).get("matrix") or {})
+    if not mx:
+        return 1
+    if "include" in mx:
+        return len(mx["include"])
+    n = 1
+    for k, v in mx.items():
+        if isinstance(v, list):
+            n *= len(v)
+    return n
+
+
+def runs(j):
+    return [(i, s.get("name") or "", str(s.get("run") or ""))
+            for i, s in enumerate(steps(j), 1)]
+
+
+print("══ 1. 官方取件入口: 每架构恰好一个 producer ══")
+fetchers = {}
+for j in JOBS:
+    hit = [(i, n) for i, n, r in runs(j) if FETCH.search(r)]
+    if hit:
+        fetchers[j] = (hit, inst(j))
+for j, (hit, n) in sorted(fetchers.items()):
+    print("       %-24s ×%-2d  step %s" % (j, n, [h[0] for h in hit]))
+total = sum(n * len(h) for j, (h, n) in fetchers.items())
+(ok if list(fetchers) == [PRODUCER] else
+ bad)("只有 %s 一个 job 去官方取件(实得 %r)" % (PRODUCER, sorted(fetchers)))
+(ok if total <= 2 else
+ bad)("整个 run 的官方取件次数 ≤ 每架构一次(实得 %d 次)" % total)
+if PRODUCER in JOBS:
+    mx = ((JOBS[PRODUCER].get("strategy") or {}).get("matrix") or {})
+    arches = mx.get("arch") or []
+    (ok if arches else bad)("producer 按架构建 matrix(实得 %r)" % (arches,))
+    (ok if len(arches) == len(set(arches)) else bad)("每种架构只有一格, 没有重复 producer")
+else:
+    bad("workflow 里没有 %s 这个 job" % PRODUCER)
+
+print()
+print("══ 2/3. 消费者: 不自己取件, 也没有公网回退 ══")
+consumers = [j for j in JOBS if j != PRODUCER and
+             any("mosdns" in r or "mosdns" in n for _, n, r in runs(j))]
+for j in sorted(consumers):
+    self_fetch = [i for i, n, r in runs(j) if FETCH.search(r)]
+    (ok if not self_fetch else
+     bad)("%s 不自己调 prepare-mosdns.sh / 拉 Release(实得 step %r)" % (j, self_fetch))
+    netty = [(i, n) for i, n, r in runs(j)
+             if NET.search(r) and re.search(r"mosdns", r, re.I)]
+    (ok if not netty else
+     bad)("%s 的 mosdns 相关步骤里没有 curl/wget/Release 回退(实得 %r)" % (j, netty))
+
+print()
+print("══ 4. 消费者依赖 producer 并下载 artifact ══")
+for j in sorted(consumers):
+    need = JOBS[j].get("needs")
+    need = [need] if isinstance(need, str) else (need or [])
+    (ok if PRODUCER in need else bad)("%s 的 needs 含 %s(实得 %r)" % (j, PRODUCER, need))
+    dl = [s for s in steps(j) if "download-artifact" in str(s.get("uses") or "")]
+    (ok if dl else bad)("%s 有 download-artifact 步骤" % j)
+
+print()
+print("══ 5. 消费者自己重算摘要与版本, 不认服务端摘要 ══")
+INSTALLER = "tests/install-mosdns-artifact.sh"
+(ok if os.path.exists(os.path.join(ROOT, INSTALLER)) else
+ bad)("有 %s(消费者侧统一校验入口)" % INSTALLER)
+if os.path.exists(os.path.join(ROOT, INSTALLER)):
+    src = open(os.path.join(ROOT, INSTALLER), encoding="utf-8").read()
+    (ok if "sha256sum" in src else bad)("消费者自己算 sha256(不认 artifact 服务端摘要)")
+    (ok if "lib/versions.sh" in src else bad)("期望值从当前 checkout 的 lib/versions.sh 读")
+    (ok if "pdg_mosdns_binary_ok" in src else bad)("消费者也走生产判据复核")
+    (ok if re.search(r"install\s+-m\s*755", src) else bad)("以 mode 755 安装")
+    (ok if not NET.search(src) else bad)("消费者安装脚本里没有任何联网动作")
+    (ok if "SKIP" not in src else bad)("不合格时硬失败, 不 SKIP")
+for j in sorted(consumers):
+    uses_installer = any(INSTALLER in r for _, _, r in runs(j))
+    (ok if uses_installer else bad)("%s 用统一的 %s 做二次校验" % (j, INSTALLER))
+
+print()
+print("══ 6/7. artifact 名字与保留期 ══")
+NAMER = "tests/mosdns-artifact-name.sh"
+(ok if os.path.exists(os.path.join(ROOT, NAMER)) else
+ bad)("有 %s —— 名字由钉值生成, 不再维护第二份硬编码" % NAMER)
+if os.path.exists(os.path.join(ROOT, NAMER)):
+    ns = open(os.path.join(ROOT, NAMER), encoding="utf-8").read()
+    (ok if "lib/versions.sh" in ns else bad)("名字生成器读 lib/versions.sh")
+    for part, why in (("MOSDNS_VER", "版本"), ("arch", "架构"), ("sha", "摘要前缀")):
+        (ok if re.search(part, ns, re.I) else bad)("名字含%s" % why)
+    (ok if not re.search(r'v[0-9]+\.[0-9]+\.[0-9]+', ns) else
+     bad)("名字生成器里没有硬编码的版本号")
+up = [(j, s) for j in JOBS for s in steps(j) if "upload-artifact" in str(s.get("uses") or "")]
+(ok if len(up) == 1 else bad)("只有一处 upload-artifact(实得 %d)" % len(up))
+for j, s in up:
+    w = s.get("with") or {}
+    (ok if str(w.get("retention-days")) == "1" else
+     bad)("保留期为最短的 1 天(实得 %r)" % w.get("retention-days"))
+    (ok if "${{" in str(w.get("name") or "") else
+     bad)("artifact 名字是求值出来的而不是写死(实得 %r)" % w.get("name"))
+
+print()
+print("══ 8. action 供应链: 按仓库惯例钉定, 不许浮动 ══")
+uses = sorted({str(s.get("uses")) for j in JOBS for s in steps(j) if s.get("uses")})
+conv = re.compile(r"^actions/[\w-]+@(v\d+|[0-9a-f]{40})$")
+for u in uses:
+    print("       %s" % u)
+    (ok if conv.match(u) else bad)("%s 钉定合规(不许 @main/@master/无 ref)" % u)
+(ok if not re.search(r"uses:\s*\S+@(main|master|latest)\b", TEXT) else
+ bad)("没有浮动引用 @main/@master/@latest")
+(ok if "actions/cache" not in TEXT else bad)("没有使用 actions/cache(跨 run 缓存被禁)")
+
+print()
+print("══ 9. producer 的四层校验 ══")
+if PRODUCER in JOBS:
+    body = "\n".join(r for _, _, r in runs(PRODUCER))
+    for pat, why in ((r"prepare-mosdns\.sh", "调既有取件流程(它自己核归档 SHA 与自报版本)"),
+                     (r"sha256sum", "校验最终二进制 SHA"),
+                     (r"pdg_mosdns_binary_ok", "走生产判据再核一次"),
+                     (r"manifest", "生成 manifest")):
+        (ok if re.search(pat, body, re.I) else bad)("producer %s" % why)
+    (ok if re.search(r"rm -f .*mosdns|隔离", body) else
+     bad)("producer 先移除 runner 上偶然存在的 mosdns(不把已有状态当隐式输入)")
+    (ok if not re.search(r"token|secrets\.", body, re.I) else
+     bad)("manifest / producer 步骤里不出现 token 或 secrets")
+
+print("-" * 62)
+print("test-ci-mosdns-topology.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-ci-mosdns-topology.py
+++ b/tests/test-ci-mosdns-topology.py
@@ -53,6 +53,21 @@ FETCH = re.compile(r"prepare-mosdns\.sh|mosdns-linux-\w+\.zip")
 NET = re.compile(r"\bcurl\b|\bwget\b|releases/download")
 
 
+def code(text):
+    """去掉 shell / YAML 的整行与行尾注释。
+
+    这几格判的是"代码里有没有做某件事", 而注释里恰恰会**写明不做那件事**
+    (「不用 actions/cache」「没有 curl 回退」「无 token」)。不去注释就会把说明文字
+    当成违规 —— 第一版这一支自己踩了五次。
+    """
+    out = []
+    for ln in text.splitlines():
+        t = ln.split("#", 1)[0] if ln.lstrip().startswith("#") else \
+            (ln.split(" #", 1)[0] if " #" in ln else ln)
+        out.append(t)
+    return "\n".join(out)
+
+
 def steps(j):
     return JOBS[j].get("steps") or []
 
@@ -129,8 +144,8 @@ if os.path.exists(os.path.join(ROOT, INSTALLER)):
     (ok if "lib/versions.sh" in src else bad)("期望值从当前 checkout 的 lib/versions.sh 读")
     (ok if "pdg_mosdns_binary_ok" in src else bad)("消费者也走生产判据复核")
     (ok if re.search(r"install\s+-m\s*755", src) else bad)("以 mode 755 安装")
-    (ok if not NET.search(src) else bad)("消费者安装脚本里没有任何联网动作")
-    (ok if "SKIP" not in src else bad)("不合格时硬失败, 不 SKIP")
+    (ok if not NET.search(code(src)) else bad)("消费者安装脚本里没有任何联网动作")
+    (ok if "SKIP" not in code(src) else bad)("不合格时硬失败, 不 SKIP")
 for j in sorted(consumers):
     uses_installer = any(INSTALLER in r for _, _, r in runs(j))
     (ok if uses_installer else bad)("%s 用统一的 %s 做二次校验" % (j, INSTALLER))
@@ -145,7 +160,7 @@ if os.path.exists(os.path.join(ROOT, NAMER)):
     (ok if "lib/versions.sh" in ns else bad)("名字生成器读 lib/versions.sh")
     for part, why in (("MOSDNS_VER", "版本"), ("arch", "架构"), ("sha", "摘要前缀")):
         (ok if re.search(part, ns, re.I) else bad)("名字含%s" % why)
-    (ok if not re.search(r'v[0-9]+\.[0-9]+\.[0-9]+', ns) else
+    (ok if not re.search(r'v[0-9]+\.[0-9]+\.[0-9]+', code(ns)) else
      bad)("名字生成器里没有硬编码的版本号")
 up = [(j, s) for j in JOBS for s in steps(j) if "upload-artifact" in str(s.get("uses") or "")]
 (ok if len(up) == 1 else bad)("只有一处 upload-artifact(实得 %d)" % len(up))
@@ -163,9 +178,10 @@ conv = re.compile(r"^actions/[\w-]+@(v\d+|[0-9a-f]{40})$")
 for u in uses:
     print("       %s" % u)
     (ok if conv.match(u) else bad)("%s 钉定合规(不许 @main/@master/无 ref)" % u)
-(ok if not re.search(r"uses:\s*\S+@(main|master|latest)\b", TEXT) else
+(ok if not any(re.search(r"@(main|master|latest)$", u) for u in uses) else
  bad)("没有浮动引用 @main/@master/@latest")
-(ok if "actions/cache" not in TEXT else bad)("没有使用 actions/cache(跨 run 缓存被禁)")
+(ok if not any("actions/cache" in u for u in uses) else
+ bad)("没有任何 uses: actions/cache(跨 run 缓存被禁)")
 
 print()
 print("══ 9. producer 的四层校验 ══")
@@ -178,7 +194,7 @@ if PRODUCER in JOBS:
         (ok if re.search(pat, body, re.I) else bad)("producer %s" % why)
     (ok if re.search(r"rm -f .*mosdns|隔离", body) else
      bad)("producer 先移除 runner 上偶然存在的 mosdns(不把已有状态当隐式输入)")
-    (ok if not re.search(r"token|secrets\.", body, re.I) else
+    (ok if not re.search(r"token|secrets\.", code(body), re.I) else
      bad)("manifest / producer 步骤里不出现 token 或 secrets")
 
 print("-" * 62)

--- a/tests/test-e2e-mosdns-fixture.py
+++ b/tests/test-e2e-mosdns-fixture.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""E2E 的"健康机器"夹具必须播种**真实钉定**的 mosdns 二进制, 不是只会打印版本号的 shell 桩。
+
+exact-head CI 33235374627 里六支 E2E 红, 两条根因都落在这里:
+
+  · e2e-install.sh 在 /usr/local/bin/mosdns 写了个 shell 桩(`case $1 in version) echo …`)。
+    安装器旧短路只比自报版本, 桩就够用; 现在还要求 SHA256 等于官方钉值, 桩当然不符 →
+    安装器进入下载分支 → 而这支同时把 curl 也打了桩 → ZIP 校验失败 → 整次装机 die。
+  · 另外五支的夹具**根本不播种** mosdns(e2e-lib 还会主动删掉小于 1MB 的桩)。doctor 的
+    check_mosdns_binary 于是判 fail, cmd_update 的自检门看到 1 项失败就整个回滚。
+
+修的方向已经定了: **不放宽判据, 改夹具**。一台"装好的网关"按定义就有那个二进制;
+夹具里没有它, 那份夹具本身就是假的 —— 它正是把这两个洞藏了这么久的原因。
+
+这一支钉住夹具契约, 不碰生产判据。
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+LIB = open(os.path.join(ROOT, "tests/e2e-lib.sh"), encoding="utf-8").read()
+INST = open(os.path.join(ROOT, "tests/e2e-install.sh"), encoding="utf-8").read()
+VERS = open(os.path.join(ROOT, "lib/versions.sh"), encoding="utf-8").read()
+CI = open(os.path.join(ROOT, ".github/workflows/ci.yml"), encoding="utf-8").read()
+
+
+def body(src, name):
+    m = re.search(r"\n%s\(\)\{(.*?)\n\}" % re.escape(name), src, re.S)
+    return m.group(1) if m else ""
+
+
+print("══ 1. 播种函数存在, 且播完要用生产判据复核 ══")
+seed = body(LIB, "e2e_seed_mosdns_bin")
+(ok if seed else bad)("e2e-lib.sh 里有 e2e_seed_mosdns_bin")
+(ok if "pdg_mosdns_binary_ok" in seed else
+ bad)("播种后用生产判据 pdg_mosdns_binary_ok 复核(版本与摘要同时命中)")
+(ok if "prepare-mosdns.sh" in seed else
+ bad)("取件走既有准备流程 tests/prepare-mosdns.sh(SHA256 已在那边校验, 不另立一套)")
+# 夹具自己不许去改判据、不许绕过摘要
+for wforb in ("PDG_TEST_MODE", "PDG_SKIP_SHA", "--no-verify", "sha256sum -c -"):
+    (ok if wforb not in seed else bad)("播种函数里没有 %s 这类绕过" % wforb)
+
+print()
+print("══ 2. 健康夹具真的会调它 ══")
+si = body(LIB, "e2e_seed_install")
+(ok if "e2e_seed_mosdns_bin" in si else
+ bad)("e2e_seed_install 播种 mosdns 二进制(一台装好的网关按定义就有它)")
+
+print()
+print("══ 3. e2e-install.sh 不再写 shell 假桩 ══")
+stub = re.search(r"cat > /usr/local/bin/mosdns <<", INST)
+(ok if not stub else
+ bad)("e2e-install.sh 里没有 `cat > /usr/local/bin/mosdns` 这样的假桩")
+(ok if "e2e_seed_mosdns_bin" in INST else
+ bad)("e2e-install.sh 改用真实钉定二进制播种")
+# 它仍然可以测"已有合法二进制时严格短路", 但不许重新教安装器接受假桩
+(ok if "pdg_mosdns_is_version" not in INST else
+ bad)("没有把安装器的判据换回只看自报版本")
+
+print()
+print("══ 4. 夹具不访问生产机、不改生产判据 ══")
+for f in ("tests/e2e-lib.sh", "tests/e2e-install.sh", "tests/prepare-mosdns.sh"):
+    txt = open(os.path.join(ROOT, f), encoding="utf-8").read()
+    hits = [w for w in ("ts.net", "tailscale", "jp2", "@jp", "ssh ") if w in txt]
+    (ok if not hits else bad)("%s 不碰生产机 / tailnet(实得 %r)" % (f, hits))
+# 判据本体在 lib/versions.sh, 测试目录里不许出现第二份实现
+impl = [f for f in os.listdir(os.path.join(ROOT, "tests"))
+        if f.endswith((".sh", ".py")) and
+        re.search(r"^pdg_mosdns_binary_ok\(\)\{", open(os.path.join(ROOT, "tests", f),
+                  encoding="utf-8", errors="replace").read(), re.M)]
+(ok if not impl else
+ bad)("tests/ 下没有第二份 pdg_mosdns_binary_ok 实现(实得 %r)" % impl)
+
+print()
+print("══ 5. CI: e2e job 先备好钉定二进制, 于是夹具本身不联网 ══")
+# 夹具在 CI 里应当直接复用 job 备好的那一份 —— 让每个用例各下一次才是新增的公网依赖。
+m = re.search(r"\n  e2e:\n(.*?)\n  [a-z-]+:\n", CI, re.S)
+(ok if m else bad)("抽得到 e2e job")
+if m:
+    (ok if "prepare-mosdns.sh" in m.group(1) else
+     bad)("e2e job 里有「准备钉死版 mosdns」这一步(与 lint/functional 同一份脚本)")
+(ok if CI.count("prepare-mosdns.sh") >= 3 else
+ bad)("prepare-mosdns.sh 被复用而不是各写各的(实得 %d 处)" % CI.count("prepare-mosdns.sh"))
+
+print()
+print("══ 6. 真跑一次: 桩被拒, 真二进制被接受 ══")
+import hashlib                                               # noqa: E402
+import shutil                                                # noqa: E402
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import tmpguard                                              # noqa: E402
+W = tmpguard.mkdtemp(prefix="pdg-e2emos.")
+pin = dict(re.findall(r'\[mosdns-bin-(\w+)\]="([0-9a-f]{64})"', VERS))
+arch = subprocess.run(["dpkg", "--print-architecture"], capture_output=True,
+                      text=True).stdout.strip() or "amd64"
+mver = (re.search(r'^MOSDNS_VER="([^"]+)"', VERS, re.M) or [None, "v5.3.4"])[1]
+
+
+def ask(path):
+    """真调生产判据。"""
+    sc = ('source "%s/lib/versions.sh"\n'
+          'pdg_mosdns_binary_ok %s %s "%s"; echo "rc=$?"\n' % (ROOT, arch, mver, path))
+    return subprocess.run(["bash", "-c", sc], capture_output=True, text=True).stdout.strip()
+
+
+# ① 老的 shell 假桩
+fake = os.path.join(W, "mosdns")
+open(fake, "w").write('#!/bin/sh\ncase "$1" in version) echo "mosdns %s-0-gb732318";; esac\nexit 0\n' % mver)
+os.chmod(fake, 0o755)
+(ok if ask(fake).endswith("rc=1") else
+ bad)("老的 shell 假桩被生产判据**拒绝**(实得 %r)" % ask(fake))
+# 它确实"自报版本对得上" —— 证明拒绝的理由是内容而不是版本
+v = subprocess.run([fake, "version"], capture_output=True, text=True).stdout
+(ok if mver in v else bad)("假桩确实自报了正确版本(所以旧短路才会接受它)")
+
+# ② 真实钉定二进制
+real = "/usr/local/bin/mosdns"
+if os.path.exists(real) and hashlib.sha256(open(real, "rb").read()).hexdigest() == pin.get(arch):
+    (ok if ask(real).endswith("rc=0") else
+     bad)("真实钉定二进制被生产判据**接受**(实得 %r)" % ask(real))
+    ok("本机 %s 的 sha256 与 lib/versions.sh 的 %s 钉值相符" % (real, arch))
+else:
+    bad("本机没有钉死版 mosdns —— 「真二进制被接受」那一格未验(不是通过)。"
+        "备一份: sudo bash tests/prepare-mosdns.sh")
+
+print()
+print("══ 7. 无残留 ══")
+shutil.rmtree(W, ignore_errors=True)
+(ok if not os.path.exists(W) else bad)("测试自建的临时目录已清")
+import tempfile                                              # noqa: E402
+_tmp = tempfile.gettempdir()          # 不写死 /tmp: 临时物卫生守卫按这条判
+left = [d for d in os.listdir(_tmp) if d.startswith("pdg-e2emos.")]
+(ok if not left else bad)("没有同前缀的临时残留(实得 %r)" % left)
+
+print("-" * 62)
+print("test-e2e-mosdns-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-e2e-mosdns-fixture.py
+++ b/tests/test-e2e-mosdns-fixture.py
@@ -87,15 +87,23 @@ impl = [f for f in os.listdir(os.path.join(ROOT, "tests"))
  bad)("tests/ 下没有第二份 pdg_mosdns_binary_ok 实现(实得 %r)" % impl)
 
 print()
-print("══ 5. CI: e2e job 先备好钉定二进制, 于是夹具本身不联网 ══")
-# 夹具在 CI 里应当直接复用 job 备好的那一份 —— 让每个用例各下一次才是新增的公网依赖。
+print("══ 5. CI: 夹具靠 producer 的 artifact, 自己不取件 ══")
+# 上一版这里要求"e2e job 里有 prepare-mosdns.sh 这一步" —— 那正是把官方下载放大到 28 次的
+# 形态(e2e 是 matrix, 每格一个容器, "备在 job 层"就是"每个用例一次")。现在改成单次取件 +
+# artifact 扇出, 判据跟着换: e2e job **不许**自己取件, 只许 needs 到 producer 并下载。
+# 取件次数与 DAG 的完整守卫在 tests/test-ci-mosdns-topology.py, 这里只钉与夹具直接相关的两条。
 m = re.search(r"\n  e2e:\n(.*?)\n  [a-z-]+:\n", CI, re.S)
 (ok if m else bad)("抽得到 e2e job")
 if m:
-    (ok if "prepare-mosdns.sh" in m.group(1) else
-     bad)("e2e job 里有「准备钉死版 mosdns」这一步(与 lint/functional 同一份脚本)")
-(ok if CI.count("prepare-mosdns.sh") >= 3 else
- bad)("prepare-mosdns.sh 被复用而不是各写各的(实得 %d 处)" % CI.count("prepare-mosdns.sh"))
+    (ok if "prepare-mosdns.sh" not in m.group(1) else
+     bad)("e2e job **不再**自己调 prepare-mosdns.sh(那会按 matrix 格数放大官方下载)")
+    (ok if "prepare-mosdns-fixture" in m.group(1) else
+     bad)("e2e job needs 到 producer")
+    (ok if "download-artifact" in m.group(1) else
+     bad)("e2e job 用 download-artifact 取本次 run 的钉定二进制")
+(ok if CI.count("prepare-mosdns.sh") == 1 else
+ bad)("整份 workflow 里 prepare-mosdns.sh 只出现 1 次(唯一的取件入口)(实得 %d)"
+      % CI.count("prepare-mosdns.sh"))
 
 print()
 print("══ 6. 真跑一次: 桩被拒, 真二进制被接受 ══")

--- a/tests/test-mosdns-artifact-roundtrip.sh
+++ b/tests/test-mosdns-artifact-roundtrip.sh
@@ -81,7 +81,7 @@ neg(){ # $1=场景 $2=准备命令
   local out rc=0
   out="$(bash "$ROOT/tests/install-mosdns-artifact.sh" "$D/dl" "$ARCH" "$D/bin/mosdns" 2>&1)" || rc=$?
   if [[ "$rc" != 0 ]]; then
-    ok "$1 → 硬失败(rc=$rc): $(grep -m1 '\[FAIL\]' <<<"$out" | cut -c1-92)"
+    ok "$1 → 硬失败(rc=$rc): $(grep -m1 '\[FAIL\]' <<<"$out" | awk '{print substr($0,1,90)}')"
   else
     bad "$1 → 竟然通过了"
   fi
@@ -96,6 +96,16 @@ neg "manifest 版本写错" \
     'python3 -c "
 import json,sys
 p=sys.argv[1]; d=json.load(open(p)); d[\"version\"]=\"v0.0.1\"; json.dump(d,open(p,\"w\"))" "$D/dl/manifest.json"'
+# 这一格专门隔离"自算 SHA"那一层: 二进制被换掉, manifest 也被同步改成与新内容一致 ——
+# 于是 manifest 交叉核对是过的, 能抓住它的只剩"与 lib/versions.sh 钉值比对"这一步。
+# 少了它, 把消费者的 SHA 校验整段摘掉也不会有任何一格转红(负控③当场量到 0 条)。
+neg "二进制被换 + manifest 同步改成一致(只有仓库钉值能抓)" \
+    'printf "\x00" >> "$D/dl/mosdns"
+     python3 -c "
+import json,sys,hashlib
+p=sys.argv[1]; d=json.load(open(p))
+d[\"binary_sha256\"]=hashlib.sha256(open(sys.argv[2],\"rb\").read()).hexdigest()
+json.dump(d,open(p,\"w\"))" "$D/dl/manifest.json" "$D/dl/mosdns"'
 neg "manifest 缺失" 'rm -f "$D/dl/manifest.json"'
 neg "二进制缺失" 'rm -f "$D/dl/mosdns"'
 

--- a/tests/test-mosdns-artifact-roundtrip.sh
+++ b/tests/test-mosdns-artifact-roundtrip.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# producer → artifact → 多个 consumer 这条链, 在本机走一遍真的。
+#
+# CI 里跨 job 传 artifact 的那一段(upload/download-artifact)本机证明不了, 只能等
+# exact-head CI；但**消费者侧的四层校验**是纯本地逻辑, 完全可以在这里钉死:
+# 自算 SHA、manifest 交叉核对、自报版本、生产判据。
+#
+# 重点是两个否定用例:
+#   · 二进制改一个字节 → 必须硬失败(artifact 服务端摘要证明不了内容是官方那一份);
+#   · manifest 写错但二进制没动 → 也必须被当前仓库钉值抓住(manifest 不是权威)。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-artroundtrip.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+# shellcheck source=lib/versions.sh
+source "$ROOT/lib/versions.sh" || { echo "[FAIL] 读不到 lib/versions.sh"; exit 1; }
+ARCH="$(dpkg --print-architecture 2>/dev/null)"; [[ "$ARCH" == arm64 ]] || ARCH=amd64
+WANT="${PDG_SHA256[mosdns-bin-$ARCH]:-}"
+[[ -n "$WANT" ]] || { echo "[FAIL] 没有 mosdns-bin-$ARCH 的钉值"; exit 1; }
+
+echo "══ 0. 名字生成器: producer 与 consumer 必须算出同一个名字 ══"
+n1="$(bash "$ROOT/tests/mosdns-artifact-name.sh" "$ARCH")"
+n2="$(cd "$WORK" && bash "$ROOT/tests/mosdns-artifact-name.sh")"     # 不传架构, 自己推断
+[[ -n "$n1" && "$n1" == "$n2" ]] && ok "两次调用一致: $n1" || bad "名字不一致: '$n1' vs '$n2'"
+[[ "$n1" == "mosdns-${MOSDNS_VER}-${ARCH}-${WANT:0:12}" ]] \
+  && ok "名字 = mosdns-<版本>-<架构>-<摘要前 12>" || bad "名字形态不对: $n1"
+
+echo
+echo "══ 1. producer: 造出真实钉定二进制 + manifest ══"
+PROD="$WORK/producer"; mkdir -p "$PROD"
+if [[ -x /usr/local/bin/mosdns ]] \
+   && [[ "$(sha256sum /usr/local/bin/mosdns | cut -d' ' -f1)" == "$WANT" ]]; then
+  cp /usr/local/bin/mosdns "$PROD/mosdns"          # 本机已有钉定版, 直接用(零网络)
+else
+  PDG_TEST_MOSDNS="$PROD/mosdns" bash "$ROOT/tests/prepare-mosdns.sh" >/dev/null 2>&1 || true
+fi
+if [[ -f "$PROD/mosdns" ]] && [[ "$(sha256sum "$PROD/mosdns" | cut -d' ' -f1)" == "$WANT" ]]; then
+  ok "producer 产出的二进制 SHA256 命中钉值"
+else
+  bad "拿不到钉定版 mosdns —— 这一支未验(不是通过)。备一份: sudo bash tests/prepare-mosdns.sh"
+  echo "────────────────────────────────────────"
+  echo "test-mosdns-artifact-roundtrip.sh: 通过 $pass, 失败 $nfail"
+  exit 1
+fi
+chmod 755 "$PROD/mosdns"
+GOT="$(sha256sum "$PROD/mosdns" | cut -d' ' -f1)"
+printf '{"version":"%s","arch":"%s","archive_sha256":"%s","binary_sha256":"%s","source_release":"%s","producer_commit":"%s"}\n' \
+  "$MOSDNS_VER" "$ARCH" "${PDG_SHA256[mosdns-$ARCH]}" "$GOT" \
+  "https://github.com/IrineSistiana/mosdns/releases/tag/$MOSDNS_VER" "0000000" \
+  > "$PROD/manifest.json"
+python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$PROD/manifest.json" \
+  && ok "manifest 是合法 JSON" || bad "manifest 不是合法 JSON"
+grep -qiE 'token|secret|/home/|ts\.net' "$PROD/manifest.json" \
+  && bad "manifest 里出现了不该有的环境数据" || ok "manifest 只含可公开的溯源事实"
+bash "$ROOT/tests/mosdns-artifact-name.sh" "$ARCH" >/dev/null && ok "producer 侧名字可生成"
+
+echo
+echo "══ 2. 两个独立消费者: 各自复制 → 重新校验 → 安装 ══"
+for c in consumerA consumerB; do
+  D="$WORK/$c"; mkdir -p "$D/dl" "$D/bin"
+  cp "$PROD/mosdns" "$PROD/manifest.json" "$D/dl/"          # 模拟 download-artifact
+  out="$(bash "$ROOT/tests/install-mosdns-artifact.sh" "$D/dl" "$ARCH" "$D/bin/mosdns" 2>&1)"; rc=$?
+  [[ "$rc" == 0 ]] && ok "$c 四层校验全过并装好" || bad "$c 失败 rc=$rc: $(tail -2 <<<"$out")"
+  [[ -x "$D/bin/mosdns" ]] && ok "$c 目标可执行" || bad "$c 目标没装上"
+  [[ "$(stat -c%a "$D/bin/mosdns" 2>/dev/null)" == 755 ]] \
+    && ok "$c 安装 mode=755" || bad "$c mode=$(stat -c%a "$D/bin/mosdns" 2>/dev/null)"
+  grep -q '四层过' <<<"$out" && ok "$c 报出了四层校验" || bad "$c 没报四层: $out"
+done
+
+echo
+echo "══ 3. 否定用例 ══"
+neg(){ # $1=场景 $2=准备命令
+  local D="$WORK/neg"; rm -rf "$D"; mkdir -p "$D/dl" "$D/bin"
+  cp "$PROD/mosdns" "$PROD/manifest.json" "$D/dl/"
+  eval "$2"
+  local out rc=0
+  out="$(bash "$ROOT/tests/install-mosdns-artifact.sh" "$D/dl" "$ARCH" "$D/bin/mosdns" 2>&1)" || rc=$?
+  if [[ "$rc" != 0 ]]; then
+    ok "$1 → 硬失败(rc=$rc): $(grep -m1 '\[FAIL\]' <<<"$out" | cut -c1-92)"
+  else
+    bad "$1 → 竟然通过了"
+  fi
+  [[ ! -e "$D/bin/mosdns" ]] && ok "$1 → 没有把坏件装上去" || bad "$1 → 坏件被装上了"
+}
+neg "二进制改一个字节" 'printf "\x00" >> "$D/dl/mosdns"'
+neg "manifest 摘要写错但二进制没动" \
+    'python3 -c "
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d[\"binary_sha256\"]=\"0\"*64; json.dump(d,open(p,\"w\"))" "$D/dl/manifest.json"'
+neg "manifest 版本写错" \
+    'python3 -c "
+import json,sys
+p=sys.argv[1]; d=json.load(open(p)); d[\"version\"]=\"v0.0.1\"; json.dump(d,open(p,\"w\"))" "$D/dl/manifest.json"'
+neg "manifest 缺失" 'rm -f "$D/dl/manifest.json"'
+neg "二进制缺失" 'rm -f "$D/dl/mosdns"'
+
+echo
+echo "══ 4. 消费者侧不联网 ══"
+# 把 curl/wget 从 PATH 上摘掉再跑一遍 —— 真依赖网络的话这里必然露馅。
+D="$WORK/nonet"; mkdir -p "$D/dl" "$D/bin" "$D/fakebin"
+cp "$PROD/mosdns" "$PROD/manifest.json" "$D/dl/"
+for c in curl wget; do printf '#!/bin/sh\necho "禁止联网: %s" >&2\nexit 97\n' "$c" > "$D/fakebin/$c"; chmod 755 "$D/fakebin/$c"; done
+out="$(PATH="$D/fakebin:$PATH" bash "$ROOT/tests/install-mosdns-artifact.sh" "$D/dl" "$ARCH" "$D/bin/mosdns" 2>&1)"; rc=$?
+{ [[ "$rc" == 0 ]] && ! grep -q '禁止联网' <<<"$out"; } \
+  && ok "curl/wget 被换成拒绝桩后仍然成功 —— 消费者确实不联网" \
+  || bad "消费者路径上有联网动作(rc=$rc): $(tail -2 <<<"$out")"
+
+echo
+echo "══ 5. 零残留 ══"
+[[ -d "$WORK" ]] && ok "本轮临时物都在自建目录内($WORK)"
+_leftover=0
+for d in "${TMPDIR:-/tmp}"/pdg-artroundtrip.*; do
+  [[ -e "$d" ]] || continue
+  [[ "$d" == "$WORK" ]] || _leftover=$((_leftover+1))
+done
+[[ "$_leftover" == 0 ]] && ok "没有同前缀的旧残留" || bad "有 $_leftover 个同前缀残留"
+
+echo "────────────────────────────────────────"
+echo "test-mosdns-artifact-roundtrip.sh: 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-mosdns-binary-evidence.py
+++ b/tests/test-mosdns-binary-evidence.py
@@ -166,7 +166,10 @@ if hasattr(checks, "check_mosdns_binary"):
      bad)("说清是「二进制内容与官方钉值不一致」(实得 %r)" % (r[2] if r else None))
 
     r = call(gone, real_sha)
-    (ok if r and r[0] != "ok" else bad)("文件不存在 → 不许 ok(实得 %r)" % (r,))
+    # 精确判 fail, 不是"只要不是 ok 就行"。mosdns 是核心运行文件, 它不在是**确定性故障**,
+    # 不是"无结论" —— 写成 != ok 的话, 把它降成 warn 这一格照样绿(负控③当场量到 0 条转红)。
+    (ok if r and r[0] == "fail" else
+     bad)("文件不存在 → fail(核心运行文件缺失是确定性故障, 不是无结论)(实得 %r)" % (r,))
 
     r = call(real, "")
     (ok if r and r[0] == "warn" else

--- a/tests/test-mosdns-binary-evidence.py
+++ b/tests/test-mosdns-binary-evidence.py
@@ -179,7 +179,9 @@ if hasattr(checks, "check_mosdns_binary"):
 print()
 print("══ 5. 安装器: 同版本但内容不同, 不许短路 ══")
 # 短路条件必须是"语义版本相同 **且** 落盘二进制的 SHA256 等于该架构钉值"。
-seg = re.search(r"if ! pdg_mosdns_is_version.*?\nfi\n", INST, re.S)
+# 锚在**章节边界**上而不是某个函数名上: 短路判据换个名字是这一轮正要做的事,
+# 把锚点写成旧函数名, 修好之后这一格会安静地抽不到东西。
+seg = re.search(r"# ── 2\. mosdns ──.*?(?=# ── 3\.)", INST, re.S)
 (ok if seg else bad)("抽得到 install.sh 的 mosdns 安装段")
 if seg:
     s = seg.group(0)
@@ -204,7 +206,7 @@ if helper:
     def probe(pin_sha):
         script = (
             'source "%s/lib/versions.sh"\n'
-            'PDG_SHA256[mosdns-amd64test]="%s"\n'
+            'PDG_SHA256[mosdns-bin-amd64test]="%s"\n'
             'PATH="%s:$PATH"\n'
             'pdg_mosdns_binary_ok amd64test "%s" "%s"; echo "rc=$?"\n'
             % (ROOT, pin_sha, sb, PIN_VER, fake))

--- a/tests/test-mosdns-binary-evidence.py
+++ b/tests/test-mosdns-binary-evidence.py
@@ -185,8 +185,19 @@ seg = re.search(r"# ── 2\. mosdns ──.*?(?=# ── 3\.)", INST, re.S)
 (ok if seg else bad)("抽得到 install.sh 的 mosdns 安装段")
 if seg:
     s = seg.group(0)
-    (ok if "mosdns-bin-" in s or "pdg_mosdns_binary_ok" in s else
-     bad)("短路条件里带上了二进制摘要(否则跳过下载 = 跳过供应链校验)")
+    # 判据要落在**短路条件那一行**上。写成"这一段里提到过摘要"是不够的: 段尾还有一处
+    # 装完之后的复核也提到 mosdns-bin-, 于是把短路改回只看自报版本时, 这一格照样绿
+    # (负控⑨当场量到 0 条转红)。
+    cond = re.search(r"^if ! (.+); then$", s, re.M)
+    (ok if cond else bad)("抽得到短路那一行的条件")
+    if cond:
+        c = cond.group(1)
+        (ok if "pdg_mosdns_binary_ok" in c else
+         bad)("短路条件本身要求二进制摘要相符, 不只是版本(实得 %r)" % c)
+        (ok if "pdg_mosdns_is_version" not in c else
+         bad)("短路条件不再是「自报版本相同就跳过」(实得 %r)" % c)
+    (ok if "mosdns-bin-" in s else
+     bad)("安装段里用到了二进制钉值(装完之后还要再核一次落盘内容)")
     (ok if "PDG_SHA256[mosdns-$MARCH]" in s else
      bad)("下载后的压缩包 ZIP 校验没有被削弱")
     (ok if "_stash_bin" in s else bad)("既有的回滚保护还在")

--- a/tests/test-mosdns-binary-evidence.py
+++ b/tests/test-mosdns-binary-evidence.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""mosdns 的证据必须同时认**退出码、执行路径和二进制内容**, 三者缺一都是假绿。
+
+实测: 下面这组输入会被当前判据判成 OK ——
+
+    rc=1
+    stdout="mosdns v5.3.4-0-gb732318"
+    stderr="fatal: broken"
+
+判据把 stdout 与 stderr 拼起来正则找版本号, 找到就算数, 退出码根本没看。一个起不来的
+mosdns 只要还能打印自己的版本, doctor 就会说"✓ 钉死值"。
+
+第二件: 判据调的是 PATH 里的 `mosdns`, 而 systemd 实际执行的是 /usr/local/bin/mosdns
+(ExecStart 写死)。PATH 前面搁一个别的 mosdns, doctor 报的就不是网关在跑的那个。
+
+第三件: 安装器的短路条件是"自报版本相同就跳过下载"。于是一个**内容不同、但自报 v5.3.4**
+的二进制会让整段安装被跳过 —— 连带跳过 SHA256 供应链校验。项目钉的 PDG_SHA256[mosdns-*]
+是下载**压缩包**的哈希, 一旦跳过下载, 它就再也没有机会被用上; 落盘的那个二进制本身,
+项目从来没有钉过。
+
+线上两台当前的二进制已经核实为官方原版, 这里修的是**证据闭包**, 不是事故现场。
+"""
+import hashlib
+import os
+import re
+import stat
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "deploy/bot"))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import tmpguard                                              # noqa: E402
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+import checks                                                # noqa: E402
+
+CHK = open(os.path.join(ROOT, "deploy/bot/checks.py"), encoding="utf-8").read()
+VERS = open(os.path.join(ROOT, "lib/versions.sh"), encoding="utf-8").read()
+INST = open(os.path.join(ROOT, "install.sh"), encoding="utf-8").read()
+W = tmpguard.mkdtemp(prefix="pdg-mosbin.")
+
+PIN_VER = (re.search(r'^MOSDNS_VER="([^"]+)"', VERS, re.M) or [None, "v5.3.4"])[1]
+
+print("══ 1. 判据固定在 systemd 真正执行的那个路径上 ══")
+# ExecStart 写的是绝对路径; 判据必须问同一个文件, 否则报的是"某个 mosdns"而不是"这台跑的那个"
+unit = re.search(r"ExecStart=(\S*/mosdns)\s", INST)
+(ok if unit else bad)("install.sh 的 mosdns.service 里抽得到 ExecStart 路径")
+UNIT_BIN = unit.group(1) if unit else "/usr/local/bin/mosdns"
+(ok if UNIT_BIN in CHK else
+ bad)("checks.py 里出现 systemd 执行的那个绝对路径 %s(实得: 未出现)" % UNIT_BIN)
+body = re.search(r"def check_mosdns_version\(.*?\n(?=\ndef )", CHK, re.S)
+(ok if body else bad)("抽得到 check_mosdns_version")
+if body:
+    b = body.group(0)
+    (ok if not re.search(r'_run\(\[\s*"mosdns"', b) else
+     bad)("判据不再用裸的 \"mosdns\"(那会跟着 PATH 走, 报的可能是另一个二进制)")
+
+print()
+print("══ 2. 退出码是证据的一部分 ══")
+_run0 = checks._run
+
+
+def stub(seq, path_filter=None):
+    def f(cmd, *a, **k):
+        if cmd and "mosdns" in str(cmd[0]):
+            if path_filter is not None:
+                path_filter.append(cmd[0])
+            return seq
+        return _run0(cmd, *a, **k)
+    return f
+
+
+if body:
+    seen = []
+    checks._run = stub((0, "mosdns %s-0-gb732318\n" % PIN_VER, ""), seen)
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] == "ok" else bad)("rc=0 + 版本相符 → ok(实得 %r)" % (r,))
+    (ok if seen and seen[0] == UNIT_BIN else
+     bad)("判据调的是 %s(实得 %r)" % (UNIT_BIN, seen[0] if seen else None))
+
+    # ★ 实测的假绿形态: 命令失败了, 但它在崩之前把版本号打出来了
+    checks._run = stub((1, "mosdns %s-0-gb732318\n" % PIN_VER, "fatal: broken"))
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] != "ok" else
+     bad)("rc=1 但 stdout 里有正确版本 → **不许**判绿(实得 %r)" % (r,))
+    (ok if r and ("rc" in r[2] or "退出" in r[2] or "非 0" in r[2]) else
+     bad)("说清是命令失败而不是版本不符(实得 %r)" % (r[2] if r else None))
+
+    # 版本号只出现在 stderr 里, 同样不算成功证据
+    checks._run = stub((0, "", "mosdns %s-0-gb732318\n" % PIN_VER))
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] != "ok" else
+     bad)("版本只在 stderr 里 → 不算成功证据(实得 %r)" % (r,))
+
+    # 解析不出版本 → warn + 无结论
+    checks._run = stub((0, "hello world\n", ""))
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] == "warn" else bad)("解析不出版本 → warn(实得 %r)" % (r,))
+
+    # 版本不符 → warn, 两边都报
+    checks._run = stub((0, "mosdns v9.9.9-0-gx\n", ""))
+    r = checks.check_mosdns_version()
+    (ok if r and r[0] == "warn" and "v9.9.9" in r[2] and PIN_VER in r[2] else
+     bad)("版本不符 → warn 且两边的值都报出来(实得 %r)" % (r,))
+    checks._run = _run0
+
+print()
+print("══ 3. lib/versions.sh 里钉了**解压后二进制**的哈希 ══")
+HEX = r'"([0-9a-f]{64})"'
+pins = dict(re.findall(r"\[mosdns-bin-(amd64|arm64)\]=" + HEX, VERS))
+for arch in ("amd64", "arm64"):
+    (ok if arch in pins else
+     bad)("PDG_SHA256[mosdns-bin-%s] 已钉(压缩包哈希在跳过下载时根本用不上)" % arch)
+zips = dict(re.findall(r"\[mosdns-(amd64|arm64)\]=" + HEX, VERS))
+for arch in pins:
+    (ok if pins[arch] != zips.get(arch) else
+     bad)("%s 的二进制哈希与压缩包哈希不是同一个值(相同说明钉错了对象)" % arch)
+# 取值过程必须写下来: 没有出处的哈希就是 TOFU, 换个人来无从复算
+(ok if re.search(r"解压后|unzip", VERS) and "mosdns-bin-" in VERS else
+ bad)("versions.sh 里写清了这两个值是怎么算出来的")
+
+print()
+print("══ 4. doctor 有一条二进制完整性判据 ══")
+(ok if hasattr(checks, "check_mosdns_binary") else
+ bad)("checks.py 里有 check_mosdns_binary")
+(ok if "check_mosdns_binary" in CHK.split("ALL = [")[-1] else
+ bad)("check_mosdns_binary 登记进了 ALL(不登记就永远不会跑)")
+
+if hasattr(checks, "check_mosdns_binary"):
+    real = os.path.join(W, "mosdns_real")
+    open(real, "wb").write(b"official-bytes")
+    os.chmod(real, 0o755)
+    real_sha = hashlib.sha256(b"official-bytes").hexdigest()
+    other = os.path.join(W, "mosdns_other")
+    open(other, "wb").write(b"tampered-bytes")
+    os.chmod(other, 0o755)
+    gone = os.path.join(W, "mosdns_gone")
+
+    def call(path, pin, arch="amd64"):
+        return checks.check_mosdns_binary(_bin=path, _pin=pin, _arch=arch)
+
+    r = call(real, real_sha)
+    (ok if r and r[0] == "ok" else bad)("摘要相符 → ok(实得 %r)" % (r,))
+    (ok if r and real_sha[:12] in r[2] else
+     bad)("绿的时候给出短前缀, 便于人工核对(实得 %r)" % (r[2] if r else None))
+    (ok if r and real_sha not in r[2] else
+     bad)("只给短前缀, 不整串打出来(实得 %r)" % (r[2] if r else None))
+
+    r = call(other, real_sha)
+    (ok if r and r[0] == "fail" else
+     bad)("同版本、内容不同 → fail(这正是跳过下载后无人再校验的那个形态)(实得 %r)" % (r,))
+    (ok if r and ("内容" in r[2] or "不一致" in r[2]) else
+     bad)("说清是「二进制内容与官方钉值不一致」(实得 %r)" % (r[2] if r else None))
+
+    r = call(gone, real_sha)
+    (ok if r and r[0] != "ok" else bad)("文件不存在 → 不许 ok(实得 %r)" % (r,))
+
+    r = call(real, "")
+    (ok if r and r[0] == "warn" else
+     bad)("钉值读不到 → warn + 无结论(不是「没问题」)(实得 %r)" % (r,))
+
+    r = call(real, real_sha, arch="riscv64")
+    (ok if r and r[0] == "warn" else
+     bad)("架构不在钉值表里 → warn + 无结论(实得 %r)" % (r,))
+
+print()
+print("══ 5. 安装器: 同版本但内容不同, 不许短路 ══")
+# 短路条件必须是"语义版本相同 **且** 落盘二进制的 SHA256 等于该架构钉值"。
+seg = re.search(r"if ! pdg_mosdns_is_version.*?\nfi\n", INST, re.S)
+(ok if seg else bad)("抽得到 install.sh 的 mosdns 安装段")
+if seg:
+    s = seg.group(0)
+    (ok if "mosdns-bin-" in s or "pdg_mosdns_binary_ok" in s else
+     bad)("短路条件里带上了二进制摘要(否则跳过下载 = 跳过供应链校验)")
+    (ok if "PDG_SHA256[mosdns-$MARCH]" in s else
+     bad)("下载后的压缩包 ZIP 校验没有被削弱")
+    (ok if "_stash_bin" in s else bad)("既有的回滚保护还在")
+
+# 真跑一次判据函数(在沙箱里, 不碰 /usr/local/bin)
+helper = re.search(r"\npdg_mosdns_binary_ok\(\)\{", VERS)
+(ok if helper else
+ bad)("lib/versions.sh 里有 pdg_mosdns_binary_ok(单一真源, install.sh 与测试共用)")
+if helper:
+    sb = os.path.join(W, "bin")
+    os.makedirs(sb, exist_ok=True)
+    fake = os.path.join(sb, "mosdns")
+    open(fake, "w").write('#!/bin/sh\necho "mosdns %s-0-gb732318"\n' % PIN_VER)
+    os.chmod(fake, 0o755)
+    fake_sha = hashlib.sha256(open(fake, "rb").read()).hexdigest()
+
+    def probe(pin_sha):
+        script = (
+            'source "%s/lib/versions.sh"\n'
+            'PDG_SHA256[mosdns-amd64test]="%s"\n'
+            'PATH="%s:$PATH"\n'
+            'pdg_mosdns_binary_ok amd64test "%s" "%s"; echo "rc=$?"\n'
+            % (ROOT, pin_sha, sb, PIN_VER, fake))
+        return subprocess.run(["bash", "-c", script],
+                              capture_output=True, text=True).stdout.strip()
+
+    out = probe(fake_sha)
+    (ok if out.endswith("rc=0") else
+     bad)("版本对 + 摘要对 → 0(可以短路)(实得 %r)" % out)
+    out = probe("0" * 64)
+    (ok if out.endswith("rc=1") else
+     bad)("版本对但摘要不对 → 非 0(必须重新下载并走 ZIP 校验)(实得 %r)" % out)
+    out = probe("")
+    (ok if out.endswith("rc=1") else
+     bad)("钉值为空 → 非 0(存疑就装, 不能存疑就跳过)(实得 %r)" % out)
+
+print("-" * 62)
+print("test-mosdns-binary-evidence.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-p2-runtime-fixes.sh
+++ b/tests/test-p2-runtime-fixes.sh
@@ -175,8 +175,14 @@ mkrepo(){                               # $1=latest|behind|dirty; 打印仓库�
   # 那样这一格就测不出真正的错误形态了。
   e2e_git "$d" -c user.email=t@t -c user.name=t tag -a v9.9.9 -m r 2>/dev/null
   if [[ "$1" == behind ]]; then
+    # 这一格的名字是"落后", 造的现场必须**真的**落后: 在 c1 之上再提交 c2、把 tag 移到 c2,
+    # 再把 HEAD 退回 c1。原先只是在打完 tag 之后多提交一笔而 HEAD 留在 c2 —— 那是
+    # **领先**最新发布, 恰好是相反的一态。旧判据只比"相等不相等", 两者看起来一样,
+    # 于是这个名不副实的夹具一直绿着; 方向判据一上来它就露馅了。
     echo x > "$d/extra.txt"; e2e_git "$d" add -A >/dev/null 2>&1
     e2e_git "$d" -c user.email=t@t -c user.name=t commit -q -m c2
+    e2e_git "$d" -c user.email=t@t -c user.name=t tag -f -a v9.9.9 -m r 2>/dev/null
+    e2e_git "$d" checkout -q HEAD~1 2>/dev/null
   fi
   echo "$d"
 }
@@ -209,6 +215,10 @@ drv_update(){                           # $1=pdg.sh $2=仓库 → 输出 + 副�
     fn "$f" '/^_core_bindir(){/,/^}/p'
     fn "$f" '/^_pdg_same_file(){/,/^}/p'
     fn "$f" '/^_update_in_sync(){/,/^}/p'
+    # 短路现在建在方向判据之上(same/behind/ahead/diverged), 判据要跟着抽出来 ——
+    # 缺了它 cmd_update 会在第一道门上 command-not-found, 于是这一节测的全是"判不出关系",
+    # 而不是短路本身。旧版 pdg.sh 里没有这个函数, fn 抽不到就是一段空 —— 反向对照照旧成立。
+    fn "$f" '/^_update_release_relation(){/,/^}/p'
     fn "$f" '/^cmd_update(){/,/^}/p'
     echo 'cmd_update; echo "RC=$?"'
   } > "$WORK/d4.sh"

--- a/tests/test-status-adblock-line.py
+++ b/tests/test-status-adblock-line.py
@@ -110,8 +110,17 @@ if not missing:
     r2 = subprocess.run(["bash", "-c", "source %s; _adblock_status_line" % cl],
                         capture_output=True, text=True, env=env)
     out_on = (r2.stdout or "").strip()
-    (ok if "1234" in out_on else bad)("已启用时报出生效表的条数(实得 %r)" % out_on)
-    (ok if "2" in out_on else bad)("已启用时报出用户规则数(实得 %r)" % out_on)
+    # 两个数字必须**分别具名断言**, 不能用子串包含。`"2" in out_on` 看着像在验"自定义 2 条",
+    # 实际同一行里的 1234 就含着字符 2 —— 把产品改成恒定输出"自定义 0 条", 这一格照样绿
+    # (实测: 改坏之后 23/23 全通过)。一个永远不会红的断言比没有断言更糟, 它还在冒充证据。
+    mline = re.search(r"第三方表\s*(\d+)\s*条\s*/\s*自定义\s*(\d+)\s*条", out_on)
+    (ok if mline else
+     bad)("已启用那行能按结构解析出两个具名字段(实得 %r)" % out_on)
+    if mline:
+        (ok if mline.group(1) == "1234" else
+         bad)("第三方表 = 1234(实得 %s, 整行 %r)" % (mline.group(1), out_on))
+        (ok if mline.group(2) == "2" else
+         bad)("自定义 = 2(实得 %s, 整行 %r)" % (mline.group(2), out_on))
     (ok if "\n" not in out_on else bad)("已启用那行是单行(实得 %r)" % out_on)
     (ok if not re.findall(r"\d+\s*次", out_on) else
      bad)("那一行里没有「N 次」(实得 %r)" % out_on)

--- a/tests/test-status-adblock-line.py
+++ b/tests/test-status-adblock-line.py
@@ -80,7 +80,10 @@ open(os.path.join(W, "state", "effective_list.txt"), "w").write(
     "".join("x%d.example\n" % i for i in range(1234)))
 
 # 只抽那一行所依赖的函数, 单独跑 —— 整个 cmd_status 要 systemctl, 跑不动
-need = ["_adb_count_rules", "_adblock_intent", "_adblock_status_line"]
+# 只读状态那条链现在是四段: 三态读取器 + 可读性判据 + 计数 + 渲染。少抽一段,
+# 渲染函数会掉进"规则文件读不出来"那条分支, 而现场其实好好的。
+need = ["_adblock_read_state", "_adb_rules_readable",
+        "_adb_count_rules", "_adblock_intent", "_adblock_status_line"]
 missing = [f for f in need if ("\n%s()" % f) not in PDGSH]
 (ok if not missing else bad)("依赖的函数都在(缺: %r)" % missing)
 if not missing:

--- a/tests/test-update-faults.sh
+++ b/tests/test-update-faults.sh
@@ -15,6 +15,10 @@ ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
 bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
 
 sed -n '/^cmd_update(){/,/^}/p' "$ROOT/deploy/bot/pdg.sh" > "$WORK/upd.sh"
+# cmd_update 现在先问一次"这次到底是不是在往前走"(_update_release_relation)。判据要**真**跟着
+# 抽出来: 缺了它, cmd_update 会在第一道门上就 command-not-found → 判不出关系 → 拒绝执行,
+# 于是下面每一条故障注入都打在同一个空处, 而它们本来是要测后面那些阶段的。
+sed -n '/^_update_release_relation(){/,/^}/p' "$ROOT/deploy/bot/pdg.sh" >> "$WORK/upd.sh"
 
 mkdir -p "$WORK/repo/.git"          # 让 [[ -d $REPO_DIR/.git ]] 为真, 跳过 clone
 # cmd_update 会 source 运行模块清单(lib/modules.sh)。桩仓库里给一份**同名同函数**的替身:

--- a/tests/test-update-mosdns-preflight.sh
+++ b/tests/test-update-mosdns-preflight.sh
@@ -218,7 +218,7 @@ echo "══ 4. 关系门优先于预检: ahead/diverged 仍由关系门拒绝 �
 for spec in "ahead:main:领先" "diverged:side:分叉"; do
   IFS=: read -r nm ref kw <<<"$spec"
   mkrepo "$WORK/repo" bogus >/dev/null 2>&1
-  command git -C "$WORK/repo" tag -d v2.0.0 >/dev/null 2>&1
+  g "$WORK/repo" tag -d v2.0.0 >/dev/null 2>&1
   g "$WORK/repo" checkout -q "$ref" 2>/dev/null
   [[ "$nm" == diverged ]] && g "$WORK/repo" tag -a v2.0.0 -m x main >/dev/null 2>&1
   # 仓库钉值同时也是坏的 → mosdns 预检也过不了。看谁先说话。

--- a/tests/test-update-mosdns-preflight.sh
+++ b/tests/test-update-mosdns-preflight.sh
@@ -60,48 +60,74 @@ else
 fi
 
 echo
-echo "══ 3. 四类状态 × 真跑 cmd_update ══"
-g(){ e2e_git "$1" "${@:2}"; }
-mkrepo(){                       # HEAD 落后一个 tag → 关系判定为 behind, 走真实更新
-  local r="$1"; rm -rf "$r"; mkdir -p "$r/lib"
-  command git -C "$r" init -q -b main
-  g "$r" config user.email t@t; g "$r" config user.name t; g "$r" config commit.gpgsign false
-  printf 'pdg_install_runtime_modules(){ return 0; }\n' > "$r/lib/modules.sh"
-  # 仓库自带一份 versions.sh: 预检要从它读钉值, 与 install.sh 同一个来源
-  cat > "$r/lib/versions.sh" <<'V'
-MOSDNS_VER="v9.9.9"
-declare -A PDG_SHA256=( [mosdns-bin-amd64]="__SHA__" [mosdns-bin-arm64]="__SHA__" )
-pdg_mosdns_binary_ok(){
-  local arch="${1:-}" want="${2:-${MOSDNS_VER:-}}" bin="${3:-/usr/local/bin/mosdns}" got exp
-  [[ -n "$arch" && -n "$want" && -x "$bin" ]] || return 1
-  exp="${PDG_SHA256[mosdns-bin-$arch]:-}"; [[ -n "$exp" ]] || return 1
-  got="$("$bin" version 2>/dev/null | head -1)" || return 1
-  [[ "$got" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
-  [[ "${BASH_REMATCH[1]}" == "${want#v}" ]] || return 1
-  got="$(sha256sum "$bin" 2>/dev/null | awk '{print $1}')"
-  [[ -n "$got" && "$got" == "$exp" ]]
-}
-V
-  echo A > "$r/f"; g "$r" add -A; g "$r" commit -qm A
-  g "$r" tag -a v1.0.0 -m v1.0.0
-  echo B > "$r/f"; g "$r" add -A; g "$r" commit -qm B
-  g "$r" tag -a v2.0.0 -m v2.0.0
-  g "$r" checkout -q -b side v1.0.0
-  echo D > "$r/f"; g "$r" add -A; g "$r" commit -qm D
-  g "$r" checkout -q v1.0.0            # HEAD = v1.0.0, 最新 tag = v2.0.0 → behind
-}
-
-# 造一个"合法 mosdns": 自报 v9.9.9 的可执行文件, 钉值就取它自己的 sha256
+echo "══ 3A. 四类不合法状态: 直接问预检(路径由参数注入, 生产调用点不传参)══"
+# 沙箱里改不动 /usr/local/bin/mosdns(要 root), 所以四种形态用参数注入。
+# **裁决逻辑一个字没变** —— 变的只是被问的是哪个文件。
 BIN="$WORK/bin"; mkdir -p "$BIN"
-mkmosdns(){                      # $1=version 串; 打印文件路径
-  printf '#!/bin/sh\ncase "$1" in version) echo "mosdns %s-0-gabc";; esac\nexit 0\n' "$1" > "$BIN/mosdns"
-  chmod 755 "$BIN/mosdns"; echo "$BIN/mosdns"
+mkmosdns(){ printf '#!/bin/sh\ncase "$1" in version) echo "mosdns %s-0-gabc";; esac\nexit 0\n' "$1" > "$2"; chmod 755 "$2"; }
+mkmosdns v9.9.9 "$WORK/mosdns.good"
+GOOD_SHA="$(sha256sum "$WORK/mosdns.good" | cut -d' ' -f1)"
+
+mkvers(){        # $1=目标目录; 造一份只认 $GOOD_SHA 的 versions.sh(结构与生产同形)
+  mkdir -p "$1/lib"
+  cat > "$1/lib/versions.sh" <<V
+MOSDNS_VER="v9.9.9"
+declare -A PDG_SHA256=( [mosdns-bin-amd64]="$GOOD_SHA" [mosdns-bin-arm64]="$GOOD_SHA" )
+V
+  # 判据本体从**真的那份**取, 不在测试里另写一遍 —— 否则测的是我抄得对不对
+  sed -n '/^pdg_mosdns_binary_ok(){/,/^}/p' "$ROOT/lib/versions.sh" >> "$1/lib/versions.sh"
 }
-# 原件另存一份: $BIN/mosdns 每一格都会被改坏或删掉, 拿它当"合法原件"的话,
-# 第二格之后就 cp 不出东西来了(第一版就是这么把 ①⑥ 两格测空的)。
-mkmosdns v9.9.9 >/dev/null
-GOOD="$WORK/mosdns.pristine"; cp "$BIN/mosdns" "$GOOD"; chmod 755 "$GOOD"
-GOOD_SHA="$(sha256sum "$GOOD" | cut -d' ' -f1)"
+mkvers "$WORK/vrepo"
+
+ask(){           # $1=二进制路径 → "rc|输出"
+  local rc=0 out
+  out=$(REPO_DIR="$WORK/vrepo" bash -c "
+    c_y(){ echo \"\$*\"; }
+    REPO_DIR='$WORK/vrepo'
+    source '$WORK/pre.sh'
+    _update_mosdns_preflight '$1'" 2>&1) || rc=$?
+  printf '%s\n' "$rc|$out"
+}
+cp "$WORK/mosdns.good" "$BIN/mosdns"; chmod 755 "$BIN/mosdns"
+r=$(ask "$BIN/mosdns"); [[ "${r%%|*}" == 0 ]] \
+  && ok "合法(版本对 + 摘要对)→ 预检放行" || bad "合法却被拒: ${r#*|}"
+
+declare -A CASE=(
+  ["文件不存在"]='rm -f "$BIN/mosdns"'
+  ["执行不了"]='cp "$WORK/mosdns.good" "$BIN/mosdns"; chmod 644 "$BIN/mosdns"'
+  ["version 命令非零"]='printf "#!/bin/sh\nexit 3\n" > "$BIN/mosdns"; chmod 755 "$BIN/mosdns"'
+  ["自报版本不符"]='mkmosdns v1.2.3 "$BIN/mosdns"'
+  ["摘要不符"]='mkmosdns v9.9.9 "$BIN/mosdns"; printf "\n# tampered\n" >> "$BIN/mosdns"'
+)
+declare -A WANT=(
+  ["文件不存在"]='不存在'  ["执行不了"]='执行不了'  ["version 命令非零"]='命令非零'
+  ["自报版本不符"]='版本不符'  ["摘要不符"]='摘要不符'
+)
+for k in "文件不存在" "执行不了" "version 命令非零" "自报版本不符" "摘要不符"; do
+  eval "${CASE[$k]}"
+  r=$(ask "$BIN/mosdns"); rc="${r%%|*}"; out="${r#*|}"
+  [[ "$rc" != 0 ]] && ok "[$k] 预检拒绝(rc=$rc)" || bad "[$k] 预检竟然放行"
+  grep -q "${WANT[$k]}" <<<"$out" && ok "[$k] 原因具名: ${WANT[$k]}" \
+    || bad "[$k] 原因不具名(期望含 ${WANT[$k]}): $(tr '\n' ' ' <<<"$out" | cut -c1-120)"
+  grep -q 'mosdns' <<<"$out" && ok "[$k] 点名了是 mosdns" || bad "[$k] 没点名组件"
+done
+# 读不到 versions.sh / 架构无钉值 → 一样拒绝(fail-closed)
+cp "$WORK/mosdns.good" "$BIN/mosdns"; chmod 755 "$BIN/mosdns"
+r=$(REPO_DIR="$WORK/nosuch" bash -c "c_y(){ echo \"\$*\"; }; REPO_DIR='$WORK/nosuch'; source '$WORK/pre.sh'; _update_mosdns_preflight '$BIN/mosdns'" 2>&1; echo "rc=$?")
+grep -q 'rc=1' <<<"$r" && ok "读不到 versions.sh → 拒绝(fail-closed, 不在存疑时动手)" \
+  || bad "读不到 versions.sh 却放行了: $r"
+
+echo
+echo "══ 3B. 真跑 cmd_update: 预检不合法时零副作用 ══"
+# 这一层不注入路径 —— 走的是生产那条写死的 /usr/local/bin/mosdns。
+# 让它"不合法"的办法不是动那个文件(沙箱里动不了), 而是让仓库的钉值与它对不上:
+# 判据两边都要对得上才算合法, 改哪一边效果一样, 而改钉值不需要 root。
+REALBIN=/usr/local/bin/mosdns
+if [[ ! -x "$REALBIN" ]]; then
+  bash "$ROOT/tests/prepare-mosdns.sh" >/dev/null 2>&1 || true
+fi
+if [[ -x "$REALBIN" ]]; then ok "本机有 $REALBIN, 可以跑真实调用链那一层"
+else bad "拿不到钉死版 mosdns —— 真实调用链那一层未验(不是通过)。备一份: bash tests/prepare-mosdns.sh"; fi
 
 cat > "$WORK/harness.sh" <<'EOF'
 REPO_DIR="$WORK/repo"; REPO_URL="file:///dev/null"; ENVF="$WORK/none.env"
@@ -115,12 +141,14 @@ _pdg_core(){ echo mihomo; }
 _pdg_bot_cred(){ echo unset; }
 pdg_fetch_release_tags(){ return 0; }
 _update_in_sync(){ return 1; }
-dpkg(){ echo amd64; }
-git(){ printf '%s\n' "$*" >> "$WORK/git.log"; command git "$@"; }
-install(){ printf 'install %s\n' "$*" >> "$WORK/side.log"; return 0; }
+git(){ printf '%s
+' "$*" >> "$WORK/git.log"; command git "$@"; }
+install(){ printf 'install %s
+' "$*" >> "$WORK/side.log"; return 0; }
 bash(){ [[ "$*" == *__migrate* ]] && { echo migrate >> "$WORK/side.log"; return 0; }; command bash "$@"; }
 _update_core_binary(){ echo core >> "$WORK/side.log"; return 0; }
-systemctl(){ printf 'systemctl %s\n' "$*" >> "$WORK/side.log"; return 0; }
+systemctl(){ printf 'systemctl %s
+' "$*" >> "$WORK/side.log"; return 0; }
 python3(){ case "$*" in *py_compile*) return 0;;
   *doctor.py*) cat "$WORK/doctor.json";; *) command python3 "$@";; esac; }
 mihomo(){ return 0; }
@@ -132,68 +160,70 @@ EOF
 export WORK
 echo '[{"level":"ok","check":"服务","detail":"都在"}]' > "$WORK/doctor.json"
 
-run(){                          # $1=mosdns 现场造法; 打印 "rc|输出"
-  mkrepo "$WORK/repo" >/dev/null 2>&1
-  sed -i "s/__SHA__/$GOOD_SHA/g" "$WORK/repo/lib/versions.sh"
-  : > "$WORK/side.log"; : > "$WORK/git.log"
-  eval "$1"
-  local rc=0 out
-  out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1) || rc=$?
-  printf '%s\n' "$rc|$out"
+g(){ e2e_git "$1" "${@:2}"; }
+mkrepo(){                       # HEAD 落后一个 tag → behind → 走真实更新
+  local r="$1" pin="$2"         # pin=real → 用仓库真钉值; pin=bogus → 故意对不上
+  rm -rf "$r"; mkdir -p "$r/lib"
+  command git -C "$r" init -q -b main
+  g "$r" config user.email t@t; g "$r" config user.name t; g "$r" config commit.gpgsign false
+  printf 'pdg_install_runtime_modules(){ return 0; }\n' > "$r/lib/modules.sh"
+  cp "$ROOT/lib/versions.sh" "$r/lib/versions.sh"
+  if [[ "$pin" == bogus ]]; then
+    sed -i 's/\[mosdns-bin-amd64\]="./[mosdns-bin-amd64]="0/; s/\[mosdns-bin-arm64\]="./[mosdns-bin-arm64]="0/' "$r/lib/versions.sh"
+  fi
+  echo A > "$r/f"; g "$r" add -A; g "$r" commit -qm A
+  g "$r" tag -a v1.0.0 -m v1.0.0
+  echo B > "$r/f"; g "$r" add -A; g "$r" commit -qm B
+  g "$r" tag -a v2.0.0 -m v2.0.0
+  g "$r" checkout -q -b side v1.0.0
+  echo D > "$r/f"; g "$r" add -A; g "$r" commit -qm D
+  g "$r" checkout -q v1.0.0
 }
 side(){ grep -qF "$1" "$WORK/side.log" 2>/dev/null; }
 did_reset(){ grep -qE '(^| )reset ' "$WORK/git.log" 2>/dev/null; }
 HEAD_OF(){ command git -C "$WORK/repo" rev-parse HEAD 2>/dev/null; }
-
-nofx(){                          # 逐项零副作用
-  local tag="$1" h0="$2"
+run(){                          # $1=real|bogus [$2=--dry-run] → "rc|输出"; h0 存进 $H0
+  mkrepo "$WORK/repo" "$1" >/dev/null 2>&1
+  HEAD_OF > "$WORK/head0"          # $(run …) 是子 shell, 变量回不来, 前像只能落盘
+  : > "$WORK/side.log"; : > "$WORK/git.log"
+  local rc=0 out
+  out=$(bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update ${2:-}" 2>&1) || rc=$?
+  printf '%s\n' "$rc|$out"
+}
+nofx(){
+  local tag="$1"
   side SNAPSHOT   && bad "$tag: 建了快照" || ok "$tag: 快照数不变"
-  did_reset       && bad "$tag: 执行了 reset" || ok "$tag: HEAD 未被 reset"
-  [[ "$(HEAD_OF)" == "$h0" ]] && ok "$tag: git HEAD 逐字节不变" || bad "$tag: HEAD 变了"
-  side "install " && bad "$tag: 装了文件" || ok "$tag: 已装文件未被触碰"
+  did_reset       && bad "$tag: 执行了 reset" || ok "$tag: 未 reset"
+  [[ "$(HEAD_OF)" == "$(cat "$WORK/head0" 2>/dev/null)" ]] \
+    && ok "$tag: git HEAD 与工作区逐字节不变" || bad "$tag: HEAD 变了"
+  side "install " && bad "$tag: 装了文件" || ok "$tag: 已装文件摘要不变"
   side migrate    && bad "$tag: 调了 __migrate" || ok "$tag: __migrate 未调用"
-  side systemctl  && bad "$tag: 碰了 systemctl" || ok "$tag: 服务未被动过(InvocationID 不变)"
+  side systemctl  && bad "$tag: 碰了 systemctl" || ok "$tag: 服务未动(InvocationID 不变)"
   side ROLLBACK   && bad "$tag: 进了 rollback" || ok "$tag: rollback 计数 0"
 }
 
-# ① 合法 → 允许进入更新
-r=$(run 'install -m755 "$GOOD" "$BIN/mosdns"'); rc="${r%%|*}"; out="${r#*|}"
-did_reset && ok "① 合法 mosdns → 放行, 正常进入更新" || bad "① 合法却被挡住了: $(tail -3 <<<"$out")"
-[[ "$rc" == 0 ]] && ok "① rc=0" || bad "① rc=$rc: $(tail -3 <<<"$out")"
+if [[ -x "$REALBIN" ]]; then
+  r=$(run real); rc="${r%%|*}"; out="${r#*|}"
+  did_reset && ok "钉值与真实二进制相符 → 预检放行, 正常进入更新" \
+    || bad "合法却被挡住: $(tail -3 <<<"$out")"
+  [[ "$rc" == 0 ]] && ok "合法路径 rc=0" || bad "合法路径 rc=$rc: $(tail -3 <<<"$out")"
+fi
+r=$(run bogus); rc="${r%%|*}"; out="${r#*|}"
+[[ "$rc" != 0 ]] && ok "钉值对不上 → rc 非 0(实得 $rc)" || bad "钉值对不上却 rc=0"
+grep -q 'mosdns' <<<"$out" && ok "具名指出是 mosdns" || bad "没点名: $(tail -2 <<<"$out")"
+grep -q '✅ 已更新' <<<"$out" && bad "冒充已更新" || ok "没冒充已更新"
+nofx "预检拒绝"
 
-# ②③④⑤ 四类不合法
-for cell in \
-  "② 文件不存在|rm -f \"\$BIN/mosdns\"|不存在|缺失" \
-  "③ 版本命令非零|printf '#!/bin/sh\\nexit 3\\n' > \"\$BIN/mosdns\"; chmod 755 \"\$BIN/mosdns\"|执行不了|version 命令" \
-  "④ 自报版本不符|mkmosdns v1.2.3 >/dev/null|版本|不符" \
-  "⑤ SHA256 不符|mkmosdns v9.9.9 >/dev/null; printf '\\n# tampered\\n' >> \"\$BIN/mosdns\"|摘要|内容" \
-; do
-  IFS='|' read -r tag setup kw1 kw2 <<<"$cell"
-  mkrepo "$WORK/repo" >/dev/null 2>&1
-  h0="$(HEAD_OF)"
-  r=$(run "$setup"); rc="${r%%|*}"; out="${r#*|}"
-  echo "── $tag ──"
-  [[ "$rc" != 0 ]] && ok "$tag: rc 非 0(实得 $rc)" || bad "$tag: 竟然 rc=0"
-  grep -q 'mosdns' <<<"$out" && ok "$tag: 具名指出是 mosdns 的问题" || bad "$tag: 没说是 mosdns: $(tail -2 <<<"$out")"
-  # 关键词必须出现在**提到 mosdns 的那一行**上。否则 "校验新版本…" 里的「版本」二字
-  # 就能让 ③ 假绿 —— 那句话跟 mosdns 毫无关系(第一版就是这么绿的)。
-  grep 'mosdns' <<<"$out" | grep -qE "$kw1|$kw2" && ok "$tag: 说清了是哪一类不合法" \
-    || bad "$tag: 原因不具名(期望 mosdns 那一行含 $kw1/$kw2): $(tail -2 <<<"$out")"
-  grep -q '✅ 已更新' <<<"$out" && bad "$tag: 冒充已更新" || ok "$tag: 没冒充已更新"
-  nofx "$tag" "$h0"
-done
-
-echo
 echo "══ 4. 关系门优先于预检: ahead/diverged 仍由关系门拒绝 ══"
 for spec in "ahead:main:领先" "diverged:side:分叉"; do
   IFS=: read -r nm ref kw <<<"$spec"
-  mkrepo "$WORK/repo" >/dev/null 2>&1
+  mkrepo "$WORK/repo" bogus >/dev/null 2>&1
   command git -C "$WORK/repo" tag -d v2.0.0 >/dev/null 2>&1
   g "$WORK/repo" checkout -q "$ref" 2>/dev/null
   [[ "$nm" == diverged ]] && g "$WORK/repo" tag -a v2.0.0 -m x main >/dev/null 2>&1
-  rm -f "$BIN/mosdns"                       # mosdns 同时也不合法 —— 看谁先说话
+  # 仓库钉值同时也是坏的 → mosdns 预检也过不了。看谁先说话。
   : > "$WORK/side.log"; : > "$WORK/git.log"
-  out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1); rc=$?
+  out=$(bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1); rc=$?
   { [[ "$rc" != 0 ]] && grep -q "$kw" <<<"$out"; } \
     && ok "$nm: 仍由关系门先拒绝(不是被预检抢答)" \
     || bad "$nm: 关系门没有优先(rc=$rc): $(tail -2 <<<"$out")"
@@ -201,23 +231,21 @@ done
 
 echo
 echo "══ 5. dry-run 契约不变: 零副作用, 不受预检影响 ══"
-mkrepo "$WORK/repo" >/dev/null 2>&1
-sed -i "s/__SHA__/$GOOD_SHA/g" "$WORK/repo/lib/versions.sh"
-rm -f "$BIN/mosdns"                          # 故意不合法
-h0="$(HEAD_OF)"; : > "$WORK/side.log"; : > "$WORK/git.log"
-out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update --dry-run" 2>&1); rc=$?
+r=$(run bogus --dry-run); rc="${r%%|*}"; out="${r#*|}"
 grep -q '待更新提交' <<<"$out" && ok "dry-run 照旧列出待更新提交(不被预检打断)" \
   || bad "dry-run 被预检改了行为: $out"
-nofx "dry-run" "$h0"
+nofx "dry-run"
 
 echo
 echo "══ 6. 更新前合法、更新过程把它破坏 → 更新后 doctor 仍判红并回滚 ══"
 # 这条安全门不得因为加了前置预检就放松。
 echo '[{"level":"fail","check":"mosdns 二进制","detail":"内容与官方钉值不一致"}]' > "$WORK/doctor.json"
-r=$(run 'install -m755 "$GOOD" "$BIN/mosdns"'); rc="${r%%|*}"; out="${r#*|}"
+if [[ -x "$REALBIN" ]]; then
+r=$(run real); rc="${r%%|*}"; out="${r#*|}"
 [[ "$rc" != 0 ]] && ok "更新后自检判红 → rc 非 0" || bad "更新后判红却 rc=0"
 side ROLLBACK && ok "触发了既有回滚(安全门没被放松)" || bad "没回滚: $(tail -3 <<<"$out")"
 grep -q '✅ 已更新' <<<"$out" && bad "谎报成功" || ok "没谎报成功"
+fi
 echo '[{"level":"ok","check":"服务","detail":"都在"}]' > "$WORK/doctor.json"
 
 echo "────────────────────────────────────────"

--- a/tests/test-update-mosdns-preflight.sh
+++ b/tests/test-update-mosdns-preflight.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# mosdns 二进制不合法时, `pdg update` 必须在**第一次副作用之前**具名停下。
+#
+# 由来是 exact-head CI 33235374627: doctor 新增的 check_mosdns_binary 会在
+# /usr/local/bin/mosdns 缺失时判 fail, 而 cmd_update 的自检门在**更新做完之后**才跑
+# doctor —— 于是一次普通 update 先建快照、reset、装文件、跑迁移、重启服务, 走完全程,
+# 最后被自检判红, 再整个回滚。机器动了一遍又退回来, 结果只是回到起点; 而每跑一次都
+# 重复一遍。五支 E2E 就是这么红的。
+#
+# doctor 那条判据是对的(mosdns 是核心运行文件, 缺失或摘要不符是确定性故障, 不是"无结论"),
+# 该改的是**问的时机**: 更新前就问一次, 不合法就停在动手之前。
+#
+# 判据用生产共用的那一份 —— lib/versions.sh 的 pdg_mosdns_binary_ok, 与 install.sh
+# 的严格短路同一个函数。不在这里另立一套。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-mospre.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+command -v git >/dev/null 2>&1 || { echo "[SKIP] 无 git"; exit 0; }
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"
+
+sed -n '/^cmd_update(){/,/^}/p'                   "$ROOT/deploy/bot/pdg.sh" >  "$WORK/upd.sh"
+sed -n '/^_update_release_relation(){/,/^}/p'     "$ROOT/deploy/bot/pdg.sh" >> "$WORK/upd.sh"
+sed -n '/^_update_mosdns_preflight(){/,/^}/p'     "$ROOT/deploy/bot/pdg.sh" >  "$WORK/pre.sh"
+
+echo "══ 1. 预检函数存在, 且用的是生产共用判据 ══"
+if [[ -s "$WORK/pre.sh" ]]; then ok "pdg.sh 里有 _update_mosdns_preflight"; else
+  bad "pdg.sh 里没有 _update_mosdns_preflight —— 更新前没有这一问"; fi
+grep -q 'pdg_mosdns_binary_ok' "$WORK/pre.sh" 2>/dev/null \
+  && ok "预检的裁决走 pdg_mosdns_binary_ok(与 install.sh 同一份判据)" \
+  || bad "预检没走生产共用判据 —— 另立一套迟早与安装器/doctor 漂开"
+grep -q 'lib/versions.sh' "$WORK/pre.sh" 2>/dev/null \
+  && ok "钉值从 lib/versions.sh 读(单一真源)" || bad "预检没读 lib/versions.sh"
+
+echo
+echo "══ 2. 预检在**真实调用顺序**里位于第一次副作用之前 ══"
+# 只测一个孤立 helper 是不够的 —— 要证明的是它在 cmd_update 里被调用的位置。
+posn(){ grep -n "$1" "$WORK/upd.sh" 2>/dev/null | head -1 | cut -d: -f1; }
+P_PRE="$(posn '_update_mosdns_preflight')"
+P_SNAP="$(posn '更新前留快照')"
+P_RESET="$(posn 'reset --hard -q')"
+P_INST="$(posn 'pdg_install_runtime_modules')"
+P_MIG="$(posn 'bash /usr/local/bin/pdg __migrate')"
+P_SVC="$(posn 'systemctl daemon-reload')"
+if [[ -n "$P_PRE" ]]; then
+  ok "cmd_update 里调用了预检(第 $P_PRE 行)"
+  for pair in "快照:$P_SNAP" "reset:$P_RESET" "装文件:$P_INST" "迁移:$P_MIG" "服务:$P_SVC"; do
+    nm="${pair%%:*}"; ln="${pair#*:}"
+    if [[ -n "$ln" && "$P_PRE" -lt "$ln" ]]; then ok "预检在「$nm」之前($P_PRE < $ln)"
+    else bad "预检不在「$nm」之前(预检 $P_PRE, $nm $ln)"; fi
+  done
+else
+  bad "cmd_update 里根本没调用预检 —— 位置无从谈起"
+fi
+
+echo
+echo "══ 3. 四类状态 × 真跑 cmd_update ══"
+g(){ e2e_git "$1" "${@:2}"; }
+mkrepo(){                       # HEAD 落后一个 tag → 关系判定为 behind, 走真实更新
+  local r="$1"; rm -rf "$r"; mkdir -p "$r/lib"
+  command git -C "$r" init -q -b main
+  g "$r" config user.email t@t; g "$r" config user.name t; g "$r" config commit.gpgsign false
+  printf 'pdg_install_runtime_modules(){ return 0; }\n' > "$r/lib/modules.sh"
+  # 仓库自带一份 versions.sh: 预检要从它读钉值, 与 install.sh 同一个来源
+  cat > "$r/lib/versions.sh" <<'V'
+MOSDNS_VER="v9.9.9"
+declare -A PDG_SHA256=( [mosdns-bin-amd64]="__SHA__" [mosdns-bin-arm64]="__SHA__" )
+pdg_mosdns_binary_ok(){
+  local arch="${1:-}" want="${2:-${MOSDNS_VER:-}}" bin="${3:-/usr/local/bin/mosdns}" got exp
+  [[ -n "$arch" && -n "$want" && -x "$bin" ]] || return 1
+  exp="${PDG_SHA256[mosdns-bin-$arch]:-}"; [[ -n "$exp" ]] || return 1
+  got="$("$bin" version 2>/dev/null | head -1)" || return 1
+  [[ "$got" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  [[ "${BASH_REMATCH[1]}" == "${want#v}" ]] || return 1
+  got="$(sha256sum "$bin" 2>/dev/null | awk '{print $1}')"
+  [[ -n "$got" && "$got" == "$exp" ]]
+}
+V
+  echo A > "$r/f"; g "$r" add -A; g "$r" commit -qm A
+  g "$r" tag -a v1.0.0 -m v1.0.0
+  echo B > "$r/f"; g "$r" add -A; g "$r" commit -qm B
+  g "$r" tag -a v2.0.0 -m v2.0.0
+  g "$r" checkout -q -b side v1.0.0
+  echo D > "$r/f"; g "$r" add -A; g "$r" commit -qm D
+  g "$r" checkout -q v1.0.0            # HEAD = v1.0.0, 最新 tag = v2.0.0 → behind
+}
+
+# 造一个"合法 mosdns": 自报 v9.9.9 的可执行文件, 钉值就取它自己的 sha256
+BIN="$WORK/bin"; mkdir -p "$BIN"
+mkmosdns(){                      # $1=version 串; 打印文件路径
+  printf '#!/bin/sh\ncase "$1" in version) echo "mosdns %s-0-gabc";; esac\nexit 0\n' "$1" > "$BIN/mosdns"
+  chmod 755 "$BIN/mosdns"; echo "$BIN/mosdns"
+}
+# 原件另存一份: $BIN/mosdns 每一格都会被改坏或删掉, 拿它当"合法原件"的话,
+# 第二格之后就 cp 不出东西来了(第一版就是这么把 ①⑥ 两格测空的)。
+mkmosdns v9.9.9 >/dev/null
+GOOD="$WORK/mosdns.pristine"; cp "$BIN/mosdns" "$GOOD"; chmod 755 "$GOOD"
+GOOD_SHA="$(sha256sum "$GOOD" | cut -d' ' -f1)"
+
+cat > "$WORK/harness.sh" <<'EOF'
+REPO_DIR="$WORK/repo"; REPO_URL="file:///dev/null"; ENVF="$WORK/none.env"
+need_root(){ :; }
+_lock(){ :; }
+c_g(){ echo "$*"; }
+c_y(){ echo "$*"; }
+sleep(){ :; }
+_pdg_platform(){ echo android; }
+_pdg_core(){ echo mihomo; }
+_pdg_bot_cred(){ echo unset; }
+pdg_fetch_release_tags(){ return 0; }
+_update_in_sync(){ return 1; }
+dpkg(){ echo amd64; }
+git(){ printf '%s\n' "$*" >> "$WORK/git.log"; command git "$@"; }
+install(){ printf 'install %s\n' "$*" >> "$WORK/side.log"; return 0; }
+bash(){ [[ "$*" == *__migrate* ]] && { echo migrate >> "$WORK/side.log"; return 0; }; command bash "$@"; }
+_update_core_binary(){ echo core >> "$WORK/side.log"; return 0; }
+systemctl(){ printf 'systemctl %s\n' "$*" >> "$WORK/side.log"; return 0; }
+python3(){ case "$*" in *py_compile*) return 0;;
+  *doctor.py*) cat "$WORK/doctor.json";; *) command python3 "$@";; esac; }
+mihomo(){ return 0; }
+nft(){ return 0; }
+cmd_snapshot(){ echo SNAPSHOT >> "$WORK/side.log"
+  _PDG_SNAP_CREATED="$WORK/snap"; mkdir -p "$_PDG_SNAP_CREATED"; : | gzip > "$_PDG_SNAP_CREATED/snap.tar.gz"; return 0; }
+cmd_rollback(){ echo "ROLLBACK $*" >> "$WORK/side.log"; return 0; }
+EOF
+export WORK
+echo '[{"level":"ok","check":"服务","detail":"都在"}]' > "$WORK/doctor.json"
+
+run(){                          # $1=mosdns 现场造法; 打印 "rc|输出"
+  mkrepo "$WORK/repo" >/dev/null 2>&1
+  sed -i "s/__SHA__/$GOOD_SHA/g" "$WORK/repo/lib/versions.sh"
+  : > "$WORK/side.log"; : > "$WORK/git.log"
+  eval "$1"
+  local rc=0 out
+  out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1) || rc=$?
+  printf '%s\n' "$rc|$out"
+}
+side(){ grep -qF "$1" "$WORK/side.log" 2>/dev/null; }
+did_reset(){ grep -qE '(^| )reset ' "$WORK/git.log" 2>/dev/null; }
+HEAD_OF(){ command git -C "$WORK/repo" rev-parse HEAD 2>/dev/null; }
+
+nofx(){                          # 逐项零副作用
+  local tag="$1" h0="$2"
+  side SNAPSHOT   && bad "$tag: 建了快照" || ok "$tag: 快照数不变"
+  did_reset       && bad "$tag: 执行了 reset" || ok "$tag: HEAD 未被 reset"
+  [[ "$(HEAD_OF)" == "$h0" ]] && ok "$tag: git HEAD 逐字节不变" || bad "$tag: HEAD 变了"
+  side "install " && bad "$tag: 装了文件" || ok "$tag: 已装文件未被触碰"
+  side migrate    && bad "$tag: 调了 __migrate" || ok "$tag: __migrate 未调用"
+  side systemctl  && bad "$tag: 碰了 systemctl" || ok "$tag: 服务未被动过(InvocationID 不变)"
+  side ROLLBACK   && bad "$tag: 进了 rollback" || ok "$tag: rollback 计数 0"
+}
+
+# ① 合法 → 允许进入更新
+r=$(run 'install -m755 "$GOOD" "$BIN/mosdns"'); rc="${r%%|*}"; out="${r#*|}"
+did_reset && ok "① 合法 mosdns → 放行, 正常进入更新" || bad "① 合法却被挡住了: $(tail -3 <<<"$out")"
+[[ "$rc" == 0 ]] && ok "① rc=0" || bad "① rc=$rc: $(tail -3 <<<"$out")"
+
+# ②③④⑤ 四类不合法
+for cell in \
+  "② 文件不存在|rm -f \"\$BIN/mosdns\"|不存在|缺失" \
+  "③ 版本命令非零|printf '#!/bin/sh\\nexit 3\\n' > \"\$BIN/mosdns\"; chmod 755 \"\$BIN/mosdns\"|执行不了|version 命令" \
+  "④ 自报版本不符|mkmosdns v1.2.3 >/dev/null|版本|不符" \
+  "⑤ SHA256 不符|mkmosdns v9.9.9 >/dev/null; printf '\\n# tampered\\n' >> \"\$BIN/mosdns\"|摘要|内容" \
+; do
+  IFS='|' read -r tag setup kw1 kw2 <<<"$cell"
+  mkrepo "$WORK/repo" >/dev/null 2>&1
+  h0="$(HEAD_OF)"
+  r=$(run "$setup"); rc="${r%%|*}"; out="${r#*|}"
+  echo "── $tag ──"
+  [[ "$rc" != 0 ]] && ok "$tag: rc 非 0(实得 $rc)" || bad "$tag: 竟然 rc=0"
+  grep -q 'mosdns' <<<"$out" && ok "$tag: 具名指出是 mosdns 的问题" || bad "$tag: 没说是 mosdns: $(tail -2 <<<"$out")"
+  # 关键词必须出现在**提到 mosdns 的那一行**上。否则 "校验新版本…" 里的「版本」二字
+  # 就能让 ③ 假绿 —— 那句话跟 mosdns 毫无关系(第一版就是这么绿的)。
+  grep 'mosdns' <<<"$out" | grep -qE "$kw1|$kw2" && ok "$tag: 说清了是哪一类不合法" \
+    || bad "$tag: 原因不具名(期望 mosdns 那一行含 $kw1/$kw2): $(tail -2 <<<"$out")"
+  grep -q '✅ 已更新' <<<"$out" && bad "$tag: 冒充已更新" || ok "$tag: 没冒充已更新"
+  nofx "$tag" "$h0"
+done
+
+echo
+echo "══ 4. 关系门优先于预检: ahead/diverged 仍由关系门拒绝 ══"
+for spec in "ahead:main:领先" "diverged:side:分叉"; do
+  IFS=: read -r nm ref kw <<<"$spec"
+  mkrepo "$WORK/repo" >/dev/null 2>&1
+  command git -C "$WORK/repo" tag -d v2.0.0 >/dev/null 2>&1
+  g "$WORK/repo" checkout -q "$ref" 2>/dev/null
+  [[ "$nm" == diverged ]] && g "$WORK/repo" tag -a v2.0.0 -m x main >/dev/null 2>&1
+  rm -f "$BIN/mosdns"                       # mosdns 同时也不合法 —— 看谁先说话
+  : > "$WORK/side.log"; : > "$WORK/git.log"
+  out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1); rc=$?
+  { [[ "$rc" != 0 ]] && grep -q "$kw" <<<"$out"; } \
+    && ok "$nm: 仍由关系门先拒绝(不是被预检抢答)" \
+    || bad "$nm: 关系门没有优先(rc=$rc): $(tail -2 <<<"$out")"
+done
+
+echo
+echo "══ 5. dry-run 契约不变: 零副作用, 不受预检影响 ══"
+mkrepo "$WORK/repo" >/dev/null 2>&1
+sed -i "s/__SHA__/$GOOD_SHA/g" "$WORK/repo/lib/versions.sh"
+rm -f "$BIN/mosdns"                          # 故意不合法
+h0="$(HEAD_OF)"; : > "$WORK/side.log"; : > "$WORK/git.log"
+out=$(PATH="$BIN:$PATH" bash -c "source '$WORK/harness.sh'; source '$WORK/pre.sh'; source '$WORK/upd.sh'; cmd_update --dry-run" 2>&1); rc=$?
+grep -q '待更新提交' <<<"$out" && ok "dry-run 照旧列出待更新提交(不被预检打断)" \
+  || bad "dry-run 被预检改了行为: $out"
+nofx "dry-run" "$h0"
+
+echo
+echo "══ 6. 更新前合法、更新过程把它破坏 → 更新后 doctor 仍判红并回滚 ══"
+# 这条安全门不得因为加了前置预检就放松。
+echo '[{"level":"fail","check":"mosdns 二进制","detail":"内容与官方钉值不一致"}]' > "$WORK/doctor.json"
+r=$(run 'install -m755 "$GOOD" "$BIN/mosdns"'); rc="${r%%|*}"; out="${r#*|}"
+[[ "$rc" != 0 ]] && ok "更新后自检判红 → rc 非 0" || bad "更新后判红却 rc=0"
+side ROLLBACK && ok "触发了既有回滚(安全门没被放松)" || bad "没回滚: $(tail -3 <<<"$out")"
+grep -q '✅ 已更新' <<<"$out" && bad "谎报成功" || ok "没谎报成功"
+echo '[{"level":"ok","check":"服务","detail":"都在"}]' > "$WORK/doctor.json"
+
+echo "────────────────────────────────────────"
+echo "test-update-mosdns-preflight.sh: 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-update-release-relation.sh
+++ b/tests/test-update-release-relation.sh
@@ -35,6 +35,11 @@ source "$ROOT/tests/repoguard.sh"
 
 sed -n '/^cmd_update(){/,/^}/p'                 "$ROOT/deploy/bot/pdg.sh" > "$WORK/upd.sh"
 sed -n '/^_update_release_relation(){/,/^}/p'   "$ROOT/deploy/bot/pdg.sh" > "$WORK/rel.sh"
+# behind 那一路现在还要过一次 mosdns 完整性预检。判据本身另有专测
+# (test-update-mosdns-preflight.sh), 这一支只关心方向, 所以把真函数抽出来、再用一个
+# 恒真的替身盖住 —— 不抽的话是 command-not-found, 那测的既不是方向也不是完整性。
+sed -n '/^_update_mosdns_preflight(){/,/^}/p'  "$ROOT/deploy/bot/pdg.sh" >> "$WORK/rel.sh"
+printf '_update_mosdns_preflight(){ return 0; }\n' >> "$WORK/rel.sh"
 
 # ── 判据函数必须存在, 且**只有一份** ────────────────────────────────────────
 # dry-run 与正式 update 各写一份关系判断的话, 两边迟早会漂: 一边修好了另一边还在降级。

--- a/tests/test-update-release-relation.sh
+++ b/tests/test-update-release-relation.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# `pdg update` 只跟随发布 tag。以前的判据只有一条: HEAD 与最新 tag **恰好相等**就短路,
+# 否则一律 `git reset --hard <tag>`。于是当 HEAD 是最新 tag 的**后代**(机器上跑着尚未发布
+# 的提交)时, 一次普通的 `pdg update` 会把它静默退回上一个 Release —— 不提示、不确认,
+# 事后只能从 mtime 和 git reflog 里倒推出发生过什么。
+#
+# 这一支钉住四种关系各自该有的行为, 用**真 git 仓库**造拓扑(不打桩 git 的祖先判定,
+# 否则测的是桩的想法而不是 git 的想法):
+#
+#   HEAD 与最新 tag 的关系          正式 update 应有行为
+#   ─────────────────────────      ─────────────────────────────────────────
+#   完全相同                        文件同步时幂等短路(不建快照、不重启)
+#   当前落后(tag 是当前后代)        正常升级
+#   当前领先(tag 是当前祖先)        明确拒绝: 不建快照、不 reset、不重启
+#   两边分叉                        明确拒绝: 不猜方向、不 reset
+#
+# 外加: 没有 tag 沿用既有 fail-closed; 关系判不出来时非零退出且无副作用;
+#       --dry-run 在"当前领先"时必须说清会拒绝, 不许只显示一段空的 HEAD..tag。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-updrel.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+
+command -v git >/dev/null 2>&1 || { echo "[SKIP] 没有 git —— 这一支必须用真 git 判祖先关系"; exit 0; }
+
+sed -n '/^cmd_update(){/,/^}/p'                 "$ROOT/deploy/bot/pdg.sh" > "$WORK/upd.sh"
+sed -n '/^_update_release_relation(){/,/^}/p'   "$ROOT/deploy/bot/pdg.sh" > "$WORK/rel.sh"
+
+# ── 判据函数必须存在, 且**只有一份** ────────────────────────────────────────
+# dry-run 与正式 update 各写一份关系判断的话, 两边迟早会漂: 一边修好了另一边还在降级。
+if [[ -s "$WORK/rel.sh" ]]; then
+  ok "pdg.sh 里有 _update_release_relation 这个单一判据"
+else
+  bad "pdg.sh 里没有 _update_release_relation —— 关系判断没有单一事实源"
+fi
+_ndef=$(grep -c '^_update_release_relation(){' "$ROOT/deploy/bot/pdg.sh")
+[[ "$_ndef" == 1 ]] && ok "判据只定义了一次(实得 $_ndef)" || bad "判据定义了 $_ndef 次"
+_nuse=$(grep -c '_update_release_relation' "$ROOT/deploy/bot/pdg.sh")
+[[ "$_nuse" -ge 3 ]] \
+  && ok "判据被 dry-run 与正式路径共用(引用 $_nuse 处 ≥ 定义1+调用2)" \
+  || bad "判据只出现 $_nuse 处 —— dry-run 与正式 update 没有共用它"
+
+# ── 真 git 拓扑 ─────────────────────────────────────────────────────────────
+g(){ command git -C "$1" "${@:2}"; }
+mkrepo(){ # $1=目标目录 $2=是否给 C 打 v2.0.0(1/0); 造出 A(v1.0.0) → B → C 与从 A 分叉的 D
+  local r="$1" tag2="${2:-0}"
+  rm -rf "$r"; mkdir -p "$r"
+  g "$r" init -q -b main
+  g "$r" config user.email t@t; g "$r" config user.name t; g "$r" config commit.gpgsign false
+  mkdir -p "$r/lib"
+  # cmd_update 会 source 仓库里的运行模块清单; 给一份最小替身(真清单要校验源文件存在)
+  printf 'pdg_install_runtime_modules(){ return 0; }\n' > "$r/lib/modules.sh"
+  echo A > "$r/f"; g "$r" add -A; g "$r" commit -qm A
+  g "$r" tag -a v1.0.0 -m v1.0.0
+  echo B > "$r/f"; g "$r" add -A; g "$r" commit -qm B
+  echo C > "$r/f"; g "$r" add -A; g "$r" commit -qm C
+  # v2.0.0 是可选的: "当前领先最新发布"这一态**必须**没有更高的 tag, 否则 HEAD 恰好落在
+  # 最新 tag 上, 测的就变成 same 而不是 ahead 了(第一版就是这么把红灯测没的)。
+  [[ "$tag2" == 1 ]] && g "$r" tag -a v2.0.0 -m v2.0.0
+  g "$r" checkout -q -b side v1.0.0
+  echo D > "$r/f"; g "$r" add -A; g "$r" commit -qm D
+  g "$r" checkout -q main
+}
+
+cat > "$WORK/harness.sh" <<'EOF'
+REPO_DIR="$WORK/repo"; REPO_URL="file:///dev/null"; ENVF="$WORK/none.env"
+need_root(){ :; }
+_lock(){ :; }
+c_g(){ echo "$*"; }
+c_y(){ echo "$*"; }
+sleep(){ :; }
+_pdg_platform(){ echo "${PLATFORM:-android}"; }
+_pdg_core(){ echo mihomo; }
+_pdg_bot_cred(){ echo "${CRED:-unset}"; }
+pdg_fetch_release_tags(){ [[ -n "${FAIL_FETCH:-}" ]] && return 1; return 0; }
+# 已装文件是否与仓库一致: 这条另有专测, 这里只当成一个可控输入。
+_update_in_sync(){ return "${INSYNC_RC:-0}"; }
+# git **不打桩** —— 祖先关系必须由真 git 判。只记录调用, 便于断言 reset 到底有没有发生。
+git(){ printf '%s\n' "$*" >> "$WORK/git.log"; command git "$@"; }
+install(){ printf 'install %s\n' "$*" >> "$WORK/side.log"; return 0; }
+bash(){ [[ "$*" == *__migrate* ]] && { echo "migrate" >> "$WORK/side.log"; return 0; }; command bash "$@"; }
+_update_core_binary(){ echo "core" >> "$WORK/side.log"; return 0; }
+systemctl(){ printf 'systemctl %s\n' "$*" >> "$WORK/side.log"; return 0; }
+python3(){ case "$*" in *py_compile*) return 0;; *doctor.py*) echo '[{"level":"ok","check":"服务","detail":"都在"}]'; return 0;; *) command python3 "$@";; esac; }
+mihomo(){ return 0; }
+nft(){ return 0; }
+cmd_snapshot(){ echo "SNAPSHOT_CALLED" >> "$WORK/side.log"
+  _PDG_SNAP_CREATED="$WORK/snap"; mkdir -p "$_PDG_SNAP_CREATED"; : | gzip > "$_PDG_SNAP_CREATED/snap.tar.gz"; return 0; }
+cmd_rollback(){ echo "ROLLBACK_CALLED $*" >> "$WORK/side.log"; return 0; }
+EOF
+export WORK
+
+# run <HEAD-ref> <额外env> [--dry-run] → "<rc>|<输出>"; 副作用记在 $WORK/side.log, git 调用记在 git.log
+run(){
+  local head="$1" tag2="$2" envs="$3"; shift 3
+  mkrepo "$WORK/repo" "$tag2" >/dev/null 2>&1
+  g "$WORK/repo" checkout -q "$head"
+  : > "$WORK/side.log"; : > "$WORK/git.log"
+  local rc=0 out
+  # shellcheck disable=SC2086
+  out=$(env $envs bash -c "source '$WORK/harness.sh'; source '$WORK/rel.sh'; source '$WORK/upd.sh'; cmd_update $*" 2>&1) || rc=$?
+  printf '%s\n' "$rc|$out"
+}
+side(){ grep -qF "$1" "$WORK/side.log" 2>/dev/null; }
+did_reset(){ grep -qE '(^| )reset ' "$WORK/git.log" 2>/dev/null; }
+
+# ── 关系判据本身: 四态 ──────────────────────────────────────────────────────
+echo "══ 1. _update_release_relation 四态 ══"
+relof(){ # $1=HEAD ref, $2=tag → 打印判据结果; 判不出来打印 "<rc=N>"
+  mkrepo "$WORK/repo" 1 >/dev/null 2>&1
+  g "$WORK/repo" checkout -q "$1"
+  local r rc=0
+  r=$(bash -c "source '$WORK/rel.sh'; _update_release_relation '$WORK/repo' '$2'") || rc=$?
+  [[ "$rc" == 0 ]] && printf '%s' "$r" || printf '<rc=%s>' "$rc"
+}
+if [[ -s "$WORK/rel.sh" ]]; then
+  r=$(relof v1.0.0 v1.0.0); [[ "$r" == same ]]     && ok "HEAD 就是 tag → same" || bad "same 判成了 '$r'"
+  r=$(relof v1.0.0 v2.0.0); [[ "$r" == behind ]]   && ok "tag 是 HEAD 的后代 → behind" || bad "behind 判成了 '$r'"
+  r=$(relof main   v1.0.0); [[ "$r" == ahead ]]    && ok "HEAD 是 tag 的后代 → ahead(未发布提交)" || bad "ahead 判成了 '$r'"
+  r=$(relof side   v2.0.0); [[ "$r" == diverged ]] && ok "两边分叉 → diverged" || bad "diverged 判成了 '$r'"
+  # 判不出关系: 目标 tag 根本不存在 → 必须非零退出, 不许退回某个默认关系
+  r=$(relof main   v9.9.9); [[ "$r" == "<rc=1>" ]] && ok "tag 解析不了 → 非零退出, 不给默认关系" || bad "tag 不存在时返回了 '$r'"
+  r=$(bash -c "source '$WORK/rel.sh'; _update_release_relation '$WORK/nosuchrepo' v1.0.0"; echo "rc=$?" ) 
+  [[ "$r" == *"rc=1"* ]] && ok "不是 git 仓库 → 非零退出" || bad "非仓库时返回了 '$r'"
+else
+  bad "判据缺失, 四态无从验证(以下正式 update 的断言仍会跑)"
+fi
+
+echo
+echo "══ 2. 正式 update: 当前领先最新发布 → 拒绝且零副作用 ══"
+r=$(run main 0 "")
+rc="${r%%|*}"; out="${r#*|}"
+[[ "$rc" != 0 ]] && ok "rc 非 0(实得 $rc)" || bad "当前领先最新发布, update 竟然 rc=0 —— 这就是静默降级"
+did_reset && bad "执行了 git reset —— 未发布提交被退回 $(grep -oE 'reset.*' "$WORK/git.log" | head -1)" || ok "没有执行 git reset"
+side SNAPSHOT_CALLED && bad "建了快照(拒绝路径不该有任何副作用)" || ok "没建快照"
+side migrate         && bad "跑了迁移" || ok "没跑迁移"
+side "install "      && bad "装了文件" || ok "没装任何文件"
+side systemctl       && bad "碰了 systemctl" || ok "没碰 systemctl"
+grep -qE '未发布|领先|拒绝' <<<"$out" && ok "说清了为什么拒绝(实得: $(grep -m1 -E '未发布|领先|拒绝' <<<"$out"))" \
+  || bad "拒绝了却没说原因: $(tail -3 <<<"$out")"
+grep -q '✅ 已更新' <<<"$out" && bad "谎报成功" || ok "没谎报成功"
+# 环境变量不得成为降级后门: PDG_UPDATE_FORCE 是"强制重装同一版本", 不是"允许降级"
+r=$(run main 0 "PDG_UPDATE_FORCE=1"); rc="${r%%|*}"
+[[ "$rc" != 0 ]] && ok "PDG_UPDATE_FORCE=1 也拒绝(它不是降级开关)" || bad "PDG_UPDATE_FORCE 成了降级后门"
+did_reset && bad "PDG_UPDATE_FORCE 下执行了 reset" || ok "PDG_UPDATE_FORCE 下也没 reset"
+
+echo
+echo "══ 3. 正式 update: 两边分叉 → 拒绝, 不猜方向 ══"
+r=$(run side 1 ""); rc="${r%%|*}"; out="${r#*|}"
+[[ "$rc" != 0 ]] && ok "rc 非 0(实得 $rc)" || bad "分叉时 update rc=0"
+did_reset && bad "分叉时执行了 git reset" || ok "分叉时没 reset"
+side SNAPSHOT_CALLED && bad "分叉时建了快照" || ok "分叉时没建快照"
+grep -qE '分叉|拒绝' <<<"$out" && ok "说清了是分叉" || bad "分叉没说清: $(tail -3 <<<"$out")"
+
+echo
+echo "══ 4. 正式 update: 当前落后 → 正常升级 ══"
+r=$(run v1.0.0 1 ""); rc="${r%%|*}"; out="${r#*|}"
+did_reset && ok "落后时照常 reset 到发布 tag" || bad "落后时没有升级 —— 判据把正常升级也挡了"
+[[ "$rc" == 0 ]] && ok "落后时 rc=0" || bad "落后时 rc=$rc: $(tail -3 <<<"$out")"
+
+echo
+echo "══ 5. 正式 update: HEAD 就是最新发布 → 幂等短路 ══"
+r=$(run v1.0.0 0 "INSYNC_RC=0"); rc="${r%%|*}"; out="${r#*|}"
+[[ "$rc" == 0 ]] && ok "相同时 rc=0" || bad "相同时 rc=$rc"
+side SNAPSHOT_CALLED && bad "相同且已同步却建了快照" || ok "相同且已同步: 未建快照"
+grep -q '已是最新发布' <<<"$out" && ok "明说已是最新" || bad "没说已是最新: $(tail -3 <<<"$out")"
+
+echo
+echo "══ 6. 没有发布 tag → 沿用既有 fail-closed ══"
+mkrepo "$WORK/repo" 1 >/dev/null 2>&1
+g "$WORK/repo" tag -d v1.0.0 >/dev/null; g "$WORK/repo" tag -d v2.0.0 >/dev/null
+: > "$WORK/side.log"; : > "$WORK/git.log"
+out=$(bash -c "source '$WORK/harness.sh'; source '$WORK/rel.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1); rc=$?
+[[ "$rc" != 0 ]] && ok "无 tag → rc 非 0" || bad "无 tag 却 rc=0"
+grep -qE '没有发布 tag|没有任何发布 tag|无法确定目标版本' <<<"$out" \
+  && ok "无 tag 的措辞未变(e2e-update.sh 据此判)" || bad "无 tag 措辞变了: $(tail -3 <<<"$out")"
+did_reset && bad "无 tag 却 reset 了" || ok "无 tag 没 reset"
+
+echo
+echo "══ 7. --dry-run 在「当前领先」时必须说清会拒绝 ══"
+r=$(run main 0 "" --dry-run); rc="${r%%|*}"; out="${r#*|}"
+grep -qE '未发布|领先' <<<"$out" && ok "dry-run 说清当前是未发布提交" \
+  || bad "dry-run 没说当前领先: $out"
+grep -qE '拒绝|不会自动降级|不会降级' <<<"$out" && ok "dry-run 说清正式 update 会拒绝、不会自动降级" \
+  || bad "dry-run 没说会拒绝: $out"
+# 旧文案的病灶: 打印一段空的 "待更新提交(HEAD..tag):" 然后什么都不列 → 看着像"已是最新"
+if grep -q 'HEAD\.\.' <<<"$out"; then
+  bad "dry-run 仍在显示空的 HEAD..tag 区间 —— 会被读成「无需更新」"
+else
+  ok "dry-run 不再显示那段会被误读的空 HEAD..tag"
+fi
+side SNAPSHOT_CALLED && bad "dry-run 建了快照" || ok "dry-run 零副作用: 没建快照"
+did_reset && bad "dry-run 执行了 reset" || ok "dry-run 零副作用: 没 reset"
+# dry-run 在正常「落后」时仍要列出待更新提交
+r=$(run v1.0.0 1 "" --dry-run); out="${r#*|}"
+grep -q 'B' <<<"$out" && ok "dry-run 落后时照旧列出待更新提交" || bad "dry-run 落后时不列提交了: $out"
+
+echo "────────────────────────────────────────"
+echo "test-update-release-relation.sh: 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-update-release-relation.sh
+++ b/tests/test-update-release-relation.sh
@@ -27,6 +27,11 @@ ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
 bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
 
 command -v git >/dev/null 2>&1 || { echo "[SKIP] 没有 git —— 这一支必须用真 git 判祖先关系"; exit 0; }
+# 会动 ref/config 的 git 一律走 e2e_git: 它把守卫和动作绑成一件事, 于是不存在"忘了守"
+# 这种形态。由来是一次真事故 —— 裸 git 打在了本仓库上, 56 个 tag 与全部 remote-tracking
+# 一起没了。这一支要造四种 git 拓扑, 正是最该走它的用例。
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"
 
 sed -n '/^cmd_update(){/,/^}/p'                 "$ROOT/deploy/bot/pdg.sh" > "$WORK/upd.sh"
 sed -n '/^_update_release_relation(){/,/^}/p'   "$ROOT/deploy/bot/pdg.sh" > "$WORK/rel.sh"
@@ -46,11 +51,13 @@ _nuse=$(grep -c '_update_release_relation' "$ROOT/deploy/bot/pdg.sh")
   || bad "判据只出现 $_nuse 处 —— dry-run 与正式 update 没有共用它"
 
 # ── 真 git 拓扑 ─────────────────────────────────────────────────────────────
-g(){ command git -C "$1" "${@:2}"; }
+g(){ e2e_git "$1" "${@:2}"; }          # 只读查询也走它: 目标始终是本轮自造的一次性仓库
 mkrepo(){ # $1=目标目录 $2=是否给 C 打 v2.0.0(1/0); 造出 A(v1.0.0) → B → C 与从 A 分叉的 D
   local r="$1" tag2="${2:-0}"
   rm -rf "$r"; mkdir -p "$r"
-  g "$r" init -q -b main
+  # init 时目标还不是仓库, e2e_guard_repo 必然拒 —— 这一处只能裸调, 但它建的是本轮自己
+  # 刚 mkdir 出来的空目录, 且 $WORK 由 mktemp 生成。init 之后所有操作都走 e2e_git。
+  command git -C "$r" init -q -b main
   g "$r" config user.email t@t; g "$r" config user.name t; g "$r" config commit.gpgsign false
   mkdir -p "$r/lib"
   # cmd_update 会 source 仓库里的运行模块清单; 给一份最小替身(真清单要校验源文件存在)
@@ -136,7 +143,7 @@ echo "══ 2. 正式 update: 当前领先最新发布 → 拒绝且零副作�
 r=$(run main 0 "")
 rc="${r%%|*}"; out="${r#*|}"
 [[ "$rc" != 0 ]] && ok "rc 非 0(实得 $rc)" || bad "当前领先最新发布, update 竟然 rc=0 —— 这就是静默降级"
-did_reset && bad "执行了 git reset —— 未发布提交被退回 $(grep -oE 'reset.*' "$WORK/git.log" | head -1)" || ok "没有执行 git reset"
+did_reset && bad "执行了 reset --hard —— 未发布提交被退回: $(grep -oE 'reset.*' "$WORK/git.log" | head -1)" || ok "没有执行 reset"
 side SNAPSHOT_CALLED && bad "建了快照(拒绝路径不该有任何副作用)" || ok "没建快照"
 side migrate         && bad "跑了迁移" || ok "没跑迁移"
 side "install "      && bad "装了文件" || ok "没装任何文件"
@@ -147,13 +154,13 @@ grep -q '✅ 已更新' <<<"$out" && bad "谎报成功" || ok "没谎报成功"
 # 环境变量不得成为降级后门: PDG_UPDATE_FORCE 是"强制重装同一版本", 不是"允许降级"
 r=$(run main 0 "PDG_UPDATE_FORCE=1"); rc="${r%%|*}"
 [[ "$rc" != 0 ]] && ok "PDG_UPDATE_FORCE=1 也拒绝(它不是降级开关)" || bad "PDG_UPDATE_FORCE 成了降级后门"
-did_reset && bad "PDG_UPDATE_FORCE 下执行了 reset" || ok "PDG_UPDATE_FORCE 下也没 reset"
+did_reset && bad "PDG_UPDATE_FORCE 下执行了 reset --hard" || ok "PDG_UPDATE_FORCE 下也没 reset"
 
 echo
 echo "══ 3. 正式 update: 两边分叉 → 拒绝, 不猜方向 ══"
 r=$(run side 1 ""); rc="${r%%|*}"; out="${r#*|}"
 [[ "$rc" != 0 ]] && ok "rc 非 0(实得 $rc)" || bad "分叉时 update rc=0"
-did_reset && bad "分叉时执行了 git reset" || ok "分叉时没 reset"
+did_reset && bad "分叉时执行了 reset --hard" || ok "分叉时没 reset"
 side SNAPSHOT_CALLED && bad "分叉时建了快照" || ok "分叉时没建快照"
 grep -qE '分叉|拒绝' <<<"$out" && ok "说清了是分叉" || bad "分叉没说清: $(tail -3 <<<"$out")"
 
@@ -195,7 +202,7 @@ else
   ok "dry-run 不再显示那段会被误读的空 HEAD..tag"
 fi
 side SNAPSHOT_CALLED && bad "dry-run 建了快照" || ok "dry-run 零副作用: 没建快照"
-did_reset && bad "dry-run 执行了 reset" || ok "dry-run 零副作用: 没 reset"
+did_reset && bad "dry-run 执行了 reset --hard" || ok "dry-run 零副作用: 没 reset"
 # dry-run 在正常「落后」时仍要列出待更新提交
 r=$(run v1.0.0 1 "" --dry-run); out="${r#*|}"
 grep -q 'B' <<<"$out" && ok "dry-run 落后时照旧列出待更新提交" || bad "dry-run 落后时不列提交了: $out"


### PR DESCRIPTION
## Summary

18 笔，把「发布安全」和「mosdns 完整性」两条链补完，并把 CI 的 mosdns 取件从按 matrix 放大收敛成每 run 每架构一次。

- **`pdg update` 不再静默降级**：新增四态关系判据（same / behind / ahead / diverged），`ahead`（机器上跑着未发布提交）与 `diverged` 在动任何东西之前拒绝。
- **mosdns 不合法时更新停在第一次副作用之前**：新增前置完整性预检，挂在 `behind` 这一路上、快照与 reset 之前。
- **诊断不再把「读不到」说成「关闭」**：去广告状态改为 enabled / disabled / unknown 三态；mosdns 判据认退出码、固定执行路径、比对落盘二进制摘要。
- **CI 取件收敛**：一个 producer 取件并四层校验，经本次 workflow 的短期 artifact 分发给 29 个 consumer 实例。

> **本 PR 不是「零生产改动」。** 前 14 笔改了 4 个生产文件（`deploy/bot/pdg.sh` +286、`deploy/bot/checks.py` +88、`lib/versions.sh` +35、`install.sh` +17，合计 379 增 / 47 删）。只有**最后四笔**（`45860a3`…`bf651d7`）相对 `90257eef` 是纯 CI/测试改动。

## Root causes

| # | 缺陷 | 形态 |
|---|---|---|
| 1 | `cmd_update` 只在 HEAD **恰好等于**最新 tag 时短路，否则一律 `git reset --hard <tag>` | `reset --hard` 对方向一视同仁 → HEAD 是 tag 的后代时被当成升级执行，未发布提交被静默退回，还打印「✅ 已更新」 |
| 2 | doctor 的 mosdns 完整性判据跑在更新**做完之后** | mosdns 不在的机器会先建快照、reset、装文件、跑迁移、重启服务，走完全程再被自检判红整个回滚——动一遍又回到起点，且每次 update 重复一遍 |
| 3 | `_adblock_intent` 把「文件不存在 / 不可读 / 值非法 / 真的没启用」折成同一个空值 | 权限问题在屏幕上长得和「这台机器没开去广告」一模一样 |
| 4 | mosdns 版本判据不看退出码、拼 stdout+stderr 找版本、跟 PATH 走；钉的是下载 ZIP 而非落盘二进制 | `rc=1` + stdout 有版本 + stderr `fatal:` 被判成 ✓；内容不同但自报同版本的二进制会跳过整段安装与校验 |
| 5 | E2E 夹具用只会 `echo` 版本号的 shell 桩，或干脆不播种 mosdns | 夹具替被测代码说谎，把 2、4 藏了很久 |
| 6 | 取件步骤放在 job 层，而 `e2e` 是 matrix | 「备在 job 层」就是「每个用例一次」：21 格 = 21 次下载，全 run 28 次 |

## Product behavior changes

**更新方向**

| HEAD ↔ 最新 tag | rc | 建快照 | 允许改动 |
|---|---|---|---|
| same（且文件同步） | 0 | 否 | 幂等短路 |
| behind | 0 | 是 | 正常升级 |
| **ahead** | **1** | **否** | **无** |
| **diverged** | **1** | **否** | **无** |
| 关系判不出 | 1 | 否 | 无（fail-closed） |

`PDG_UPDATE_FORCE` 是「强制重装同一版本」，**不豁免**方向门。dry-run 不再无差别打印空的 `HEAD..tag` 区间（领先时那段是空的，读起来正好是「已是最新」），改为按关系分别说明。

**mosdns 前置预检**（只挂 `behind`，`same`/`ahead`/`diverged`/dry-run 契约不变）：文件不存在 / 不可执行 / `version` 命令非零 / 读不出版本 / 自报版本不符 / SHA256 不符 / 读不到 `lib/versions.sh` / 架构无钉值 —— 各有具名文案，返回非零，不建快照、不 reset、不装文件、不迁移、不重启。裁决只由生产共用判据 `pdg_mosdns_binary_ok` 给出。

**诊断诚实性**：去广告三态（unknown 明说「状态未知」，绝不写「未启用」；启用但规则文件缺失/不可读不显示成「0 条」）；mosdns 判据固定问 `/usr/local/bin/mosdns`（与 systemd `ExecStart` 同一文件）、要求 rc=0、只认 stdout；新增落盘二进制摘要判据；安装器短路要求版本**与**摘要同时命中。

## CI artifact topology

```
prepare-mosdns-fixture (matrix: arch=[amd64])
    └─ 29 个 consumer 实例：lint 1 · functional 1 · e2e 21 · e2e-dot 2
                            · dot-systemd-e2e 2 · e2e-rescue-lock-ios 1 · e2e-serial 1
dot-systemd  ← 第 31 个 job，本身不需要 mosdns，按设计不是 consumer
```

- **producer 是每 run 每架构一个下载入口，一次下载命令调用**。底层 HTTP 请求次数（重定向、`curl --retry 2`）从日志判定不了，记为**无结论**。
- 每个 consumer：`needs` 到 producer → `download-artifact` → `tests/install-mosdns-artifact.sh` 四层复核（自算 SHA256 / manifest 交叉 / 自报版本 / 生产判据）→ `install -m 755`。任一不符硬失败，不 SKIP，路径上没有 curl/wget/Release URL 回退。
- artifact 名 `mosdns-<版本>-<架构>-<摘要前12>`，由 `tests/mosdns-artifact-name.sh` 从 `lib/versions.sh` 现算；producer 与 consumer 调同一份。保留期 1 天，`if-no-files-found: error`。
- **`manifest.json` 是交叉证据，不是信任根**。信任根始终是仓库里的版本、架构与 SHA256——消费者先自算摘要比钉值，manifest 只做第二重交叉。
- 之前隐藏的消费者 `e2e-serial` 已成为显式 consumer：它串行跑 `e2e-install` / `e2e-update` 等，取件原先发生在夹具内部、被脚本输出捕获吞掉，job 日志上完全看不见。

## Failure and rollback semantics

- 方向门与 mosdns 预检都在**第一次副作用之前**（预检行号 < 快照 < reset < 装文件 < `__migrate` < 服务操作，测试逐对比较）。
- 更新前合法、更新过程把 mosdns 破坏时，**更新后的 doctor 仍判红并触发既有回滚**——这道安全门没有因为加了前置预检而放松。
- producer 失败时全部 consumer 因 `needs` 不会运行，workflow 整体失败；consumer 不允许绕过或自行联网补救。这种 dependency skip 与普通测试 SKIP 是两回事。

## Tests and exact-head evidence

同一个 head 上跑了两次 CI，结果逐项相同：

| run | event | attempt | jobs | steps | conclusion |
|---|---|---|---|---|---|
| `33251371490` | `workflow_dispatch` | 1 | 31/31 success | 594/594 success | success |
| `33254094346` | `pull_request`（本 PR 自动触发） | 1 | 31/31 success | 594/594 success | success |

两次 failure / skipped / cancelled 各 0。按 job 名集合、`(job, step 名)`、`(job, step 序号, step 名)` 以及每个 step 的 conclusion 四种口径逐项对照，**完全一致**，无新增、删除、跳过或结论差异。

`pull_request` run 里 producer 一次下载命令调用、29 个 consumer 实例各自 `download-artifact` + 四层复核（日志里都有同一行 `四层过`）；`releases/download/v5.3.4` 在整个 run 出现 0 次。

| 判据 | CI 结果 |
|---|---|
| `test-ci-mosdns-topology.py` | 68 / 0 |
| `test-mosdns-artifact-roundtrip.sh` | 29 / 0 |
| `test-e2e-mosdns-fixture.py` | 26 / 0 |
| `test-update-mosdns-preflight.sh` | 52 / 0 |
| `test-mosdns-binary-evidence.py` | 37 / 0 |
| `test-update-release-relation.sh` | 37 / 0 |
| `e2e-update-ahead-of-release.sh` | 18 / 0 |
| CI 覆盖守卫 | 断言 22 / 22 |
| ShellCheck（阻断）· 范围守卫 · 临时物卫生 · repo guard | 全部 success |

前一轮曾红的六支 E2E（`e2e-install` / `e2e-update` / `e2e-upgrade-from-release` / `e2e-update-preserve-userdata` / `e2e-rescue-migration-lock` 及其 iOS 变体）全部 success，六类旧失败签名（SHA 校验失败 / 读不到 mosdns / 自检发现 N 项 / 校验未通过 / mosdns FATAL / 因此触发的 rollback）逐支为 **0**。

**负控是本地手动证据，不冒充 CI 覆盖**：`release-diagnostic`（14 格 28/0）、`mosdns-preflight`（8 格 22/0）、`mosdns-artifact`（10 格 18/0）三支按仓库惯例不登记进 CI。

## Security and supply-chain boundaries

- 二进制钉值取自官方 Release：先用仓库现有 ZIP 钉值校验归档 → 通过后才解压 → 再算解压后二进制的 SHA256。顺序不可颠倒（先解压再算等于给来路未确认的文件盖章）。amd64 与 arm64 各自独立下载、独立校验、独立计算。
- **`actions/checkout@v5`、`actions/upload-artifact@v4`、`actions/download-artifact@v4` 是可移动的主版本标签，与仓库既有惯例一致，但不是不可变 commit SHA pin。** 同一标签下次可能解析到别的 commit。
- 未使用 `actions/cache`、未跨 run 复用 artifact、未把二进制提交进 Git、未烘进长期镜像。
- **PyYAML**：拓扑守卫要求真解析 workflow。本次 run 里 runner 镜像自带 PyYAML，`|| sudo apt-get install -y -q python3-yaml` 回退**未触发**（日志中 `Setting up python3-yaml` 出现 0 次）；若将来镜像不带它，那行回退就会成为一次 apt 公网依赖。
- 生产判据没有任何 `PDG_TEST_MODE`、摘要覆盖环境变量或对 CI/容器/测试路径的特判。

## Known unresolved items

1. **action 未按完整 commit SHA 钉定** —— 三个 `actions/*` 都是主版本标签，可移动。要更强的供应链保证需要单独一轮。
2. **PyYAML 的 apt 公网回退** —— 目前未触发，但镜像变更会让它变成公网依赖。
3. **未来 `MOSDNS_VER` 换版路径尚未闭合** —— 预检读**当前**仓库钉值放行，更新后 doctor 按**新**钉值判红并回滚；mosdns 没有 mihomo 那样的 `_update_core_binary` 换版路径。本 PR 未改版本号，不受影响。
4. 与本 PR 无关的既有台账项（如内网面板 LAN A/B、`pdg explain`）仍未开始。

## Production impact and deployment status

- **未部署**。两台生产机未连接，tailnet 未读取也未修改。
- 合并本身不改变任何在跑的机器；变更要经 Release + `pdg update` 才会到达生产。
- **合并前的现网注意事项**：在包含本修复的 Release 发布之前，生产机上不要跑普通 `pdg update` —— 现网那一版仍会把领先于 latest tag 的 HEAD 退回去。
