### PR TITLE
fix(core): make mihomo integrity and kernel pinning truthful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,9 @@ jobs:
       - name: "E2E 夹具必须播真 mosdns (shell 假桩被生产判据拒绝 / 真钉定二进制被接受 / 夹具不联网)"
         run: python3 tests/test-e2e-mosdns-fixture.py
 
+      - name: "E2E mihomo 夹具闭包 (复用要版本+摘要都对; 归档与解压产物双重校验; 失败保全前像)"
+        run: python3 tests/test-e2e-mihomo-fixture.py
+
       - name: "CI 取件拓扑 (官方 Release 每 run 每架构只取一次 / 消费者靠 artifact 且自己复核 / action 钉定)"
         run: |
           python3 -c 'import yaml' 2>/dev/null || sudo apt-get install -y -q python3-yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,6 +730,15 @@ jobs:
       - name: "准备钉死版 mihomo (SHA256 校验, 供需要真内核的测试共用)"
         run: bash tests/prepare-mihomo.sh
 
+      - name: "mihomo 完整性闭包 (绝对路径+退出码+自报版本+内容摘要; PATH 影子无效; 内容漂移仍可修)"
+        run: bash tests/test-mihomo-integrity.sh
+
+      - name: "mihomo doctor 四态 (版本不符/摘要不符 fail; 无从对照 warn 且明说无结论; 全中才 ok)"
+        run: python3 tests/test-mihomo-binary-evidence.py
+
+      - name: "mihomo 真实换核 (v1.19.29→钉死版; 成功/配置检查失败/起来不稳 三态; 坏件绝不落盘)"
+        run: bash tests/test-mihomo-real-swap.sh
+
       - name: "混合规则 AND 语义 (跨字段 AND/同字段 OR/不支持组合拒绝/真 mihomo -t)"
         run: python3 tests/test-rule-mixed.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,6 +746,8 @@ jobs:
       # 而 tests/test-rescue-sets.py 正是钉着"只准备一次"这条(判据按字面数出现次数,
       # 所以这段注释也不能把那条命令原样写出来)。
       # CI 上必须**严格模式** —— 缺二进制要判失败, 不许把关键校验变成绿灯跳过。
+      # 这一步**不需要 sudo**(与同 job 的 mosdns 步不同): 它装到工作区的 tests/.bin/,
+      # 不写 /usr/local/bin。容器里的 e2e 各 job 则是本来就 root、镜像里没有 sudo。
       - name: "校验并安装钉定 mihomo 到 tests/.bin (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         run: |
           set -euo pipefail
@@ -1057,7 +1059,9 @@ jobs:
       - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
         # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
-        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
+        # 这三个 job 跑在 debian:12 容器里(本来就是 root, 镜像里没有 sudo) —— 与同 job
+        # 既有的 mosdns 安装步写法保持一致, 不能照抄 lint/functional 那种宿主机上的 sudo -E。
+        run: bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "跑 ${{ matrix.script }}"
         env: { PDG_E2E_ISOLATED: "1" }
         run: bash tests/${{ matrix.script }}
@@ -1436,7 +1440,9 @@ jobs:
       - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
         # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
-        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
+        # 这三个 job 跑在 debian:12 容器里(本来就是 root, 镜像里没有 sudo) —— 与同 job
+        # 既有的 mosdns 安装步写法保持一致, 不能照抄 lint/functional 那种宿主机上的 sudo -E。
+        run: bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "跑 e2e-rescue-migration-lock.sh (iOS)"
         env:
           PDG_E2E_ISOLATED: "1"
@@ -1478,7 +1484,9 @@ jobs:
       - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
         # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
-        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
+        # 这三个 job 跑在 debian:12 容器里(本来就是 root, 镜像里没有 sudo) —— 与同 job
+        # 既有的 mosdns 安装步写法保持一致, 不能照抄 lint/functional 那种宿主机上的 sudo -E。
+        run: bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "E2E 串行 hermetic (同一容器里按原顺序连着跑, 每个都必须全绿)"
         env:
           PDG_E2E_ISOLATED: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,16 @@ jobs:
         # 目前所有 runner 都是 x86_64 → 只有 amd64 一格。将来真出现 arm64 runner 时
         # 这里加一格即可: 消费者各自按自己的架构算 artifact 名, 不会拿错。
         arch: [amd64]
-    name: "取件 mosdns (${{ matrix.arch }}, 每 run 每架构仅此一次)"
+    name: "取件 mosdns + mihomo (${{ matrix.arch }}, 每 run 每架构仅此一次)"
     steps:
       - uses: actions/checkout@v5
-      # 不把 runner 上偶然存在的 mosdns 当隐式输入: 先清干净, 这一步才真的证明了完整取件。
-      - name: "隔离 runner 上偶然存在的 mosdns"
+      # 不把 runner 上偶然存在的内核当隐式输入: 先清干净, 这一步才真的证明了完整取件。
+      - name: "隔离 runner 上偶然存在的 mosdns / mihomo"
         run: |
           set -euo pipefail
-          sudo rm -f /usr/local/bin/mosdns
+          sudo rm -f /usr/local/bin/mosdns /usr/local/bin/mihomo
           ! command -v mosdns >/dev/null 2>&1 || { echo "PATH 上仍有 mosdns: $(command -v mosdns)"; exit 1; }
+          ! command -v mihomo >/dev/null 2>&1 || { echo "PATH 上仍有 mihomo: $(command -v mihomo)"; exit 1; }
       - name: "推导 artifact 名(由 lib/versions.sh 的钉值生成)"
         id: name
         run: echo "artifact=$(bash tests/mosdns-artifact-name.sh ${{ matrix.arch }})" >> "$GITHUB_OUTPUT"
@@ -48,6 +49,11 @@ jobs:
           set -euo pipefail
           mkdir -p artifact
           PDG_TEST_MOSDNS="$PWD/artifact/mosdns" bash tests/prepare-mosdns.sh
+          # mihomo 走同一条路、同一个 artifact: E2E 的夹具需要**真钉死版**内核(shell 桩
+          # 自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确地拒掉)。
+          # 放在这个 job 里 = 每 run 每架构仍然只取一次件, 消费者一律靠 artifact。
+          PDG_TEST_BIN_DIR="$PWD/artifact-mihomo" bash tests/prepare-mihomo.sh >/dev/null
+          cp "$PWD/artifact-mihomo/mihomo" artifact/mihomo
       - name: "校验最终二进制 SHA + 生产判据 + 生成 manifest"
         shell: bash
         run: |
@@ -60,11 +66,17 @@ jobs:
           [ "$GOT" = "$WANT" ] || { echo "二进制 SHA256 不符: $GOT != $WANT"; exit 1; }
           # 生产判据 —— 与 install.sh 的严格短路、doctor 的完整性判据同一个函数
           pdg_mosdns_binary_ok "$ARCH" "$MOSDNS_VER" "$PWD/artifact/mosdns"
+          MI_WANT="${PDG_SHA256[mihomo-bin-$ARCH]}"
+          MI_GOT="$(sha256sum artifact/mihomo | awk '{print $1}')"
+          [ "$MI_GOT" = "$MI_WANT" ] || { echo "mihomo 二进制 SHA256 不符: $MI_GOT != $MI_WANT"; exit 1; }
+          pdg_mihomo_binary_ok "$ARCH" "$MIHOMO_VER" "$PWD/artifact/mihomo"
           # manifest 只记可公开的溯源事实: 无 token、无 runner 路径、无生产地址
-          printf '{"version":"%s","arch":"%s","archive_sha256":"%s","binary_sha256":"%s","source_release":"%s","producer_commit":"%s"}\n' \
+          printf '{"version":"%s","arch":"%s","archive_sha256":"%s","binary_sha256":"%s","source_release":"%s","producer_commit":"%s","mihomo_version":"%s","mihomo_archive_sha256":"%s","mihomo_binary_sha256":"%s","mihomo_source_release":"%s"}\n' \
             "$MOSDNS_VER" "$ARCH" "${PDG_SHA256[mosdns-$ARCH]}" "$GOT" \
             "https://github.com/IrineSistiana/mosdns/releases/tag/$MOSDNS_VER" \
-            "$GITHUB_SHA" > artifact/manifest.json
+            "$GITHUB_SHA" \
+            "$MIHOMO_VER" "${PDG_SHA256[mihomo-$ARCH]}" "$MI_GOT" \
+            "https://github.com/MetaCubeX/mihomo/releases/tag/$MIHOMO_VER" > artifact/manifest.json
           cat artifact/manifest.json
       - uses: actions/upload-artifact@v4
         with:
@@ -728,10 +740,17 @@ jobs:
       - name: "渲染判废默认安全 (pdgtx 缺失/损坏/旧版时 str/repr/审计均不含用户值)"
         run: python3 tests/test-render-refusal.py
 
-      # 需要真内核的测试共用这一份: 下一次、按 lib/versions.sh 的 SHA256 校验一次, 放到
-      # tests/.bin/。CI 上必须**严格模式** —— 缺二进制要判失败, 不许把关键校验变成绿灯跳过。
-      - name: "准备钉死版 mihomo (SHA256 校验, 供需要真内核的测试共用)"
-        run: bash tests/prepare-mihomo.sh
+      # 需要真内核的测试共用这一份, 放到 tests/.bin/。取件**不在这里做** —— 走与 mosdns
+      # 同一个 artifact(producer 每 run 每架构只取一次件), 这里只做四层复核后装到位。
+      # 以前这一步自己跑准备脚本, 那样全 run 就有两处取件(这里一处、producer 一处),
+      # 而 tests/test-rescue-sets.py 正是钉着"只准备一次"这条(判据按字面数出现次数,
+      # 所以这段注释也不能把那条命令原样写出来)。
+      # CI 上必须**严格模式** —— 缺二进制要判失败, 不许把关键校验变成绿灯跳过。
+      - name: "校验并安装钉定 mihomo 到 tests/.bin (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: |
+          set -euo pipefail
+          mkdir -p tests/.bin
+          bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture "" "$PWD/tests/.bin/mihomo"
 
       - name: "mihomo 完整性闭包 (绝对路径+退出码+自报版本+内容摘要; PATH 影子无效; 内容漂移仍可修)"
         run: bash tests/test-mihomo-integrity.sh
@@ -1035,6 +1054,10 @@ jobs:
       # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
       - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
+      - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
+        # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
+        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "跑 ${{ matrix.script }}"
         env: { PDG_E2E_ISOLATED: "1" }
         run: bash tests/${{ matrix.script }}
@@ -1410,6 +1433,10 @@ jobs:
       # lib/versions.sh 自己重算 SHA、重核自报版本, 最后再走一次生产判据。不合格硬失败。
       - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
+      - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
+        # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
+        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "跑 e2e-rescue-migration-lock.sh (iOS)"
         env:
           PDG_E2E_ISOLATED: "1"
@@ -1448,6 +1475,10 @@ jobs:
           path: /tmp/mosdns-fixture
       - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         run: bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
+      - name: "校验并安装钉定 mihomo (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        # 与 mosdns 同一个 artifact、同一套四层复核。E2E 夹具需要**真钉死版**内核:
+        # shell 桩自报版本对、内容不对, 会被 install.sh 的短路与 doctor 判据正确拒掉。
+        run: sudo -E bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture
       - name: "E2E 串行 hermetic (同一容器里按原顺序连着跑, 每个都必须全绿)"
         env:
           PDG_E2E_ISOLATED: "1"

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -327,11 +327,89 @@ def check_health_timer():
     return ("ok", NAME, "已排定下一次运行。")
 
 
-def check_core_version():
-    _, out, _ = _run(["mihomo", "-v"])
-    m = re.search(r"v?(\d+\.\d+\.\d+)", out or "")
-    return ("ok", "mihomo 版本", "v" + m.group(1) + " ✓(版本随项目发布更新)") if m \
-        else ("warn", "mihomo 版本", "读不到版本")
+# systemd 的 ExecStart 写的就是这个绝对路径。判据必须问**同一个文件** —— 问 PATH 上的
+# `mihomo` 只能告诉你"某个 mihomo 是什么版本", 而不是"这台网关在跑的那个是什么版本"。
+# (与 MOSDNS_BIN 同构; 这条判据以前正是缺了这一层, 见 check_core_version 的说明。)
+MIHOMO_BIN = "/usr/local/bin/mihomo"
+
+
+def check_core_version(_bin=None, _pin=None):
+    """跑着的 mihomo **自报**什么版本, 与钉死版是否精确相等。
+
+    这条判据以前是三重假绿, 三层都要说清楚:
+      · 它跑的是 PATH 上的 `mihomo`, 而 systemd 执行的是 /usr/local/bin/mihomo;
+      · 它对**任何**能解析出来的版本都返回 ok, 文案还写"版本随项目发布更新" ——
+        v0.0.1 也绿;
+      · 它吞掉退出码: 命令非零但输出里有个版本号照样绿。
+    现在: 绝对路径 + 退出码为 0 + 与 MIHOMO_VER 精确相等, 才 ok。
+
+    本条只管**自报版本**; 文件**内容**是不是官方那一份由 check_mihomo_binary 单独判 ——
+    两件事分开报, 因为"版本对但内容不对"正是最该被看见的那一种。
+    """
+    name = "mihomo 版本"
+    b = _bin or MIHOMO_BIN
+    want = _pin if _pin is not None else _pinned_mihomo_ver()
+    if not want:
+        return ("warn", name, "读不到 lib/versions.sh 里的 MIHOMO_VER —— 本项无结论")
+    if not os.path.exists(b):
+        return ("fail", name, "%s **不存在**(核心内核不在, 这台机器现在是坏的)" % b)
+    rc, out, err = _run([b, "-v"])
+    if rc != 0:
+        return ("fail", name, "%s -v **退出码非零**(rc=%s) —— 它打印出来的版本号不算数" % (b, rc))
+    m = re.search(r"v?(\d+\.\d+\.\d+)", (out or "") + (err or ""))
+    if not m:
+        return ("fail", name, "%s -v 的输出里**读不出版本号**" % b)
+    got = "v" + m.group(1)
+    if got != (want if want.startswith("v") else "v" + want):
+        return ("fail", name, "自报版本 %s 与钉死版 %s **不符** —— `sudo pdg update` 会把它换回来"
+                % (got, want))
+    return ("ok", name, "%s ✓(自报版本与钉死版一致; 文件内容另见「mihomo 二进制」)" % got)
+
+
+def _pinned_mihomo_ver():
+    m = re.search(r'^MIHOMO_VER="([^"]+)"', _versions_sh(), re.M)
+    return m.group(1) if m else ""
+
+
+def _pinned_mihomo_bin_shas():
+    """{架构: 解压后二进制的 SHA256}。架构不在这张表里 = 本项无从对照, 不是"没问题"。"""
+    return dict(re.findall(r'\[mihomo-bin-(\w+)\]="([0-9a-f]{64})"', _versions_sh()))
+
+
+def check_mihomo_binary(_bin=None, _pin=None, _arch=None):
+    """跑着的 mihomo 二进制**内容**是不是官方那一份。
+
+    与 check_mosdns_binary 同构, 理由也一样: 版本是二进制自报的字符串。安装器与换核的
+    短路条件曾经只看自报版本(而且看的是 PATH 上那个), 于是一个内容不同、自报 v1.19.30
+    的文件能让整段下载与校验被跳过 —— 而项目原先只钉了下载**归档**的哈希, 一旦跳过下载,
+    那个钉值就再也没有机会被用上。
+
+    钉值读不到 / 架构不在表里 → warn + 无结论。那不是"没问题", 是"无从对照"。
+    """
+    name = "mihomo 二进制"
+    b = _bin or MIHOMO_BIN
+    arch = _arch if _arch is not None else _host_arch()
+    shas = _pinned_mihomo_bin_shas()
+    if arch not in shas:
+        return ("warn", name, "架构 %s 不在钉值表里(已钉: %s)—— 本项无结论"
+                % (arch, "/".join(sorted(shas)) or "无"))
+    pin = _pin if _pin is not None else shas.get(arch, "")
+    if not pin:
+        return ("warn", name, "读不到 %s 的二进制钉死摘要 —— 本项无结论" % arch)
+    try:
+        h = hashlib.sha256()
+        with open(b, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        got = h.hexdigest()
+    except OSError as e:
+        return ("fail", name, "读不到 %s(%s)" % (b, e.strerror or e.errno))
+    if got == pin:
+        return ("ok", name, "内容与官方钉值一致 ✓(sha256 %s…)" % got[:12])
+    return ("fail", name,
+            "二进制**内容**与官方钉值不一致: 实得 %s…, 钉死 %s… —— "
+            "同一个版本号下内容被换过(或安装时跳过了校验)。`sudo pdg update` 会重下并修复。"
+            % (got[:12], pin[:12]))
 
 # mosdns 的钉死版本。**从 lib/versions.sh 读**, 不在这里写第二份 —— 两处手写必然漂,
 # 而漂掉的表现是这条判据报绿、实际跑的却不是钉死那版。
@@ -2540,7 +2618,7 @@ def check_deep_lan_acl():
             pass
 
 
-ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_mosdns_version, check_mosdns_binary, check_dot_arecord, check_dot_domain_sync,
+ALL = [check_platform, check_services, check_bot_credentials, check_health_timer, check_core_version, check_mihomo_binary, check_mosdns_version, check_mosdns_binary, check_dot_arecord, check_dot_domain_sync,
        check_internal_cidr, check_cidr_drift, check_nft, check_nft_input_chains, check_redirect, check_gms,
        check_tailscale_isolation, check_tailscale_residue, check_tailnet_direct_port,
        check_lan_routes, check_lan_whitelist, check_lan_proxy_routes, check_lan_cert,

--- a/deploy/bot/pdg.sh
+++ b/deploy/bot/pdg.sh
@@ -1623,7 +1623,11 @@ _update_core_binary(){
   march=$(dpkg --print-architecture 2>/dev/null); [[ "$march" == arm64 ]] || march=amd64
   tmp=$(mktemp -d)
   ver="$MIHOMO_VER"
-  pdg_mihomo_is_version "$ver" && { rm -rf "$tmp"; return 0; }   # 已是钉死版本(精确比较, 非子串)
+  # 短路判据按**内容**判(与 install.sh、doctor 同一个函数、同一份钉值)。旧判据
+  # pdg_mihomo_is_version 问的是 PATH 上的 mihomo 且只比自报版本 —— PATH 上一个自报
+  # v1.19.30 的壳, 或者把 /usr/local/bin/mihomo 内容换掉而版本串留着, 都能让整段换核
+  # 被跳过, 而日志上连"更新 mihomo 内核"这行都不会出现。
+  pdg_mihomo_binary_ok "$march" "$ver" "$bindir/mihomo" && { rm -rf "$tmp"; return 0; }
   c_g "更新 mihomo 内核 → $ver …"
   curl -fsSL "https://github.com/MetaCubeX/mihomo/releases/download/${ver}/mihomo-linux-${march}-${ver}.gz" -o "$tmp/m.gz" \
     || { c_y "  下载失败(版本与发布不一致, 不能当作已更新)"; rm -rf "$tmp"; return 1; }
@@ -1631,6 +1635,11 @@ _update_core_binary(){
     || { c_y "  SHA 校验失败 → 判为更新失败(不降级成警告后继续)"; rm -rf "$tmp"; return 1; }
   gunzip -c "$tmp/m.gz" > "$tmp/mihomo" || { c_y "  解压失败"; rm -rf "$tmp"; return 1; }
   [[ -s "$tmp/mihomo" ]] || { c_y "  解压产物为空"; rm -rf "$tmp"; return 1; }
+  chmod 755 "$tmp/mihomo" 2>/dev/null || true
+  # 落盘**之前**核解压产物。归档 SHA 过了只说明下载对了; 而换核是在一台正在服务的机器上
+  # 覆盖运行文件, 没有理由先把一个还没核过的文件放进 /usr/local/bin 再回头补票。
+  pdg_verify_sha256 "$tmp/mihomo" "${PDG_SHA256[mihomo-bin-$march]:-}" "mihomo $ver 二进制 ($march)" \
+    || { c_y "  二进制内容与钉值不符 → 拒绝换核(归档校验已过, 问题出在解压这一段)"; rm -rf "$tmp"; return 1; }
   if ! _core_swap_verify mihomo "$tmp/mihomo" "$bindir" "$ver"; then rm -rf "$tmp"; return 1; fi
   rm -rf "$tmp"
 }
@@ -1682,6 +1691,16 @@ _update_in_sync(){                      # 0 = 已装文件逐个等于仓库版�
                    "$bindir/proxy-gateway-restore-firewall.sh" || exit 1
     _pdg_same_file "$repo/deploy/bot/pdg-set-token.sh" "$bindir/pdg-set-token" || exit 1
     _pdg_same_file "$repo/deploy/bot/pdg.sh"           "$bindir/pdg"           || exit 1
+    # 内核二进制也算"已装文件"。不算的话就有这么一个现场: 仓库精确在最新 tag、工作树干净、
+    # 项目文件逐个一致, 但 /usr/local/bin/mihomo 的**内容**被换过 —— 短路照样成立,
+    # `pdg update` 直接返回 0, 而它正是这台机器上唯一的修复手段。判据用生产共用的那两个
+    # (与 install.sh、doctor 同一份钉值), 读不到 versions.sh 一律当"不同步"(fail-open,
+    # 与本函数其余部分同向: 白跑一次没有损失, 跳过修复才是灾难)。
+    # shellcheck source=lib/versions.sh
+    source "$repo/lib/versions.sh" 2>/dev/null || exit 1
+    local march; march=$(dpkg --print-architecture 2>/dev/null); [[ "$march" == arm64 ]] || march=amd64
+    pdg_mihomo_binary_ok "$march" "${MIHOMO_VER:-}" "$bindir/mihomo" || exit 1
+    pdg_mosdns_binary_ok "$march" "${MOSDNS_VER:-}" "$bindir/mosdns" || exit 1
     exit 0
   )
 }
@@ -3976,11 +3995,17 @@ _activate_mihomo_core(){
   source "$REPO_DIR/lib/units.sh"   2>/dev/null || { echo "❌ 读不到 units.sh"; return 1; }
   cp /etc/nftables.conf /etc/nftables.conf.scbak 2>/dev/null
 
-  if ! pdg_mihomo_is_version "$MIHOMO_VER"; then
+  # 这是第三个装 mihomo 的地方(前两个是 install.sh 与 _update_core_binary), 判据必须同一份:
+  # 用 PATH + 只比自报版本的老判据, 等于给"迁到 mihomo"这条路留一个后门 —— 迁过去之后
+  # 跑的可能根本不是官方那一份, 而 doctor 以前对任何能解析的版本都报绿。
+  if ! pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" /usr/local/bin/mihomo; then
     c_g "下载 mihomo $MIHOMO_VER…"; t=$(mktemp -d)
     if ! curl -fsSL "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-${march}-${MIHOMO_VER}.gz" -o "$t/m.gz" \
        || ! pdg_verify_sha256 "$t/m.gz" "${PDG_SHA256[mihomo-$march]:-}" "mihomo $MIHOMO_VER" \
        || ! gunzip -c "$t/m.gz" > "$t/mihomo"; then rm -rf "$t"; echo "❌ mihomo 下载/校验失败, 未迁移"; return 1; fi
+    # 落盘前核解压产物 —— 与 install.sh / _update_core_binary 同一道门, 同一份钉值。
+    if ! pdg_verify_sha256 "$t/mihomo" "${PDG_SHA256[mihomo-bin-$march]:-}" "mihomo $MIHOMO_VER 二进制 ($march)"; then
+      rm -rf "$t"; echo "❌ mihomo 二进制内容与钉值不符, 未迁移"; return 1; fi
     install -m755 "$t/mihomo" /usr/local/bin/mihomo; rm -rf "$t"
   fi
   install -d -m700 /etc/mihomo

--- a/install.sh
+++ b/install.sh
@@ -478,15 +478,25 @@ fi
 # mihomo 成唯一内核。旧的 sing-box 机器 `pdg update` 时由 migrate_drop_singbox 自动迁移。
 CORE=mihomo
 CORE_SVC=mihomo
-if ! pdg_mihomo_is_version "$MIHOMO_VER"; then
+# 跳过判据按**内容**判, 不是"PATH 上有个自报版本对的就算数":
+#   · 旧判据 pdg_mihomo_is_version 问的是 PATH, 而 systemd 执行的是 /usr/local/bin/mihomo
+#     —— PATH 上放个自报 v1.19.30 的壳就能让整段下载与 SHA256 校验被跳过;
+#   · 它还只比自报版本, 而版本是二进制自己打印的字符串, 换内容留版本串同样能骗过它。
+# pdg_mihomo_binary_ok 问的是**那个绝对路径**, 且版本与内容摘要都要对上(与 mosdns 同构)。
+if ! pdg_mihomo_binary_ok "$MARCH" "$MIHOMO_VER" /usr/local/bin/mihomo; then
   c_g "下载 mihomo $MIHOMO_VER ($MARCH)…"
   t=$(mktemp -d)
   curl -fsSL "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-${MARCH}-${MIHOMO_VER}.gz" -o "$t/mihomo.gz"
   pdg_verify_sha256 "$t/mihomo.gz" "${PDG_SHA256[mihomo-$MARCH]:-}" "mihomo $MIHOMO_VER ($MARCH)" \
-    || { rm -rf "$t"; die "mihomo 二进制校验未通过 → 拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)"; }
+    || { rm -rf "$t"; die "mihomo 归档校验未通过 → 拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)"; }
   gunzip -c "$t/mihomo.gz" > "$t/mihomo"
   _stash_bin /usr/local/bin/mihomo || die "备份既有 mihomo 失败 → 中止(不在无法回退的前提下覆盖二进制)。"
   install -m755 "$t/mihomo" /usr/local/bin/mihomo
+  # 落盘之后再核一次内容。归档校验通过只说明"下载对了", 解压与 install 之间还有磁盘、
+  # 还有别的进程 —— 而这个文件正是下次短路判据与 doctor 要比对的那一个(与 mosdns 同构)。
+  pdg_verify_sha256 /usr/local/bin/mihomo "${PDG_SHA256[mihomo-bin-$MARCH]:-}" \
+    "mihomo $MIHOMO_VER 二进制 ($MARCH)" \
+    || { rm -rf "$t"; die "mihomo 二进制内容与钉值不符 → 拒绝继续(归档校验已过, 问题出在解压/落盘这一段)"; }
   # shellcheck disable=SC2034  # 保留为"装成功了吗"的标记并保持 trap 前初始化;
   # 回滚已改看 BIN_TXN 事务台账(它才代表"这次碰过目标没有")。
   MIHOMO_INSTALLED=1

--- a/lib/versions.sh
+++ b/lib/versions.sh
@@ -45,6 +45,29 @@ declare -A PDG_SHA256=(
   # mihomo(流量内核): 官方 release 的 mihomo-linux-<arch>-<ver>.gz
   [mihomo-amd64]="cf06ce2c7d1421bdbda14ee4a5b6046672dc35ebf8eecd8e77504ec3c0ed9a84"
   [mihomo-arm64]="58896873736d28628f66de3677c8654fa0f180662523148e136cff4f6e890069"
+  # ── mihomo: **解压后二进制**本身的 SHA256 ─────────────────────────────────
+  # 与 mosdns 同一个道理, 而且这里的洞更大: 上面两行钉的是下载归档, 只在"真的下载了"
+  # 那条路上起作用 —— 而跳过下载的短路条件曾经是 `pdg_mihomo_is_version`, 它问的是
+  # **PATH** 上的 mihomo、而且只比**自报版本**。于是 PATH 上放一个自报 v1.19.30 的壳,
+  # 或者把 /usr/local/bin/mihomo 的内容换掉、版本串留着, 整段下载与校验都会被跳过,
+  # 而安装日志上连"下载 mihomo"这行都不会出现。落盘的那个文件本身从来没被钉过。
+  #
+  # 取值步骤(可复现, 换个人来照做应得到同一串):
+  #   1) 按**精确资产名** mihomo-linux-<arch>-v1.19.30.gz 取(同 tag 下有 20+ 个相似名:
+  #      -compatible- / -v1- / -v2- / -v3- / -go120- / -go123- 以及 .deb/.rpm/.pkg.tar.zst,
+  #      通配一下就会抓错文件);
+  #   2) 与上面的 [mihomo-<arch>] 核对归档摘要;
+  #   3) 与 GitHub Release API 的 asset digest 交叉核对(见下方说明);
+  #   4) 归档确认无误后才 gunzip;
+  #   5) sha256sum 解压产物;
+  #   6) 本机架构真跑一次 `-v` 核对自报版本, 另一架构核对完整 ELF 头。
+  # 版本 v1.19.30; 两个架构各自独立下载、独立校验、独立计算。
+  #
+  # 关于 asset digest: 上游**没有**独立签名校验文件。GitHub 在 Release API 里给出
+  # 服务器侧计算的 sha256 asset digest —— 它是一条**额外的交叉证据**, 与我们自己算的
+  # 摘要相互印证; 它不构成独立的签名信任链(同一方既托管文件又给出摘要)。
+  [mihomo-bin-amd64]="3e92df24f5e80e86b9cf9183ceb7bb575f0bd132a9dc4081dae42e80f21076ae"
+  [mihomo-bin-arm64]="b9456718a8955364b9a77c80f74dca49ded10f071c1c6b4513a0ea68a3d87a50"
   [zashboard]="403b351d3663f5fe65db053cb2f3dc980108d8f86e8c6968d56164d3452592e1"
   # Caddy 官方 release 的 caddy_<ver>_linux_<arch>.tar.gz。
   # 上游发布的校验和文件里是 **SHA-512**, 本项目统一用 SHA-256, 所以这两个值是
@@ -72,6 +95,32 @@ pdg_mihomo_is_version(){
   local want="${1#v}" got
   got="$(pdg_mihomo_version)"; got="${got#v}"
   [[ -n "$got" && "$got" == "$want" ]]
+}
+
+# pdg_mihomo_binary_ok <架构> [期望版本] [二进制路径]
+#   → 0 **仅当**四件事同时成立: 架构有钉值、文件存在且可执行、`-v` 退出码为 0 且自报版本
+#     精确相等、该文件的 SHA256 等于该架构的二进制钉值。任何一步存疑一律非 0。
+#
+# 为什么不能用 pdg_mihomo_is_version 当短路判据(它是本项目最久的一处假绿):
+#   · 它问的是 **PATH** 上的 mihomo, 而 systemd 的 ExecStart 写的是 /usr/local/bin/mihomo。
+#     PATH 上放一个自报正确版本的壳, 判据就答"已是钉死版" —— 而真正在跑的那个文件
+#     可以是缺失、旧版, 或者内容被换过;
+#   · 它只比**自报版本**, 而版本是二进制自己打印的字符串。
+# 所以这里问的是**显式路径**(默认就是 systemd 执行的那个), 并且版本与内容都要核。
+#
+# 退出码单独取, 不经管道: `$(cmd | head -1)` 的退出码是 head 的, mihomo 自己非零会被吞掉
+# —— 那正是"命令返回非零但输出里有正确版本号"这一格要挡的形态。
+pdg_mihomo_binary_ok(){
+  local arch="${1:-}" want="${2:-${MIHOMO_VER:-}}" bin="${3:-/usr/local/bin/mihomo}" out got exp
+  [[ -n "$arch" && -n "$want" && -x "$bin" ]] || return 1
+  exp="${PDG_SHA256[mihomo-bin-$arch]:-}"
+  [[ -n "$exp" ]] || return 1
+  out="$("$bin" -v 2>/dev/null)" || return 1        # 退出码必须是 0
+  out="${out%%$'\n'*}"
+  [[ "$out" =~ v?([0-9]+\.[0-9]+\.[0-9]+) ]] || return 1
+  [[ "${BASH_REMATCH[1]}" == "${want#v}" ]] || return 1
+  got="$(sha256sum "$bin" 2>/dev/null | awk '{print $1}')"
+  [[ -n "$got" && "$got" == "$exp" ]]
 }
 
 # mosdns 同理。装机曾用 `command -v mosdns` 判定 —— PATH 上有任何一个 mosdns(第三方装的、

--- a/tests/e2e-install.sh
+++ b/tests/e2e-install.sh
@@ -42,8 +42,14 @@ done
 # 以前这里写的是只会 echo 版本号的 shell 桩: 旧短路只比自报版本所以够用; 现在短路还要比
 # 内容摘要, 桩必然不符 → 进入下载分支 → 撞上下面那个假 curl → 整次装机 die。
 e2e_seed_mosdns_bin || { echo "[FAIL] 播种钉定 mosdns 失败"; exit 1; }
-# 内核二进制: 装机会下载并校验 SHA, 这里用桩替代下载(下载与 SHA 校验有专门单测)
+# 内核二进制: 与 mosdns 同一处置 —— 播真钉死版, 让安装器走"已有合法二进制 → 严格短路"。
 . "$E2E_ROOT/lib/versions.sh"
+# ⚠️ 次序要紧: 真内核播种必须排在装**假 curl** 之前。假 curl 对 *.gz 一律写字面量
+# 'stub'(sha256 = 725c546b990dd1b4…), 播种若排在它后面、又恰好需要取件, 拿到的就是它。
+# 播真钉死版, 不用 shell 桩: 桩自报版本是对的、内容是错的, 而 install.sh 的短路与
+# doctor 的完整性判据现在都看内容(CI 33353591548 的五支红灯就是这么来的)。
+e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }
+
 cat > /usr/local/bin/curl <<S
 #!/bin/sh
 # 只拦内核/规则下载: 造出一个"看起来对"的产物; 其余照常失败即可
@@ -58,14 +64,7 @@ esac
 exit 0
 S
 chmod 755 /usr/local/bin/curl
-if ! command -v mihomo >/dev/null 2>&1; then
-cat > /usr/local/bin/mihomo <<S
-#!/bin/sh
-case "\$1" in -v|version) echo "Mihomo Meta $MIHOMO_VER linux amd64";; -t) exit 0;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mihomo
-fi
+
 # tcpdump 桩: 让 detect-internal-range.sh 解析出一个确定的内网卡段(交互用例的 CIDR 探测)
 cat > /usr/local/bin/tcpdump <<'S'
 #!/bin/sh

--- a/tests/e2e-lib.sh
+++ b/tests/e2e-lib.sh
@@ -845,6 +845,48 @@ e2e_mihomo_is_real(){
   [[ "$rc_good" == 0 && "$rc_bad" != 0 ]]
 }
 
+# 播种**真实钉定**的 mihomo 二进制, 并用生产判据复核 —— 与 e2e_seed_mosdns_bin 同构。
+#
+# 为什么不能用 shell 桩: 一台"装好的网关"按定义就有这个文件, 而 install.sh 的短路与 doctor
+# 的完整性判据现在都要求它的 SHA256 等于 lib/versions.sh 的钉值。只会 echo 版本号的桩
+# 自报版本是对的、内容是错的 —— 正是这两条判据要抓的形态。
+# exact-head CI 33353591548 的五支红灯就是这么来的: 用例各自内联一个 shell 桩, 判据把它
+# 拒了之后 install.sh 真的去下载, 撞上同一个用例自己装的**假 curl**(对 *.gz 写字面量
+# 'stub', sha256 恰好是 725c546b990dd1b4…)。
+#
+# 取件顺序: 已经就位 → 直接用, 零网络; 否则从**显式路径**复制(CI 由 job 的
+# install-mihomo-artifact.sh 步骤按 artifact 装好, 每 run 只取一次件); 都没有才退到
+# prepare-mihomo.sh。本函数自己**不联网** —— 经过 curl 就会在 e2e-install 里拿到假 curl 的
+# 'stub', 所以调用点也必须排在装假 curl **之前**。
+e2e_seed_mihomo_bin(){
+  local bin=/usr/local/bin/mihomo march src
+  march="$(dpkg --print-architecture 2>/dev/null)"; [[ "$march" == arm64 ]] || march=amd64
+  _e2e_mihomo_ok(){
+    # shellcheck source=/dev/null
+    ( . "$E2E_ROOT/lib/versions.sh" 2>/dev/null \
+      && pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$1" )
+  }
+  _e2e_mihomo_ok "$bin" && return 0
+  # 先验源、再装、装完再验 —— 装完才验挡不住"装了个坏的再报错"。
+  for src in "${PDG_TEST_MIHOMO:-}" "$E2E_ROOT/tests/.bin/mihomo" /opt/pdg-e2e-bin/mihomo; do
+    [[ -n "$src" && -f "$src" ]] || continue
+    _e2e_mihomo_ok "$src" || continue
+    install -m755 "$src" "$bin" 2>/dev/null || continue
+    _e2e_mihomo_ok "$bin" && return 0
+  done
+  rm -f "$bin" 2>/dev/null || true          # 桩清干净再取件
+  hash -r 2>/dev/null || true
+  bash "$E2E_ROOT/tests/prepare-mihomo.sh" >/dev/null 2>&1 || true
+  src="$E2E_ROOT/tests/.bin/mihomo"
+  if [[ -f "$src" ]] && _e2e_mihomo_ok "$src" \
+     && install -m755 "$src" "$bin" 2>/dev/null && _e2e_mihomo_ok "$bin"; then
+    return 0
+  fi
+  echo "[FAIL] 夹具拿不到钉死版 mihomo($march) —— 一台「装好的网关」按定义就有它。" >&2
+  echo "       CI 由 job 的「校验并安装钉定 mihomo」步骤备好; 本地先跑 bash tests/prepare-mihomo.sh" >&2
+  return 1
+}
+
 # 取真内核二进制并形成**钉值闭包** —— 与 e2e_seed_mosdns_bin 同一种语义。
 # $1 可选: 目标路径, 默认 /usr/local/bin/mihomo(生产调用点不传参; 传参只为让沙箱能验,
 # 与 _update_mosdns_preflight 的可选参数同一种写法, **不是**环境变量后门)。

--- a/tests/e2e-lib.sh
+++ b/tests/e2e-lib.sh
@@ -827,28 +827,87 @@ e2e_svc_heal(){ rm -f "$E2E_TMP/e2e-svc/$1.fail"; echo 1 > "$E2E_TMP/e2e-svc/$1.
 
 # PATH 上那个 mihomo 是不是**真内核**: 正反两份配置都要判对。串行跑时它很可能是上一个脚本
 # 留下的桩(`-t` 恒 0), 拿它当内核用, "配置不合法就不许重启"这类用例会静默失效。
+# 好/坏配置探针: 证明这不是"只会回显版本号"的桩。
+# $1 可选: 要探的二进制路径, 默认沿用 PATH 上的 mihomo(既有调用点靠这个语义清桩)。
+# 注意它**只**回答"是不是一个真能解析配置的内核", 不回答版本与内容 —— 那两问由
+# pdg_mihomo_binary_ok 负责。把它当成"可以复用了"的唯一判据, 正是 exact-head CI
+# 33348976467 里五支 E2E 变红的起点。
 e2e_mihomo_is_real(){
-  command -v mihomo >/dev/null 2>&1 || return 1
+  local exe="${1:-}"
+  if [[ -z "$exe" ]]; then command -v mihomo >/dev/null 2>&1 || return 1; exe=mihomo
+  else [[ -x "$exe" ]] || return 1; fi
   local d rc_good rc_bad; d="$(mktemp -d)" || return 1
   printf '{"log-level":"silent","mixed-port":17899,"proxies":[],"rules":["MATCH,DIRECT"]}\n' > "$d/good.yaml"
   printf '{"proxies":[{"name":"x","type":"definitely-not-a-real-protocol","server":"1.1.1.1","port":1}],"rules":["MATCH,DIRECT"]}\n' > "$d/bad.yaml"
-  mihomo -t -d "$d" -f "$d/good.yaml" >/dev/null 2>&1; rc_good=$?
-  mihomo -t -d "$d" -f "$d/bad.yaml"  >/dev/null 2>&1; rc_bad=$?
+  "$exe" -t -d "$d" -f "$d/good.yaml" >/dev/null 2>&1; rc_good=$?
+  "$exe" -t -d "$d" -f "$d/bad.yaml"  >/dev/null 2>&1; rc_bad=$?
   rm -rf "$d"
   [[ "$rc_good" == 0 && "$rc_bad" != 0 ]]
 }
 
-# 取真内核二进制(钉死版本); 拿不到回非 0, 调用方据此跳过
+# 取真内核二进制并形成**钉值闭包** —— 与 e2e_seed_mosdns_bin 同一种语义。
+# $1 可选: 目标路径, 默认 /usr/local/bin/mihomo(生产调用点不传参; 传参只为让沙箱能验,
+# 与 _update_mosdns_preflight 的可选参数同一种写法, **不是**环境变量后门)。
+#
+# 旧版为什么会让五支 E2E 红(exact-head CI 33348976467):
+#   · 复用判据只有 e2e_mihomo_is_real —— 它只问"能不能解析好/坏配置", 不问版本也不问内容。
+#     镜像里任何一个能跑的 mihomo 都会让它提前返回, 于是夹具里那个是"能跑但未钉"的;
+#   · 归档下下来一个字节都不核, 解压产物也不核;
+#   · `gunzip -c … > /usr/local/bin/mihomo` **直接写目标路径** —— 下载截断就在生产路径上
+#     留半个内核, 而且旧文件已经先被 rm 掉了。
+# 生产判据从"只比自报版本"收紧成"绝对路径 + 内容摘要"之后, 这个未钉的二进制被正确地拒绝,
+# 安装失败、update 被 doctor 判红回滚。夹具替被测代码说谎, 这一版把它闭上。
 e2e_fetch_mihomo(){
-  e2e_mihomo_is_real && return 0
-  rm -f /usr/local/bin/mihomo 2>/dev/null || true      # 桩要换成真的
+  local bin="${1:-/usr/local/bin/mihomo}" march tmp cand
+  march="$(dpkg --print-architecture 2>/dev/null)"; [[ "$march" == arm64 ]] || march=amd64
   # shellcheck source=/dev/null
-  . "$E2E_ROOT/lib/versions.sh"
-  curl -fsSL --retry 2 -m 120 \
-    "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-amd64-${MIHOMO_VER}.gz" \
-    -o "$E2E_TMP/m.gz" 2>/dev/null || return 1
-  gunzip -c "$E2E_TMP/m.gz" > /usr/local/bin/mihomo 2>/dev/null || return 1
-  chmod 755 /usr/local/bin/mihomo
+  . "$E2E_ROOT/lib/versions.sh" 2>/dev/null || { echo "[FAIL] 夹具读不到 lib/versions.sh" >&2; return 1; }
+
+  # ── 复用门: 版本 + 内容都对上, 再加真内核探针, 才算"已经就位" ──────────────
+  # 问的是**这个绝对路径**, 不是 PATH 上碰巧有的那个(PATH 影子不得影响判断)。
+  if pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$bin" && e2e_mihomo_is_real "$bin"; then
+    return 0                                   # 零网络请求
+  fi
+
+  tmp="$(mktemp -d)" || { echo "[FAIL] 夹具建不出临时目录" >&2; return 1; }
+  # 失败要保全前像: 旧目标在候选全部验过之前**一个字节都不动**。
+  if ! curl -fsSL --retry 2 -m 120 \
+       "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-${march}-${MIHOMO_VER}.gz" \
+       -o "$tmp/m.gz" 2>/dev/null; then
+    echo "[FAIL] 夹具下载 mihomo $MIHOMO_VER ($march) 失败(网络不通? 版本不存在?)" >&2
+    rm -rf "$tmp"; return 1
+  fi
+  if [[ ! -s "$tmp/m.gz" ]]; then
+    echo "[FAIL] 夹具下到的 mihomo 归档是空的" >&2; rm -rf "$tmp"; return 1
+  fi
+  # 解压**之前**核归档 —— 坏档不该被展开。
+  if ! pdg_verify_sha256 "$tmp/m.gz" "${PDG_SHA256[mihomo-$march]:-}" "mihomo $MIHOMO_VER 归档 ($march)" >/dev/null 2>&1; then
+    echo "[FAIL] 夹具下到的 mihomo 归档摘要与 lib/versions.sh 钉值不符 —— 拒绝解压" >&2
+    rm -rf "$tmp"; return 1
+  fi
+  cand="$tmp/mihomo"
+  if ! gunzip -c "$tmp/m.gz" > "$cand" 2>/dev/null || [[ ! -s "$cand" ]]; then
+    echo "[FAIL] 夹具解压 mihomo 失败或产物为空" >&2; rm -rf "$tmp"; return 1
+  fi
+  chmod 755 "$cand" 2>/dev/null || true
+  # 候选必须同时过: 生产判据(版本 + 解压后二进制摘要) 与 真内核探针。
+  if ! pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$cand"; then
+    echo "[FAIL] 夹具候选 mihomo 的版本或内容摘要与钉值不符 —— 拒绝安装" >&2
+    rm -rf "$tmp"; return 1
+  fi
+  if ! e2e_mihomo_is_real "$cand"; then
+    echo "[FAIL] 夹具候选 mihomo 不是真内核(分不出好/坏配置)—— 拒绝安装" >&2
+    rm -rf "$tmp"; return 1
+  fi
+  # 到这里才动目标路径。
+  if ! install -m755 "$cand" "$bin" 2>/dev/null; then
+    echo "[FAIL] 夹具安装 mihomo 到 $bin 失败" >&2; rm -rf "$tmp"; return 1
+  fi
+  rm -rf "$tmp"
+  # 落盘之后再用生产同源判据复核一次(install 与磁盘之间还有一段路)。
+  if ! pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$bin"; then
+    echo "[FAIL] 夹具装完后 $bin 的内容与钉值不符" >&2; return 1
+  fi
 }
 # 播种**真实钉定**的 mosdns 二进制, 并用生产判据复核。
 #

--- a/tests/e2e-rescue-migration-lock.sh
+++ b/tests/e2e-rescue-migration-lock.sh
@@ -92,12 +92,9 @@ mkdir -p /var/lib/privdns-gateway
 e2e_seed_cert || e2e_skip "无 openssl, 造不出占位证书"
 
 . "$E2E_ROOT/lib/versions.sh"
-cat > /usr/local/bin/mihomo <<S
-#!/bin/sh
-case "\$1" in -v|version) echo "Mihomo Meta $MIHOMO_VER linux amd64";; -t) exit 0;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mihomo
+# 播真钉死版, 不用 shell 桩: 桩自报版本是对的、内容是错的, 而 install.sh 的短路与
+# doctor 的完整性判据现在都看内容(CI 33353591548 的五支红灯就是这么来的)。
+e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }
 
 # `ip -4 -o addr show scope global` 的桩: 救援平面靠它挑监听地址候选。沙箱里没有真网卡,
 # 不桩的话"来源段内恰好一个本机地址"这条路径根本走不到, bind-auto 那格就成了空测试。

--- a/tests/e2e-update-preserve-userdata.sh
+++ b/tests/e2e-update-preserve-userdata.sh
@@ -30,12 +30,9 @@ mkdir -p /var/lib/privdns-gateway
 e2e_seed_cert || e2e_skip "无 openssl, 造不出占位证书"
 
 . "$E2E_ROOT/lib/versions.sh"
-cat > /usr/local/bin/mihomo <<S
-#!/bin/sh
-case "\$1" in -v|version) echo "Mihomo Meta $MIHOMO_VER linux amd64";; -t) exit 0;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mihomo
+# 播真钉死版, 不用 shell 桩: 桩自报版本是对的、内容是错的, 而 install.sh 的短路与
+# doctor 的完整性判据现在都看内容(CI 33353591548 的五支红灯就是这么来的)。
+e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }
 
 # ── 真发布源(本地裸仓库), 与 e2e-update.sh 同形态 ────────────────────────────
 REPO=/opt/privdns-gateway

--- a/tests/e2e-update.sh
+++ b/tests/e2e-update.sh
@@ -26,12 +26,9 @@ e2e_seed_cert || e2e_skip "无 openssl, 造不出占位证书"
 
 # 内核二进制打桩: update 里的 _update_core_binary 会比对版本, 让它认为"已是钉死版本"
 . "$E2E_ROOT/lib/versions.sh"
-cat > /usr/local/bin/mihomo <<S
-#!/bin/sh
-case "\$1" in -v|version) echo "Mihomo Meta $MIHOMO_VER linux amd64";; -t) exit 0;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mihomo
+# 播真钉死版, 不用 shell 桩: 桩自报版本是对的、内容是错的, 而 install.sh 的短路与
+# doctor 的完整性判据现在都看内容(CI 33353591548 的五支红灯就是这么来的)。
+e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }
 # 现场是"仍在跑 sing-box 的老机器"(backend=singbox + 二进制/unit 都在): 这次 update 应当
 # 由 migrate_drop_singbox 自动迁到 mihomo 并把 sing-box 运行时清掉。
 printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/sing-box; chmod 755 /usr/local/bin/sing-box

--- a/tests/e2e-upgrade-from-release.sh
+++ b/tests/e2e-upgrade-from-release.sh
@@ -52,12 +52,9 @@ mkdir -p /var/lib/privdns-gateway
 e2e_seed_cert || e2e_skip "无 openssl, 造不出占位证书"
 
 . "$E2E_ROOT/lib/versions.sh"
-cat > /usr/local/bin/mihomo <<S
-#!/bin/sh
-case "\$1" in -v|version) echo "Mihomo Meta $MIHOMO_VER linux amd64";; -t) exit 0;; esac
-exit 0
-S
-chmod 755 /usr/local/bin/mihomo
+# 播真钉死版, 不用 shell 桩: 桩自报版本是对的、内容是错的, 而 install.sh 的短路与
+# doctor 的完整性判据现在都看内容(CI 33353591548 的五支红灯就是这么来的)。
+e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }
 
 # ── 发布源: 上一个 tag 的**真代码** + 当前工作树 ──────────────────────────────
 REPO=/opt/privdns-gateway

--- a/tests/install-mihomo-artifact.sh
+++ b/tests/install-mihomo-artifact.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# 消费者侧: 把 producer 上传的 mihomo 二进制装到位, 并**自己重新验一遍**。
+# 与 install-mosdns-artifact.sh 同构 —— 同一个 artifact、同一套四层复核。
+#
+# 为什么不能信 artifact 服务端给的摘要: 那是"传输没坏"的证明, 不是"内容是官方那一份"的证明。
+# 这个脚本按当前 checkout 的 lib/versions.sh 重算 SHA256、重核自报版本, 最后再走一次生产判据
+# pdg_mihomo_binary_ok —— 与 install.sh 的严格短路、doctor 的 check_mihomo_binary 是同一个函数。
+#
+# 这里**没有任何联网动作**: 取不到或验不过就硬失败。加"下不到就 curl 一把"的回退, 等于把
+# 每 run 一次取件的约束又放开成每 job 一次。也不 SKIP —— 静默跳过会让"夹具用了真二进制"
+# 这条契约变回一句空话(exact-head CI 33353591548 的五支红灯就是夹具说谎的后果)。
+#
+# 用法: install-mihomo-artifact.sh <artifact 解包目录> [架构] [安装目标]
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+DIR="${1:?用法: install-mihomo-artifact.sh <目录> [架构] [目标]}"
+DEST="${3:-/usr/local/bin/mihomo}"
+die(){ echo "[FAIL] $*" >&2; exit 1; }
+
+# shellcheck source=lib/versions.sh
+source "$ROOT/lib/versions.sh" || die "读不到 lib/versions.sh"
+arch="${2:-}"
+if [[ -z "$arch" ]]; then
+  arch="$(dpkg --print-architecture 2>/dev/null)" || arch=""
+  [[ -n "$arch" ]] || case "$(uname -m)" in
+    x86_64) arch=amd64;; aarch64|arm64) arch=arm64;; *) die "不支持的架构 $(uname -m)";;
+  esac
+fi
+want_sha="${PDG_SHA256[mihomo-bin-$arch]:-}"
+[[ -n "$want_sha" ]] || die "lib/versions.sh 里没有 mihomo-bin-$arch 的钉值"
+
+BIN="$DIR/mihomo"
+[[ -f "$BIN" ]] || die "artifact 里没有 mihomo($BIN)"
+
+# ① 自己算摘要 —— 不认服务端摘要, 也不认 manifest 里的数字
+got_sha="$(sha256sum "$BIN" | awk '{print $1}')"
+[[ "$got_sha" == "$want_sha" ]] \
+  || die "artifact 二进制 SHA256 与 lib/versions.sh 钉值不符: 实得 ${got_sha:0:12}…, 钉死 ${want_sha:0:12}…"
+
+# ② manifest 只做交叉核对, 不能替代上面那一步。它说的和我们算的不一致 = 供应链有问题。
+MAN="$DIR/manifest.json"
+if [[ -f "$MAN" ]]; then
+  m_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("mihomo_binary_sha256",""))' "$MAN" 2>/dev/null)"
+  m_ver="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("mihomo_version",""))' "$MAN" 2>/dev/null)"
+  m_arch="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("arch",""))' "$MAN" 2>/dev/null)"
+  [[ "$m_sha"  == "$got_sha"    ]] || die "manifest 记的 mihomo 摘要与实算不符($m_sha ≠ $got_sha)"
+  [[ "$m_ver"  == "$MIHOMO_VER" ]] || die "manifest 记的 mihomo 版本与钉值不符($m_ver ≠ $MIHOMO_VER)"
+  [[ "$m_arch" == "$arch"       ]] || die "manifest 记的架构与本机不符($m_arch ≠ $arch)"
+else
+  die "artifact 里没有 manifest.json"
+fi
+
+# ③ 装到位, 再核一次自报版本
+chmod 755 "$BIN" 2>/dev/null || true
+install -m 755 "$BIN" "$DEST" || die "安装到 $DEST 失败"
+got_ver="$("$DEST" -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+[[ "v${got_ver:-}" == "$MIHOMO_VER" ]] \
+  || die "$DEST 自报版本 v${got_ver:-未知} 与钉值 $MIHOMO_VER 不符"
+
+# ④ 最后走生产判据 —— 与 install.sh 的短路、doctor 的完整性判据同一个函数
+pdg_mihomo_binary_ok "$arch" "$MIHOMO_VER" "$DEST" \
+  || die "生产判据 pdg_mihomo_binary_ok 未通过($arch $MIHOMO_VER $DEST)"
+
+echo "[OK] $DEST  $MIHOMO_VER  $arch  sha256 ${got_sha:0:12}…(自算 + manifest 交叉 + 自报版本 + 生产判据 四层过)"

--- a/tests/negctl/e2e-fixture-closure-negative-controls.py
+++ b/tests/negctl/e2e-fixture-closure-negative-controls.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""E2E 夹具闭包(e2e_git 收口 + mihomo 取件钉值闭包)的负控。
+
+由来: exact-head CI 33348976467 的六支红灯。夹具替被测代码说谎时, 上游测试是绿的 ——
+所以这里逐格改坏夹具, 要求对应的守卫/闭包测试**变红且红在该红的那条上**。
+
+本脚本会反复改写工作区里的测试文件, 只在本地手工跑, 不进 CI。
+"""
+import hashlib
+import io
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LIB = os.path.join(ROOT, "tests/e2e-lib.sh")
+INTEG = os.path.join(ROOT, "tests/test-mihomo-integrity.sh")
+
+TESTS = {
+    "guard":   (sys.executable, "tests/test-e2e-repo-guard.py"),
+    "fixture": (sys.executable, "tests/test-e2e-mihomo-fixture.py"),
+}
+
+
+def sha(p):
+    return hashlib.sha256(open(p, "rb").read()).hexdigest()
+
+
+def run(key):
+    cmd = list(TESTS[key]); cmd[1] = os.path.join(ROOT, cmd[1])
+    env = dict(os.environ)
+    env.setdefault("PDG_TEST_MIHOMO", os.path.join(ROOT, "tests/.bin/mihomo"))
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, errors="replace", env=env)
+    fails = [l for l in (r.stdout + r.stderr).splitlines() if l.startswith("[FAIL]")]
+    return r.returncode, fails
+
+
+CELLS = [
+    ("① e2e_git 改回裸 git", INTEG,
+     'e2e_git "$REPO" config user.email t@t        >/dev/null 2>&1',
+     'git -C "$REPO" config user.email t@t         >/dev/null 2>&1',
+     "guard", "没走 e2e_git"),
+
+    ("② 复用门摘掉内容摘要判据", LIB,
+     '  if pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$bin" && e2e_mihomo_is_real "$bin"; then',
+     '  if e2e_mihomo_is_real "$bin"; then',
+     "fixture", "不短路"),
+
+    ("③ 摘掉归档 SHA 校验", LIB,
+     '  if ! pdg_verify_sha256 "$tmp/m.gz" "${PDG_SHA256[mihomo-$march]:-}" "mihomo $MIHOMO_VER 归档 ($march)" >/dev/null 2>&1; then',
+     '  if false; then',
+     "fixture", "归档"),
+
+    ("④ 摘掉解压产物的生产判据", LIB,
+     '  if ! pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$cand"; then',
+     '  if false; then',
+     "fixture", "坏件绝不落盘"),
+
+    ("⑤ 复用门改回 PATH 查找", LIB,
+     '  if pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$bin" && e2e_mihomo_is_real "$bin"; then',
+     '  if e2e_mihomo_is_real; then',
+     "fixture", "PATH"),
+
+    ("⑥ 下载失败后仍继续", LIB,
+     '''       -o "$tmp/m.gz" 2>/dev/null; then
+    echo "[FAIL] 夹具下载 mihomo $MIHOMO_VER ($march) 失败(网络不通? 版本不存在?)" >&2
+    rm -rf "$tmp"; return 1
+  fi''',
+     '''       -o "$tmp/m.gz" 2>/dev/null; then
+    :
+  fi''',
+     "fixture", "点到**下载**这一层"),
+]
+
+
+def main():
+    npass = nfail = 0
+    print("══ 正控: 不改任何东西, 两支必须全绿 ══")
+    for k in TESTS:
+        rc, f = run(k)
+        if rc == 0:
+            print("[OK]   正控 %-8s 绿" % k); npass += 1
+        else:
+            print("[FAIL] 正控 %s 本来就红(%d 条)" % (k, len(f)))
+            for l in f[:4]:
+                print("       " + l)
+            nfail += 1
+    if nfail:
+        print("正控没过, 停。"); return 1
+
+    print("\n══ 负控: %d 格 ══" % len(CELLS))
+    for name, path, old, new, test, kw in CELLS:
+        src = io.open(path, encoding="utf-8").read()
+        hits = src.count(old)
+        if hits != 1:
+            print("[FAIL] [%s] 锚点命中 %d 次(期望 1)" % (name, hits)); nfail += 1; continue
+        before = sha(path)
+        io.open(path, "w", encoding="utf-8").write(src.replace(old, new))
+        try:
+            rc, fails = run(test)
+        finally:
+            io.open(path, "w", encoding="utf-8").write(src)
+        if sha(path) != before:
+            print("[FAIL] [%s] 还原后摘要对不上" % name); nfail += 1; continue
+        if rc == 0:
+            print("[FAIL] [%s] 改坏了 %s 却仍全绿 —— 那条断言没有牙齿" % (name, test)); nfail += 1; continue
+        hit = any(kw in l for l in fails)
+        print("[OK]   [%s] 锚点 1 命中 → %s 变红 %d 条%s"
+              % (name, test, len(fails), (", 且点到「%s」" % kw) if hit else (", 但没点到「%s」" % kw)))
+        npass += 1
+        if not hit:
+            print("       ⚠️ 新增具名失败前 3 条: %s" % fails[:3])
+
+    print("\n══ ⑦ 反向对照: 只加无关注释, 新增失败必须为 0 ══")
+    for path in (LIB, INTEG):
+        src = io.open(path, encoding="utf-8").read(); before = sha(path)
+        io.open(path, "a", encoding="utf-8").write(
+            "\n# 无关注释: git config git commit pdg_mihomo_binary_ok PDG_SHA256[mihomo- gunzip\n")
+        try:
+            rg, fg = run("guard"); rf, ff = run("fixture")
+        finally:
+            io.open(path, "w", encoding="utf-8").write(src)
+        okr = sha(path) == before
+        if rg == 0 and rf == 0 and okr:
+            print("[OK]   [%s] 纯注释后仍全绿, 新增失败 0, 还原摘要一致" % os.path.basename(path))
+            npass += 1
+        else:
+            print("[FAIL] [%s] guard新增%d 条 fixture新增%d 条, 还原=%s"
+                  % (os.path.basename(path), len(fg), len(ff), okr)); nfail += 1
+
+    print("\n══ 收尾: 正式树摘要 ══")
+    for p in (LIB, INTEG, os.path.join(ROOT, "tests/test-bump-kernel-tool.sh")):
+        print("  %-28s %s…" % (os.path.basename(p), sha(p)[:16]))
+    rc, _ = run("guard"); print("  还原后 guard: %s" % ("绿" if rc == 0 else "红"))
+    npass += 1 if rc == 0 else 0
+    nfail += 0 if rc == 0 else 1
+    print("─" * 44)
+    print("通过 %d, 失败 %d" % (npass, nfail))
+    return 1 if nfail else 0
+
+
+sys.exit(main())

--- a/tests/negctl/e2e-fixture-closure-negative-controls.py
+++ b/tests/negctl/e2e-fixture-closure-negative-controls.py
@@ -16,6 +16,7 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 LIB = os.path.join(ROOT, "tests/e2e-lib.sh")
 INTEG = os.path.join(ROOT, "tests/test-mihomo-integrity.sh")
+INST = os.path.join(ROOT, "tests/e2e-install.sh")
 
 TESTS = {
     "guard":   (sys.executable, "tests/test-e2e-repo-guard.py"),
@@ -71,6 +72,26 @@ CELLS = [
     :
   fi''',
      "fixture", "点到**下载**这一层"),
+    ('⑦ E2E 里重新长出 shell 桩 mihomo', INST,
+     'e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }',
+     'cat > /usr/local/bin/mihomo <<EOSTUB\n#!/bin/sh\necho stub\nEOSTUB',
+     'fixture', '内联 shell 桩'),
+
+    ('⑧ 播种跳过源文件校验', LIB,
+     '    _e2e_mihomo_ok "$src" || continue\n    install -m755 "$src" "$bin" 2>/dev/null || continue',
+     '    install -m755 "$src" "$bin" 2>/dev/null || continue',
+     'fixture', 'install **之前**'),
+
+    ('⑨ 播种改成自己 curl(绕开 artifact)', LIB,
+     '  bash "$E2E_ROOT/tests/prepare-mihomo.sh" >/dev/null 2>&1 || true',
+     '  curl -fsSL http://example.invalid/mihomo -o "$bin" 2>/dev/null || true',
+     'fixture', '不联网'),
+
+    ('⑩ e2e-install 把播种挪到假 curl 之后', INST,
+     'e2e_seed_mihomo_bin || { echo "[FAIL] 播种钉定 mihomo 失败"; exit 1; }\n\ncat > /usr/local/bin/curl <<S',
+     'cat > /usr/local/bin/curl <<S',
+     'fixture', '假 curl'),
+
 ]
 
 

--- a/tests/negctl/mihomo-integrity-negative-controls.py
+++ b/tests/negctl/mihomo-integrity-negative-controls.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""mihomo 完整性闭包 / doctor 四态 / 换核 / bump 工具 的负控。
+
+绿灯不是证据: 一支从不失败的测试和一支写对了的测试, 通过时长得一模一样。
+每格 = 精确改坏生产代码一处 → 跑指定测试 → **要求它变红且红在该红的那条上** → 还原。
+另有正控(不改任何东西全绿)与反向对照(只加注释不得凭空造出失败)。
+
+本脚本反复改写工作区里的生产文件, 只在本地手工跑, **不进 CI**。
+"""
+import hashlib
+import io
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PDG = os.path.join(ROOT, "deploy/bot/pdg.sh")
+VER = os.path.join(ROOT, "lib/versions.sh")
+CHK = os.path.join(ROOT, "deploy/bot/checks.py")
+INST = os.path.join(ROOT, "install.sh")
+TOOL = os.path.join(ROOT, "tools/bump-kernel.sh")
+
+TESTS = {
+    "integrity": ("bash", "tests/test-mihomo-integrity.sh"),
+    "doctor":    (sys.executable, "tests/test-mihomo-binary-evidence.py"),
+    "swap":      ("bash", "tests/test-mihomo-real-swap.sh"),
+    "bump":      ("bash", "tests/test-bump-kernel-tool.sh"),
+}
+
+
+def sha(p):
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+def run(key):
+    cmd = list(TESTS[key])
+    cmd[1] = os.path.join(ROOT, cmd[1])
+    env = dict(os.environ)
+    env.setdefault("PDG_TEST_MIHOMO", os.path.join(ROOT, "tests/.bin/mihomo"))
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                       errors="replace", env=env)
+    fails = [l for l in (r.stdout + r.stderr).splitlines() if l.startswith("[FAIL]")]
+    return r.returncode, fails
+
+
+# (名字, 文件, 原文, 改成, 测试, 期望红里出现的关键词)
+CELLS = [
+    ("判据退回只比自报版本", VER,
+     '  out="$("$bin" -v 2>/dev/null)" || return 1        # 退出码必须是 0',
+     '  out="$("$bin" -v 2>/dev/null || true)"',
+     "integrity", "命令非零"),
+
+    ("判据不再比对内容摘要", VER,
+     '  exp="${PDG_SHA256[mihomo-bin-$arch]:-}"',
+     '  exp=""; return 0 # ',
+     "integrity", "同版本错误摘要"),
+
+    ("install.sh 退回 PATH 判据", INST,
+     'if ! pdg_mihomo_binary_ok "$MARCH" "$MIHOMO_VER" /usr/local/bin/mihomo; then',
+     'if ! pdg_mihomo_is_version "$MIHOMO_VER"; then',
+     "integrity", "install.sh"),
+
+    ("install.sh 落盘后不再核内容", INST,
+     '  pdg_verify_sha256 /usr/local/bin/mihomo "${PDG_SHA256[mihomo-bin-$MARCH]:-}" \\\n    "mihomo $MIHOMO_VER 二进制 ($MARCH)" \\\n    || { rm -rf "$t"; die "mihomo 二进制内容与钉值不符 → 拒绝继续(归档校验已过, 问题出在解压/落盘这一段)"; }',
+     '  true',
+     "integrity", "二次核验"),
+
+    ("换核短路退回只比版本", PDG,
+     '  pdg_mihomo_binary_ok "$march" "$ver" "$bindir/mihomo" && { rm -rf "$tmp"; return 0; }',
+     '  pdg_mihomo_is_version "$ver" && { rm -rf "$tmp"; return 0; }',
+     "swap", "内容漂移"),
+
+    ("换核不再核解压产物", PDG,
+     '  pdg_verify_sha256 "$tmp/mihomo" "${PDG_SHA256[mihomo-bin-$march]:-}" "mihomo $ver 二进制 ($march)" \\\n    || { c_y "  二进制内容与钉值不符 → 拒绝换核(归档校验已过, 问题出在解压这一段)"; rm -rf "$tmp"; return 1; }',
+     '  true',
+     "swap", "二进制"),
+
+    ("顶层短路不再看内核二进制", PDG,
+     '    pdg_mihomo_binary_ok "$march" "${MIHOMO_VER:-}" "$bindir/mihomo" || exit 1',
+     '    true',
+     "integrity", "没走到换核这一步"),
+
+    ("doctor 版本判据退回「能解析就绿」", CHK,
+     '    if got != (want if want.startswith("v") else "v" + want):',
+     '    if False:',
+     "doctor", "自报旧版"),
+
+    ("doctor 不再看绝对路径", CHK,
+     '    b = _bin or MIHOMO_BIN\n    want = _pin if _pin is not None else _pinned_mihomo_ver()',
+     '    b = "mihomo"\n    want = _pin if _pin is not None else _pinned_mihomo_ver()',
+     "doctor", ""),
+
+    ("doctor 内容判据永远 ok", CHK,
+     '    shas = _pinned_mihomo_bin_shas()',
+     '    shas = _pinned_mihomo_bin_shas(); pin = _pin or "x"; _arch = _arch or "amd64"\n    return ("ok", name, "内容与官方钉值一致 ✓")  #',
+     "doctor", "内容不符"),
+
+    ("bump 工具退回逐次直写正式文件", TOOL,
+     'mv -f "$STAGE" "$VERSIONS" || die "原子替换失败 —— 正式文件未动"',
+     'cat "$STAGE" > "$VERSIONS" || die "替换失败"',
+     "bump", "原子替换"),
+
+    ("bump 工具的 SKIP_VERIFY 后门放开", TOOL,
+     'if [[ -n "${PDG_BUMP_SKIP_VERIFY:-}" && -z "$FETCH" ]]; then\n  die "PDG_BUMP_SKIP_VERIFY 只能与 PDG_BUMP_FETCHER(测试取件器)同时使用; 官方下载路径不接受跳过校验"\nfi',
+     'true',
+     "bump", "后门"),
+
+    ("bump 工具只读 e_machine", TOOL,
+     '  [[ "$magic"  == "7f454c46" ]] || { say "  不是 ELF(magic=$magic)"; return 1; }',
+     '  true',
+     "bump", "ELF 判据没覆盖"),
+
+    ("bump 工具资产名改成模糊匹配", TOOL,
+     'select(.name==\\"$name\\")',
+     'select(.name|contains(\\"linux\\"))',
+     "bump", "资产名不是精确匹配"),
+]
+
+
+def main():
+    npass = nfail = 0
+    print("══ 正控: 不改任何东西, 四支必须全绿 ══")
+    for k in TESTS:
+        rc, fails = run(k)
+        if rc == 0:
+            print("[OK]   正控 %-10s 绿" % k); npass += 1
+        else:
+            print("[FAIL] 正控 %s 本来就是红的(%d 条) —— 后面负控都不算数" % (k, len(fails)))
+            for l in fails[:5]:
+                print("       " + l)
+            nfail += 1
+    if nfail:
+        print("正控没过, 停。")
+        return 1
+
+    print("\n══ 负控: %d 格 ══" % len(CELLS))
+    for name, path, old, new, test, kw in CELLS:
+        src = io.open(path, encoding="utf-8").read()
+        hits = src.count(old)
+        if hits != 1:
+            print("[FAIL] [%s] 锚点命中 %d 次(期望 1) —— 生产代码换写法了, 负控要跟着改"
+                  % (name, hits))
+            nfail += 1
+            continue
+        before = sha(path)
+        io.open(path, "w", encoding="utf-8").write(src.replace(old, new))
+        try:
+            rc, fails = run(test)
+        finally:
+            io.open(path, "w", encoding="utf-8").write(src)
+        after = sha(path)
+        if after != before:
+            print("[FAIL] [%s] 还原后文件摘要对不上 —— 负控自己弄脏了正式树" % name)
+            nfail += 1
+            continue
+        if rc == 0:
+            print("[FAIL] [%s] 改坏了 %s 却仍然全绿 —— 那条断言没有牙齿" % (name, test))
+            nfail += 1
+            continue
+        hit = (not kw) or any(kw in l for l in fails)
+        print("[OK]   [%s] 锚点 1 命中 → %s 变红 %d 条%s"
+              % (name, test, len(fails),
+                 ("" if not kw else (", 且点到「%s」" % kw if hit else ", 但没点到「%s」" % kw))))
+        npass += 1
+        if kw and not hit:
+            print("       ⚠️ 红在别处; 新增具名失败集合前 3 条: %s" % fails[:3])
+
+    print("\n══ 反向对照: 只加注释不得凭空造出失败 ══")
+    for path in (PDG, VER, TOOL):
+        src = io.open(path, encoding="utf-8").read()
+        before = sha(path)
+        io.open(path, "a", encoding="utf-8").write(
+            "\n# 无关注释: pdg_mihomo_is_version mihomo -v sha256sum select(.name== 工作树\n")
+        try:
+            rc_i, f_i = run("integrity")
+            rc_b, f_b = run("bump")
+        finally:
+            io.open(path, "w", encoding="utf-8").write(src)
+        ok_restore = sha(path) == before
+        if rc_i == 0 and rc_b == 0 and ok_restore:
+            print("[OK]   [%s] 追加纯注释后仍全绿, 新增失败 0, 还原后摘要一致"
+                  % os.path.basename(path))
+            npass += 1
+        else:
+            print("[FAIL] [%s] 纯注释造出了失败(integrity=%d 条, bump=%d 条)或未还原(%s)"
+                  % (os.path.basename(path), len(f_i), len(f_b), ok_restore))
+            nfail += 1
+
+    print("\n══ 收尾: 正式树摘要 ══")
+    for p in (PDG, VER, CHK, INST, TOOL):
+        print("  %-22s sha256 %s…" % (os.path.basename(p), sha(p)[:16]))
+    rc, _ = run("integrity")
+    print("  还原后 integrity: %s" % ("绿" if rc == 0 else "红"))
+    npass += 1 if rc == 0 else 0
+    nfail += 0 if rc == 0 else 1
+
+    print("─" * 44)
+    print("通过 %d, 失败 %d" % (npass, nfail))
+    return 1 if nfail else 0
+
+
+sys.exit(main())

--- a/tests/test-bump-kernel-tool.sh
+++ b/tests/test-bump-kernel-tool.sh
@@ -177,6 +177,116 @@ for AWKBIN in mawk gawk; do
   fi
 done
 
+echo
+echo "══ 10. 原子性: 中途失败时正式文件逐字节不变 ══"
+# 这个脚本要改 3~6 行, 其中大多数是 64 位十六进制。逐次直写正式文件时, 中途任何一次失败
+# 都会把它停在"版本换了、第二个哈希没换"的半套状态 —— 装机会 die 在 SHA 校验上, 报错
+# 指向供应链异常, 现场根本看不出是工具写了一半。
+atom(){ rm -rf "$WORK/atom"; mkdir -p "$WORK/atom/lib"; cp "$ROOT/lib/versions.sh" "$WORK/atom/lib/versions.sh"; }
+atom
+# 制造"第二个哈希替换失败": 把 [mihomo-bin-arm64] 那一行删掉 → 该锚点命中 0 次 → 必须整体放弃
+grep -v '\[mihomo-bin-arm64\]' "$WORK/atom/lib/versions.sh" > "$WORK/atom/lib/v2" \
+  && mv "$WORK/atom/lib/v2" "$WORK/atom/lib/versions.sh"
+BEFORE="$(sha256sum "$WORK/atom/lib/versions.sh" | cut -d' ' -f1)"
+out=$( cd "$WORK" && PDG_BUMP_ROOT="$WORK/atom" PDG_BUMP_FETCHER="$WORK/fake-fetch.sh" \
+       PDG_BUMP_SKIP_VERIFY=1 bash "$TOOL" mihomo v9.9.9 2>&1 ); rc=$?
+AFTER="$(sha256sum "$WORK/atom/lib/versions.sh" | cut -d' ' -f1)"
+[[ "$rc" != 0 ]] && ok "锚点命中 0 次 → 非零退出" || bad "缺锚点却成功了(rc=$rc)"
+[[ "$BEFORE" == "$AFTER" ]] \
+  && ok "中途失败后正式文件**逐字节不变**(sha ${BEFORE:0:12}…)" \
+  || bad "正式文件被改成了半套状态 —— 这正是原子性要挡的"
+grep -qE 'MIHOMO_VER="v9\.9\.9"' "$WORK/atom/lib/versions.sh" \
+  && bad "版本号已经被写进去了(半套状态)" || ok "版本号也没被写进去(不是只回滚了哈希)"
+compgen -G "$WORK/atom/lib/versions.sh.pdg-bump.*" >/dev/null \
+  && bad "留下了暂存文件残骸" || ok "没有暂存文件残留"
+
+echo
+echo "══ 11. 暂存文件必须与目标同目录(跨文件系统 mv 不是原子的)══"
+c2="$(sed -E 's/^[[:space:]]*#.*$//' "$TOOL")"
+[[ "$(grep -c 'mktemp "${VERSIONS}' <<<"$c2" || true)" != 0 ]] \
+  && ok "暂存文件建在 \$VERSIONS 同目录" || bad "暂存文件不在目标同目录 —— mv 可能跨文件系统"
+[[ "$(grep -c 'mv -f "\$STAGE" "\$VERSIONS"' <<<"$c2" || true)" != 0 ]] \
+  && ok "用 mv 原子替换(不是 cat 覆盖)" || bad "没有用 mv 做原子替换"
+
+echo
+echo "══ 12. 目标文件已有改动时拒绝(注释与实现必须一致)══"
+atom
+printf '\n# someone else was here\n' >> "$WORK/atom/lib/versions.sh"
+( cd "$WORK/atom" && git init -q -b main && git config user.email t@t && git config user.name t \
+  && git config commit.gpgsign false && git add -A && git commit -qm base ) >/dev/null 2>&1
+printf '\n# uncommitted change\n' >> "$WORK/atom/lib/versions.sh"
+B2="$(sha256sum "$WORK/atom/lib/versions.sh" | cut -d' ' -f1)"
+out=$( cd "$WORK" && PDG_BUMP_ROOT="$WORK/atom" PDG_BUMP_FETCHER="$WORK/fake-fetch.sh" \
+       PDG_BUMP_SKIP_VERIFY=1 bash "$TOOL" mihomo v9.9.9 2>&1 ); rc=$?
+{ [[ "$rc" != 0 ]] && [[ "$(sha256sum "$WORK/atom/lib/versions.sh" | cut -d' ' -f1)" == "$B2" ]]; } \
+  && ok "目标文件有未提交改动 → 拒绝且不动它" || bad "目标文件脏时仍然改写了(rc=$rc)"
+# 注释若写"工作树必须干净", 实现却只查目标文件 —— 文案要准确
+[[ "$(grep -c '工作树必须干净' "$TOOL" || true)" == 0 ]] \
+  && ok '注释没把范围说成整个工作区(实现查的只是目标文件)' \
+  || bad "注释说工作树, 实现只查 lib/versions.sh —— 文案与实现不符"
+
+echo
+echo "══ 13. 官方 asset digest: 精确资产名 + 不一致就拒绝 ══"
+[[ "$(grep -c '_official_digest' <<<"$c2" || true)" != 0 ]] \
+  && ok "有官方 digest 交叉核对" || bad "没有 digest 交叉核对"
+[[ "$(grep -c 'select(.name==' <<<"$c2" || true)" != 0 ]] \
+  && ok "按**精确资产名**匹配(==), 不是通配" || bad "资产名不是精确匹配 —— 同 tag 下有 20+ 个相似名"
+[[ "$(grep -c 'releases/tags/\$ver' <<<"$c2" || true)" != 0 ]] \
+  && ok "按精确 tag 取" || bad "没有按精确 tag 取"
+[[ "$(grep -c '拒绝写文件' <<<"$c2" || true)" != 0 ]] \
+  && ok "digest 不一致 → 拒绝写文件" || bad "digest 不一致没有拒绝写文件"
+# 相似资产名不得命中: 用真实的 mihomo 资产名家族做判据
+for n in mihomo-linux-amd64-compatible-v1.19.30.gz mihomo-linux-amd64-v1-v1.19.30.gz \
+         mihomo-linux-amd64-v3-go123-v1.19.30.gz mihomo-linux-amd64-v1.19.30.deb; do
+  [[ "$n" == "mihomo-linux-amd64-v1.19.30.gz" ]] && bad "相似名 $n 与目标名相等?!" || :
+done
+ok "相似资产名清单(compatible/-v1-/-v3-go123-/.deb)与目标名互不相等 —— 精确匹配才不会抓错"
+# 文案: 不许把 GitHub digest 说成独立签名
+[[ "$(grep -c '不构成独立的签名信任链' "$TOOL" || true)" != 0 ]] \
+  && ok "文案说清 digest 不是独立签名信任链" || bad "文案把 digest 说成了独立信任链"
+[[ "$(grep -c '不发布独立的签名校验文件' "$TOOL" || true)" != 0 ]] \
+  && ok "文案说清上游没有独立签名校验文件" || bad "文案没交代上游无签名文件"
+
+echo
+echo "══ 14. PDG_BUMP_SKIP_VERIFY 不得成为正式取件路径的后门 ══"
+atom
+out=$( cd "$WORK" && PDG_BUMP_ROOT="$WORK/atom" PDG_BUMP_SKIP_VERIFY=1 \
+       bash "$TOOL" mihomo v9.9.9 2>&1 ); rc=$?
+{ [[ "$rc" != 0 ]] && grep -q 'PDG_BUMP_FETCHER' <<<"$out"; } \
+  && ok "官方下载路径 + SKIP_VERIFY → 明确拒绝(它只能配测试取件器)" \
+  || bad "SKIP_VERIFY 在官方路径上被接受了 —— 那是跳过全部证据的后门(rc=$rc)"
+
+echo
+echo "══ 15. 非本机架构: 完整 ELF 头, 伪造 e_machine 不够 ══"
+[[ "$(grep -c '_elf_header_ok' <<<"$c2" || true)" != 0 ]] && ok "用的是完整 ELF 头判据" || bad "还是只读 e_machine"
+for k in '7f454c46' 'EI_CLASS' 'EI_DATA'; do
+  [[ "$(grep -c "$k" "$TOOL" || true)" != 0 ]] && ok "ELF 判据覆盖 $k" || bad "ELF 判据没覆盖 $k"
+done
+# 真造一个"只把 18-19 伪造成 amd64"的非 ELF 文件, 它必须过不了
+mkdir -p "$WORK/elf"
+python3 - "$WORK/elf/fake" <<'PYX'
+import sys
+b = bytearray(b'NOT-AN-ELF-AT-ALL...' + b'\x00'*40)
+b[18:20] = b'\x3e\x00'          # 伪造 e_machine = x86-64
+open(sys.argv[1], 'wb').write(bytes(b))
+PYX
+if bash -c "source <(sed -n '/^_elf_header_ok(){/,/^}/p' '$TOOL'); say(){ :; }; _elf_header_ok '$WORK/elf/fake' amd64" 2>/dev/null; then
+  bad "伪造 e_machine 的非 ELF 文件通过了判据"
+else ok "伪造 e_machine 的非 ELF 文件被拒(magic/class 挡住了)"; fi
+
+echo
+echo "══ 16. 反向对照: 无关注释不得凭空制造失败 ══"
+# 上面多条断言扫的是**去注释后**的代码。往工具里塞一段只含关键词的注释, 断言数不该变。
+cp "$TOOL" "$WORK/tool-commented.sh"
+printf '\n# 无关注释: git commit git push sudo 工作树必须干净 select(.name== \n' >> "$WORK/tool-commented.sh"
+c3="$(sed -E 's/^[[:space:]]*#.*$//; s/[[:space:]]#[^"'"'"']*$//' "$WORK/tool-commented.sh")"
+n_extra=0
+for w in 'git commit' 'git push' 'sudo'; do
+  [[ "$(grep -c -- "$w" <<<"$c3" || true)" != 0 ]] && n_extra=$((n_extra+1))
+done
+[[ "$n_extra" == 0 ]] && ok "注释里的关键词不会被算成代码(去注释判据有效)" \
+  || bad "注释被当成代码了 —— 会造出 $n_extra 条假失败"
+
 echo "────────────────────────────────────────"
 echo "test-bump-kernel-tool.sh: 通过 $pass, 失败 $nfail"
 [[ "$nfail" == 0 ]]

--- a/tests/test-bump-kernel-tool.sh
+++ b/tests/test-bump-kernel-tool.sh
@@ -17,6 +17,9 @@ WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-bumpkernel.XXXXXX")"; trap 'rm -rf "$WORK
 pass=0; nfail=0
 ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
 bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"    # e2e_git: 守卫与动作绑成一件事(见 test-e2e-repo-guard.py)
+
 TOOL="$ROOT/tools/bump-kernel.sh"
 
 echo "══ 1. 工具存在且可执行 ══"
@@ -212,8 +215,14 @@ echo
 echo "══ 12. 目标文件已有改动时拒绝(注释与实现必须一致)══"
 atom
 printf '\n# someone else was here\n' >> "$WORK/atom/lib/versions.sh"
-( cd "$WORK/atom" && git init -q -b main && git config user.email t@t && git config user.name t \
-  && git config commit.gpgsign false && git add -A && git commit -qm base ) >/dev/null 2>&1
+# 会写 ref/config 的 git 一律走 e2e_git —— 守卫与动作绑成一件事, 不存在"忘了守"的形态。
+# (`git init` 不受限: 仓库还不存在时守卫必然假拒。)
+git init -q -b main "$WORK/atom" >/dev/null 2>&1
+e2e_git "$WORK/atom" config user.email t@t        >/dev/null 2>&1
+e2e_git "$WORK/atom" config user.name t           >/dev/null 2>&1
+e2e_git "$WORK/atom" config commit.gpgsign false  >/dev/null 2>&1
+e2e_git "$WORK/atom" add -A                       >/dev/null 2>&1
+e2e_git "$WORK/atom" commit -qm base              >/dev/null 2>&1
 printf '\n# uncommitted change\n' >> "$WORK/atom/lib/versions.sh"
 B2="$(sha256sum "$WORK/atom/lib/versions.sh" | cut -d' ' -f1)"
 out=$( cd "$WORK" && PDG_BUMP_ROOT="$WORK/atom" PDG_BUMP_FETCHER="$WORK/fake-fetch.sh" \

--- a/tests/test-e2e-mihomo-fixture.py
+++ b/tests/test-e2e-mihomo-fixture.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""E2E 夹具取 mihomo 时必须形成钉值闭包 —— 与 e2e_seed_mosdns_bin 同一种语义。
+
+由来是 exact-head CI 33348976467 的五支红灯。夹具里的 e2e_fetch_mihomo 当时是这样的:
+
+    e2e_mihomo_is_real && return 0            # 只验"能解析好配置、能拒坏配置"
+    curl … -o "$E2E_TMP/m.gz" || return 1     # 归档摘要一个字都不核
+    gunzip -c "$E2E_TMP/m.gz" > /usr/local/bin/mihomo   # 直接写目标路径
+
+于是夹具里那个 mihomo 是"能跑但未钉"的。生产判据从"只比自报版本"收紧成"绝对路径 +
+内容摘要"之后, 它被正确地拒绝 —— 安装失败、update 被 doctor 判红回滚, 五支 E2E 全红。
+夹具替被测代码说谎, 而这正是 e2e-lib.sh 里 mosdns 那段注释早就写过的形态。
+
+本测试不碰公网: curl 由桩接管, 目标路径由参数注入(生产调用点不传参, 与
+_update_mosdns_preflight 同一种写法, **不是**环境变量后门)。
+"""
+import io
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, HERE)
+import tmpguard  # noqa: E402
+
+PASS = [0]
+FAIL = [0]
+
+
+def ok(m):
+    print("[OK]   %s" % m)
+    PASS[0] += 1
+
+
+def bad(m):
+    print("[FAIL] %s" % m)
+    FAIL[0] += 1
+
+
+LIB = io.open(os.path.join(ROOT, "tests/e2e-lib.sh"), encoding="utf-8").read()
+VERSIONS = io.open(os.path.join(ROOT, "lib/versions.sh"), encoding="utf-8").read()
+import re  # noqa: E402
+PIN_VER = re.search(r'^MIHOMO_VER="([^"]+)"', VERSIONS, re.M).group(1)
+ARCH = subprocess.run(["dpkg", "--print-architecture"], capture_output=True, text=True).stdout.strip() or "amd64"
+PIN_BIN = dict(re.findall(r'\[mihomo-bin-(\w+)\]="([0-9a-f]{64})"', VERSIONS)).get(ARCH, "")
+REAL = os.environ.get("PDG_TEST_MIHOMO") or os.path.join(ROOT, "tests/.bin/mihomo")
+
+WORK = tmpguard.mkdtemp(prefix="pdg-e2emih.")
+
+
+def sh(fn):
+    """按行首锚点抽一个函数(单行函数也要正确收尾 —— sed 的 /^}/ 会吃到下一个函数)。"""
+    i = LIB.index("\n%s(){" % fn) + 1
+    line_end = LIB.index("\n", i)
+    if LIB[i:line_end].rstrip().endswith("}"):
+        return LIB[i:line_end]
+    return LIB[i:LIB.index("\n}\n", i) + 3]
+
+
+print("══ 0. 前提 ══")
+(ok if PIN_BIN else bad)("lib/versions.sh 有 [mihomo-bin-%s]" % ARCH)
+have_real = os.path.exists(REAL)
+if have_real:
+    import hashlib
+    h = hashlib.sha256(open(REAL, "rb").read()).hexdigest()
+    (ok if h == PIN_BIN else bad)("tests/.bin/mihomo 就是钉死版(内容 == 钉值)")
+else:
+    print("[SKIP] 没有钉死版 mihomo(bash tests/prepare-mihomo.sh) —— 复用/成功安装两类用例未验")
+
+FN = sh("e2e_fetch_mihomo")
+print()
+print("══ 1. 闭包结构(源码级)══")
+for name, pat, why in [
+    ("按参数注入目标路径(默认 /usr/local/bin/mihomo)", r'local\s+bin="\$\{1:-/usr/local/bin/mihomo\}"',
+     "写死路径就没法在沙箱里验, 只能靠真机"),
+    ("用生产判据 pdg_mihomo_binary_ok", r"pdg_mihomo_binary_ok", "另写一套弱判断迟早与生产漂开"),
+    ("核归档摘要 PDG_SHA256[mihomo-<arch>]", r"PDG_SHA256\[mihomo-\$", "不核归档 = 下到什么装什么"),
+    ("解压到**临时候选**而不是直接写目标", r"gunzip -c[^\n]*\$tmp", "直写目标 = 截断就在生产路径上留半个内核"),
+]:
+    (ok if re.search(pat, FN) else bad)("%s —— %s" % (name, why))
+(bad if re.search(r"gunzip -c[^\n]*>\s*\"?\$bin", FN) or re.search(r"gunzip[^\n]*/usr/local/bin/mihomo", FN)
+ else ok)("解压不直接落到目标路径")
+# 顺序断言: 候选必须在 install **之前**过生产判据。
+# 没有这一条时, 把候选校验整个删掉也是绿的 —— 后置复核与真内核探针会顺带挡住它(纵深防御,
+# 安全上没问题), 但"坏件绝不落盘"这条契约就没人守了。负控当场揭穿过。
+_i_cand = FN.find('pdg_mihomo_binary_ok "$march" "$MIHOMO_VER" "$cand"')
+_i_inst = FN.find('install -m755 "$cand"')
+(ok if 0 <= _i_cand < _i_inst else
+ bad)("候选的生产判据排在 install **之前**(cand=%d install=%d) —— 坏件绝不落盘" % (_i_cand, _i_inst))
+_i_arch = FN.find('PDG_SHA256[mihomo-$march]')
+_i_gun = FN.find('gunzip -c')
+(ok if 0 <= _i_arch < _i_gun else
+ bad)("归档校验排在解压**之前**(archive=%d gunzip=%d)" % (_i_arch, _i_gun))
+
+print()
+print("══ 2. 行为(curl 由桩接管, 目标路径注入沙箱)══")
+
+
+def mk(path, ver, marker, mode=0o755, good_bad=True):
+    """造一个 mihomo 壳: 自报 ver; good_bad=True 时能区分好/坏配置(骗过 is_real)。"""
+    body = '#!/bin/sh\n# %s\ncase "$1" in\n  -v) echo "Mihomo Meta %s linux amd64";; \n' % (marker, ver)
+    if good_bad:
+        # 调用形态是 `mihomo -t -d <dir> -f <cfg>` → 配置路径是 **$5**, 不是 $4($4 是 -f)。
+        # 第一版取了 $4, 于是好/坏配置**分不出来**, e2e_mihomo_is_real 恒假 —— 三格负控
+        # 因此被掩盖(负控当场揭穿)。
+        body += '  -t) grep -q "definitely-not-a-real-protocol" "$5" 2>/dev/null && exit 1; exit 0;;\n'
+    body += 'esac\nexit 0\n'
+    io.open(path, "w", encoding="utf-8").write(body)
+    os.chmod(path, mode)
+
+
+def run(target, archive_src, path_shadow=None, root=None):
+    """跑一次 e2e_fetch_mihomo。archive_src=None → curl 失败; 否则 cp 该文件当下载物。"""
+    h = os.path.join(WORK, "h.sh")
+    lines = [
+        'E2E_ROOT=%r' % (root or ROOT),
+        'E2E_TMP=%r' % WORK,
+        sh("e2e_mihomo_is_real"),
+        FN,
+        'curl(){ o=""; while [ $# -gt 0 ]; do [ "$1" = -o ] && { o="$2"; shift; }; shift; done; ' +
+        ('cp %r "$o"; }' % archive_src if archive_src else 'return 22; }'),
+        'e2e_fetch_mihomo %r' % target,
+    ]
+    io.open(h, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+    env = dict(os.environ)
+    if path_shadow:
+        env["PATH"] = path_shadow + os.pathsep + env["PATH"]
+    r = subprocess.run(["bash", h], capture_output=True, text=True, errors="replace", env=env)
+    out = r.stdout + r.stderr
+    # 关键: 把"判据拒绝"与"夹具压根没跑起来"分开。函数若忽略注入的路径去写真的
+    # /usr/local/bin/mihomo, 非 root 下会 Permission denied 而返回非 0 —— 那些 rc!=0
+    # 是"跑不动", 不是"拒绝"。第一版就是这么写的, 八格因此假绿。
+    ignored = ("/usr/local/bin/mihomo" in out) or ("Permission denied" in out) or ("command not found" in out)
+    return r.returncode, out, ignored
+
+
+
+def sandbox_root(archive_path):
+    """造一个沙箱 E2E_ROOT: lib/versions.sh 的**归档**钉值改成 archive_path 的 sha,
+    **二进制**钉值原样保留真值。这样归档那一关能过, 而"落盘内容 == 官方钉值"这条
+    决定性断言仍然由真钉值把关(与 test-mihomo-real-swap.sh 同一种做法)。"""
+    import hashlib
+    r = os.path.join(WORK, "root-" + os.path.basename(archive_path).replace(".", "_"))
+    os.makedirs(os.path.join(r, "lib"), exist_ok=True)
+    sha = hashlib.sha256(open(archive_path, "rb").read()).hexdigest()
+    txt = re.sub(r'\[mihomo-(amd64|arm64)\]="[0-9a-f]{64}"',
+                 lambda m: '[mihomo-%s]="%s"' % (m.group(1), sha), VERSIONS)
+    io.open(os.path.join(r, "lib", "versions.sh"), "w", encoding="utf-8").write(txt)
+    return r
+
+
+import gzip  # noqa: E402
+import shutil  # noqa: E402
+
+TGT = os.path.join(WORK, "mihomo")
+SHADOW = os.path.join(WORK, "shadow")
+os.makedirs(SHADOW, exist_ok=True)
+mk(os.path.join(SHADOW, "mihomo"), PIN_VER, "PATH-SHADOW")
+
+GOODGZ = os.path.join(WORK, "good.gz")
+if have_real:
+    with open(REAL, "rb") as fi, gzip.GzipFile(GOODGZ, "wb", mtime=0) as fo:
+        shutil.copyfileobj(fi, fo)
+
+IMPOSTOR = os.path.join(WORK, "impostor")
+mk(IMPOSTOR, PIN_VER, "IMPOSTOR")
+IMPGZ = os.path.join(WORK, "imp.gz")
+with open(IMPOSTOR, "rb") as fi, gzip.GzipFile(IMPGZ, "wb", mtime=0) as fo:
+    shutil.copyfileobj(fi, fo)
+
+TRUNC = os.path.join(WORK, "trunc.gz")
+io.open(TRUNC, "wb").write(open(IMPGZ, "rb").read()[:40] if os.path.getsize(IMPGZ) > 40 else b"x")
+
+
+def before_image(p):
+    if not os.path.exists(p):
+        return None
+    import hashlib
+    st = os.stat(p)
+    return (hashlib.sha256(open(p, "rb").read()).hexdigest(), st.st_mode, st.st_uid, st.st_gid)
+
+
+cases = [
+    ("① 目标不存在 → 进入取件", lambda: os.path.exists(TGT) and os.remove(TGT), IMPGZ, None, "fetch"),
+    ("② PATH 上有假 %s → 仍不短路" % PIN_VER, lambda: os.path.exists(TGT) and os.remove(TGT), IMPGZ, SHADOW, "fetch"),
+    ("③ 目标能跑且能分好坏配置但摘要不符 → 不短路", lambda: mk(TGT, PIN_VER, "REALISH"), IMPGZ, None, "fetch"),
+    ("④ 目标是旧版 v1.19.29 → 不短路", lambda: mk(TGT, "v1.19.29", "OLD"), IMPGZ, None, "fetch"),
+]
+for name, setup, gz, shadow, expect in cases:
+    setup()
+    pre = before_image(TGT)
+    rc, out, ignored = run(TGT, gz, shadow)
+    if ignored:
+        bad("%s → **未验**: 夹具忽略了注入路径/跑不动(%s)" % (name, out.strip().splitlines()[-1][:70] if out.strip() else "无输出"))
+        continue
+    if rc != 0:
+        ok("%s(取件后被钉值拒绝 rc=%d, 没有静默复用)" % (name, rc))
+    else:
+        bad("%s → 竟然返回 0(短路了或装了冒牌货)" % name)
+    post = before_image(TGT)
+    if pre is not None and post != pre:
+        bad("   ↑ 失败路径动了目标文件(前像未保全)")
+
+print()
+if have_real:
+    shutil.copyfile(REAL, TGT)
+    os.chmod(TGT, 0o755)
+    rc, out, ignored = run(TGT, None)  # curl 一律失败: 若真短路就不会用到它
+    if ignored:
+        bad("⑤ **未验**: 夹具忽略注入路径")
+    elif rc == 0:
+        ok("⑤ 版本+摘要都对 → 直接复用, **零下载**(curl 桩恒失败仍返回 0)")
+    else:
+        bad("⑤ 已是钉死版却仍去取件(rc=%d) %s" % (rc, out.strip()[:80]))
+else:
+    print("[SKIP] ⑤ 需要钉死版 mihomo —— 未验")
+
+mk(TGT, "v1.19.29", "OLD-SO-WE-REACH-DOWNLOAD")   # 先让复用门不成立, 否则下面三格根本走不到取件
+pre = before_image(TGT)
+rc, out, ignored = run(TGT, IMPGZ)
+bad("⑥ **未验**: 夹具忽略注入路径") if ignored else (ok("⑥ 归档摘要不符 → 失败(rc=%d)" % rc) if rc != 0 else bad("⑥ 坏归档被接受"))
+(ok if before_image(TGT) == pre else bad)("⑥ 目标文件逐字节未变")
+
+mk(TGT, "v1.19.29", "OLD-SO-WE-REACH-DOWNLOAD")
+pre = before_image(TGT)
+rc, out, ignored = run(TGT, None)
+bad("⑦ **未验**: 夹具忽略注入路径") if ignored else (ok("⑦ 下载失败/截断 → 失败(rc=%d)" % rc) if rc != 0 else bad("⑦ 下载失败却返回 0"))
+(ok if before_image(TGT) == pre else bad)("⑦ 目标文件逐字节未变")
+(ok if re.search(r"下载 mihomo", out) else
+ bad)("⑦ 具名失败且点到**下载**这一层(不是被下一道门顺带挡住): %s" % out.strip().splitlines()[-1][:60] if out.strip() else "无输出")
+
+mk(TGT, "v1.19.29", "OLD-SO-WE-REACH-DOWNLOAD")
+pre = before_image(TGT)
+rc, out, ignored = run(TGT, TRUNC, root=sandbox_root(TRUNC))
+bad("⑧ **未验**: 夹具忽略注入路径") if ignored else (ok("⑧ 截断归档 → 失败(rc=%d)" % rc) if rc != 0 else bad("⑧ 截断归档被接受"))
+(ok if before_image(TGT) == pre else bad)("⑧ 目标文件逐字节未变")
+
+if have_real:
+    mk(TGT, PIN_VER, "SAME-VER-WRONG-CONTENT")
+    pre = before_image(TGT)
+    rc, out, ignored = run(TGT, IMPGZ)
+    bad("⑨ **未验**: 夹具忽略注入路径") if ignored else (ok("⑨ 同版本错内容(归档钉值都对得上, 只能靠二进制钉值拦) → 不安装(rc=%d)" % rc) if rc != 0 else bad("⑨ 同版本错内容被当成已就位"))
+    (ok if before_image(TGT) == pre else bad)("⑨ 目标文件逐字节未变")
+
+    os.path.exists(TGT) and os.remove(TGT)
+    rc, out, ignored = run(TGT, GOODGZ, root=sandbox_root(GOODGZ))
+    if rc == 0:
+        ok("⑩ 正确归档 + 正确二进制 → 安装成功")
+    else:
+        bad("⑩ 正确归档却装不上: rc=%d %s" % (rc, out.strip()[:100]))
+    import hashlib
+    got = hashlib.sha256(open(TGT, "rb").read()).hexdigest() if os.path.exists(TGT) else ""
+    (ok if got == PIN_BIN else bad)("⑪ 落盘内容 == 钉值(安装后用生产同源判据复核)")
+    (ok if os.path.exists(TGT) and os.access(TGT, os.X_OK) else bad)("⑪ 落盘可执行")
+else:
+    print("[SKIP] ⑨⑩⑪ 需要钉死版 mihomo —— 未验")
+
+print()
+print("══ 3. 失败路径不留脏 ══")
+os.path.exists(TGT) and os.remove(TGT)
+run(TGT, IMPGZ)
+leftovers = [f for f in os.listdir(WORK) if f.startswith("m.gz") or f.startswith("mihomo.cand")]
+(ok if not leftovers else bad)("失败后临时物已清: %s" % (leftovers or "无"))
+rc, out, ignored = run(TGT, IMPGZ)
+(bad if re.search(r"✅|已装|成功", out) else ok)("失败路径没有错误的成功文案")
+
+print("-" * 62)
+print("test-e2e-mihomo-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-e2e-mihomo-fixture.py
+++ b/tests/test-e2e-mihomo-fixture.py
@@ -266,6 +266,57 @@ leftovers = [f for f in os.listdir(WORK) if f.startswith("m.gz") or f.startswith
 rc, out, ignored = run(TGT, IMPGZ)
 (bad if re.search(r"✅|已装|成功", out) else ok)("失败路径没有错误的成功文案")
 
+print()
+print("══ 4. 静态守卫: E2E 里不许再出现「只 echo 版本的 mihomo 桩」══")
+# exact-head CI 33353591548 的五支红灯全在这上面: 那些用例各自内联一个 shell 桩 mihomo,
+# 而 install.sh 的判据一旦看内容, 桩就被正确拒绝 —— 于是安装真的去下载, 撞上同一个用例
+# 自己装的假 curl(对 *.gz 写字面量 'stub', sha256 恰好是 725c546b990dd1b4…)。
+# 桩必须换成播真钉死版; 这条守卫保证它不会再长回来。
+import glob  # noqa: E402
+STUB = re.compile(r"(cat|tee)\s*>?\s*[\"']?/usr/local/bin/mihomo")
+offenders = []
+for fn in sorted(glob.glob(os.path.join(ROOT, "tests", "e2e-*.sh"))):
+    for i, line in enumerate(io.open(fn, encoding="utf-8"), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        if STUB.search(line.split("#")[0]):
+            offenders.append("%s:%d" % (os.path.basename(fn), i))
+(ok if not offenders else
+ bad)("没有 E2E 用例把 mihomo 写成内联 shell 桩(实得: %s)" % (", ".join(offenders) or "无"))
+
+SEED = sh("e2e_seed_mihomo_bin") if "\ne2e_seed_mihomo_bin(){" in LIB else ""
+(ok if SEED else bad)("tests/e2e-lib.sh 里有统一的 e2e_seed_mihomo_bin")
+if SEED:
+    for pat, why in [
+        (r"pdg_mihomo_binary_ok", "播种前后都要过生产判据"),
+        (r"install -m ?755", "装到 /usr/local/bin/mihomo"),
+    ]:
+        (ok if re.search(pat, SEED) else bad)("e2e_seed_mihomo_bin: %s" % why)
+    (bad if re.search(r"curl|wget", SEED) else
+     ok)("e2e_seed_mihomo_bin 自己不联网(取件由 CI 的 artifact / prepare 脚本负责)")
+    # 源文件必须**先验后装**: 装完再验挡不住"装了个坏的再报错"。
+    # 断言必须落在**对源文件那次调用**上 —— 第一版用的是函数定义里那个 pdg_mihomo_binary_ok,
+    # 把"验源"整行删掉它也不动, 于是那一格没有牙齿(负控当场揭穿)。
+    _i_src = SEED.find('_e2e_mihomo_ok "$src"')
+    _i_ins = SEED.find('install -m755 "$src"')
+    (ok if 0 <= _i_src < _i_ins else
+     bad)("源文件在 install **之前**就过了判据(验源=%d install=%d)" % (_i_src, _i_ins))
+# 五支用例必须改用它
+NEED = ["e2e-install.sh", "e2e-upgrade-from-release.sh", "e2e-rescue-migration-lock.sh",
+        "e2e-update.sh", "e2e-update-preserve-userdata.sh"]
+for fn in NEED:
+    p = os.path.join(ROOT, "tests", fn)
+    txt = io.open(p, encoding="utf-8").read() if os.path.exists(p) else ""
+    (ok if "e2e_seed_mihomo_bin" in txt else bad)("%s 改用 e2e_seed_mihomo_bin" % fn)
+# e2e-install.sh 的次序: 播种必须在装假 curl **之前**
+p = os.path.join(ROOT, "tests", "e2e-install.sh")
+if os.path.exists(p):
+    t = io.open(p, encoding="utf-8").read()
+    i_seed = t.find("e2e_seed_mihomo_bin")
+    i_curl = t.find("/usr/local/bin/curl")
+    (ok if 0 <= i_seed < i_curl else
+     bad)("e2e-install.sh: 真内核播种排在假 curl **之前**(seed=%d curl=%d)" % (i_seed, i_curl))
+
 print("-" * 62)
 print("test-e2e-mihomo-fixture.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
 sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-mihomo-binary-evidence.py
+++ b/tests/test-mihomo-binary-evidence.py
@@ -35,9 +35,9 @@ def bad(m):
     FAIL[0] += 1
 
 
-import tempfile  # noqa: E402
+import tmpguard  # noqa: E402  一次性临时目录: 建了就登记, 退出即清(顶层沙箱不许裸用 tempfile)
 
-WORK = tempfile.mkdtemp(prefix="pdg-mihev.")
+WORK = tmpguard.mkdtemp(prefix="pdg-mihev.")
 PIN_VER = checks._pinned_mihomo_ver()
 
 

--- a/tests/test-mihomo-binary-evidence.py
+++ b/tests/test-mihomo-binary-evidence.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""doctor 对 mihomo 的两条判据必须**分开**说, 而且都不许"能解析就绿"。
+
+修之前 check_core_version 是三重假绿, 三层都实测复现过:
+  · 它跑 PATH 上的 `mihomo`, 而 systemd 执行的是 /usr/local/bin/mihomo;
+  · 对**任何**能解析出来的版本都返回 ok, 文案还写"版本随项目发布更新" —— v0.0.1 也绿;
+  · 吞掉退出码: 命令非零但输出里带个版本号照样绿。
+
+现在分成两条, 措辞必须能区分"自报版本"与"文件内容摘要":
+  check_core_version   —— 绝对路径 + 退出码 + 自报版本精确相等
+  check_mihomo_binary  —— 该文件内容的 SHA256 等于该架构的钉值
+四态: 缺失/版本不符/摘要不符 → fail; 架构未知或读不到钉值 → warn 且明说无结论; 全中 → ok。
+"""
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(ROOT, "deploy", "bot"))
+import checks  # noqa: E402
+
+PASS = [0]
+FAIL = [0]
+
+
+def ok(m):
+    print("[OK]   %s" % m)
+    PASS[0] += 1
+
+
+def bad(m):
+    print("[FAIL] %s" % m)
+    FAIL[0] += 1
+
+
+import tempfile  # noqa: E402
+
+WORK = tempfile.mkdtemp(prefix="pdg-mihev.")
+PIN_VER = checks._pinned_mihomo_ver()
+
+
+def mk(path, ver, marker, rc=0):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write('#!/bin/sh\n# %s\ncase "$1" in -v) echo "Mihomo Meta %s linux amd64";; esac\nexit %d\n'
+                % (marker, ver, rc))
+    os.chmod(path, 0o755)
+
+
+def sha_of(p):
+    import hashlib
+    h = hashlib.sha256()
+    with open(p, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+print("══ 0. 判据存在且登记进 ALL ══")
+(ok if hasattr(checks, "check_mihomo_binary") else bad)("checks.py 里有 check_mihomo_binary")
+names = [f.__name__ for f in checks.ALL]
+(ok if "check_mihomo_binary" in names else bad)("check_mihomo_binary 登记进了 ALL(不登记就永远不会跑)")
+(ok if "check_core_version" in names else bad)("check_core_version 仍在 ALL 里")
+(ok if PIN_VER else bad)("从 lib/versions.sh 读到 MIHOMO_VER=%s" % (PIN_VER or "<空>"))
+
+print()
+print("══ 1. 判据钉在 systemd 真正执行的绝对路径上 ══")
+(ok if getattr(checks, "MIHOMO_BIN", "") == "/usr/local/bin/mihomo" else
+ bad)("MIHOMO_BIN = /usr/local/bin/mihomo(不是 PATH 上随便哪个 mihomo)")
+src = open(os.path.join(ROOT, "deploy/bot/checks.py"), encoding="utf-8").read()
+seg = src[src.index("def check_core_version"):src.index("def _pinned_mihomo_ver")]
+(bad if '_run(["mihomo"' in seg else ok)("check_core_version 不再用裸 `mihomo`(那问的是 PATH)")
+
+print()
+print("══ 2. check_core_version 四态 ══")
+good = os.path.join(WORK, "good")
+mk(good, PIN_VER, "OFFICIAL")
+cases = [
+    ("自报版本精确相等",          lambda: (mk(good, PIN_VER, "X"), good)[1],   "ok"),
+    ("自报旧版 v1.19.29",         lambda: (mk(good, "v1.19.29", "X"), good)[1], "fail"),
+    ("自报 v0.0.1(以前也绿)",     lambda: (mk(good, "v0.0.1", "X"), good)[1],  "fail"),
+    ("退出码非零但输出有版本号",   lambda: (mk(good, PIN_VER, "X", 3), good)[1], "fail"),
+    ("绝对路径文件不存在",        lambda: os.path.join(WORK, "nosuch"),        "fail"),
+]
+for name, setup, want in cases:
+    p = setup()
+    lvl, chk, detail = checks.check_core_version(_bin=p)
+    if lvl == want:
+        ok("[%s] → %s(%s)" % (name, lvl, detail[:52]))
+    else:
+        bad("[%s] 期望 %s, 实得 %s: %s" % (name, want, lvl, detail))
+lvl, _, detail = checks.check_core_version(_bin=good, _pin="")
+(ok if lvl == "warn" and "无结论" in detail else
+ bad)("[读不到钉死版本] → warn 且明说无结论(实得 %s: %s)" % (lvl, detail))
+
+print()
+print("══ 3. check_mihomo_binary 四态 ══")
+mk(good, PIN_VER, "OFFICIAL")
+GOOD_SHA = sha_of(good)
+drift = os.path.join(WORK, "drift")
+mk(drift, PIN_VER, "DRIFTED-CONTENT")
+lvl, _, d = checks.check_mihomo_binary(_bin=good, _pin=GOOD_SHA, _arch="amd64")
+(ok if lvl == "ok" else bad)("[内容与钉值一致] → ok(实得 %s)" % lvl)
+lvl, _, d = checks.check_mihomo_binary(_bin=drift, _pin=GOOD_SHA, _arch="amd64")
+(ok if lvl == "fail" else bad)("[同版本、内容不符] → fail(实得 %s)" % lvl)
+(ok if "内容" in d else bad)("[同版本、内容不符] 文案点明是**内容**不符: %s" % d[:56])
+lvl, _, d = checks.check_mihomo_binary(_bin=os.path.join(WORK, "nosuch"), _pin=GOOD_SHA, _arch="amd64")
+(ok if lvl == "fail" else bad)("[文件不存在] → fail(实得 %s)" % lvl)
+lvl, _, d = checks.check_mihomo_binary(_bin=good, _arch="riscv64")
+(ok if lvl == "warn" and "无结论" in d else
+ bad)("[未知架构] → warn 且明说无结论(实得 %s: %s)" % (lvl, d))
+lvl, _, d = checks.check_mihomo_binary(_bin=good, _pin="", _arch="amd64")
+(ok if lvl == "warn" and "无结论" in d else
+ bad)("[读不到钉值] → warn 且明说无结论(实得 %s: %s)" % (lvl, d))
+
+print()
+print("══ 4. 两条判据的措辞必须能区分「自报版本」与「文件内容」 ══")
+mk(good, PIN_VER, "OFFICIAL")
+_, _, dv = checks.check_core_version(_bin=good)
+_, _, db = checks.check_mihomo_binary(_bin=good, _pin=sha_of(good), _arch="amd64")
+(ok if "自报" in dv else bad)("版本判据的文案里出现「自报」: %s" % dv[:56])
+(ok if ("内容" in db or "sha256" in db) else bad)("内容判据的文案里出现「内容/sha256」: %s" % db[:56])
+(bad if "版本随项目发布更新" in dv else
+ ok)("旧那句「版本随项目发布更新」已经不在(它对任何版本都绿)")
+
+print()
+print("══ 5. 真二进制端到端(有钉死版才跑, 没有则明确 SKIP 而不是冒充通过) ══")
+REAL = os.environ.get("PDG_TEST_MIHOMO", "")
+if REAL and os.path.exists(REAL):
+    lvl, _, d = checks.check_core_version(_bin=REAL)
+    (ok if lvl == "ok" else bad)("真 %s 二进制 → 版本判据 ok(实得 %s: %s)" % (PIN_VER, lvl, d[:40]))
+    lvl, _, d = checks.check_mihomo_binary(_bin=REAL, _arch="amd64")
+    (ok if lvl == "ok" else bad)("真 %s 二进制 → 内容判据 ok(实得 %s: %s)" % (PIN_VER, lvl, d[:40]))
+else:
+    print("[SKIP] 没有真 mihomo(设 PDG_TEST_MIHOMO=<路径> 可跑这一节) —— 这是未验, 不是通过")
+
+print("-" * 62)
+print("test-mihomo-binary-evidence.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-mihomo-integrity.sh
+++ b/tests/test-mihomo-integrity.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# mihomo 完整性闭包 —— 与 mosdns 那套**同一种语义**, 不另立宽松版本。
+#
+# 修之前这里是四个连着的假绿(每一条都在本轮 POC 里实测复现过):
+#   ① pdg_mihomo_version 问的是 **PATH** 上的 mihomo, 而 systemd 执行的是
+#      /usr/local/bin/mihomo。PATH 上放一个自报 v1.19.30 的壳, 判据就答"已是钉死版";
+#   ② 判据只比**自报版本**。版本是二进制自己说的 —— 换掉内容、留住版本串, install.sh 与
+#      _update_core_binary 都会跳过下载, 而日志上连"下载 mihomo"这行都不会出现;
+#   ③ lib/versions.sh 只钉了**压缩包**摘要。而压缩包摘要只在"真的下载了"那条路上起作用,
+#      被 ① ② 一短路就永远用不上 —— 落盘的那个文件本身, 项目从来没钉过;
+#   ④ 顶层「已是最新」短路只比仓库文件, 不看内核二进制。于是"仓库最新 + 项目文件一致 +
+#      内核内容漂移"这个现场里, pdg update 直接返回 0, 把唯一的修复路径堵死。
+#
+# 判据必须是: **绝对路径 + 退出码 + 自报版本 + 内容摘要**, 四者全中才算数。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-mihint.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+command -v git >/dev/null 2>&1 || { echo "[SKIP] 无 git"; exit 0; }
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"
+
+xtv(){ sed -n "/^$1(){/,/^}/p" "$ROOT/lib/versions.sh"; }
+xtp(){ sed -n "/^$1(){/,/^}/p" "$ROOT/deploy/bot/pdg.sh"; }
+PIN_VER="$(grep -oE 'MIHOMO_VER="[^"]+"' "$ROOT/lib/versions.sh" | cut -d'"' -f2)"
+
+echo "══ 1. lib/versions.sh 钉了**解压后二进制**的摘要 ══"
+for a in amd64 arm64; do
+  v="$(grep -oE "\[mihomo-bin-$a\]=\"[0-9a-f]{64}\"" "$ROOT/lib/versions.sh" | grep -oE '[0-9a-f]{64}')"
+  [[ -n "$v" ]] && ok "[mihomo-bin-$a] 已钉(${v:0:12}…)" \
+    || bad "[mihomo-bin-$a] 缺失 —— 只钉压缩包的话, 一旦短路就永远用不上那个钉值"
+done
+grep -q 'pdg_mihomo_binary_ok' "$ROOT/lib/versions.sh" \
+  && ok "有统一判据 pdg_mihomo_binary_ok" || bad "没有 pdg_mihomo_binary_ok —— 判据没收口"
+
+echo
+echo "══ 2. 判据本体: 绝对路径 + 退出码 + 自报版本 + 内容摘要, 四者全中 ══"
+BIN="$WORK/bin"; mkdir -p "$BIN" "$WORK/shadow"
+mk(){ # $1=自报版本 $2=内容标记 $3=落点 [$4=退出码]
+  printf '#!/bin/sh\n# %s\ncase "$1" in -v) echo "Mihomo Meta %s linux amd64 with go1.26";; esac\nexit %s\n' \
+    "$2" "$1" "${4:-0}" > "$3"; chmod 755 "$3"; }
+mk "$PIN_VER" OFFICIAL "$WORK/official"
+GOOD_SHA="$(sha256sum "$WORK/official" | cut -d' ' -f1)"
+
+mkvers(){ # 造一份只认 GOOD_SHA 的 versions.sh(结构与生产同形); 判据本体从真文件抽
+  mkdir -p "$1"
+  { echo "MIHOMO_VER=\"$PIN_VER\""
+    echo "declare -A PDG_SHA256=( [mihomo-bin-amd64]=\"$GOOD_SHA\" [mihomo-bin-arm64]=\"$GOOD_SHA\" )"
+    xtv pdg_mihomo_version; xtv pdg_mihomo_is_version; xtv pdg_mihomo_binary_ok
+  } > "$1/versions.sh"
+}
+mkvers "$WORK/v"
+# rc 约定: 0=放行  127=**判据本身不存在**(不是拒绝!)  其它非 0=拒绝
+# 这一层必须分开: 第一版把 127 也算成"拒绝", 于是在 pdg_mihomo_binary_ok 还没写出来的时候
+# 五格全绿 —— 那是"函数不存在"冒充"判据有牙齿", 正是本轮要清的那类假绿。
+ask(){ # $1=二进制路径; PATH 上永远有一个自报正确版本的影子
+  PATH="$WORK/shadow:$PATH" bash -c "
+    source '$WORK/v/versions.sh' 2>/dev/null || exit 99
+    command -v pdg_mihomo_binary_ok >/dev/null 2>&1 || exit 127
+    pdg_mihomo_binary_ok amd64 '$PIN_VER' '$1'" >/dev/null 2>&1; echo $?
+}
+mk "$PIN_VER" PATH-SHADOW "$WORK/shadow/mihomo"     # PATH 影子: 自报版本正确, 内容是别的
+
+cp "$WORK/official" "$BIN/mihomo"; chmod 755 "$BIN/mihomo"
+[[ "$(ask "$BIN/mihomo")" == 0 ]] && ok "版本对 + 摘要对 → 放行" || bad "合法却被拒"
+
+declare -a CASES=(
+  "同版本错误摘要|mk \"\$PIN_VER\" TAMPERED \"\$BIN/mihomo\""
+  "绝对路径旧版|mk v1.19.29 OLD \"\$BIN/mihomo\""
+  "绝对路径缺失|rm -f \"\$BIN/mihomo\""
+  "不可执行|cp \"\$WORK/official\" \"\$BIN/mihomo\"; chmod 644 \"\$BIN/mihomo\""
+)
+for c in "${CASES[@]}"; do
+  nm="${c%%|*}"; eval "${c#*|}"
+  r="$(ask "$BIN/mihomo")"
+  if [[ "$r" == 127 ]]; then
+    bad "[$nm] 判据 pdg_mihomo_binary_ok 不存在 —— 这一格**未验**, 不是通过"
+  elif [[ "$r" != 0 ]]; then ok "[$nm] 拒绝(rc=$r)"
+  else bad "[$nm] 竟然放行 —— PATH 上那个自报 $PIN_VER 的壳把判据骗过去了"; fi
+done
+# 「退出码非零」必须**单独**隔离出来测。放在上面那个循环里是测不出来的: 那些用例的内容
+# 与钉值本来就不同, 摘要那一关先把它挡了 —— 于是把"要求 rc=0"整条删掉, 用例照样绿
+# (负控当场揭穿过这一点)。这里给 rc=3 的那个壳**配它自己的钉值**, 让版本与摘要都对上,
+# 唯一不对的就是退出码。
+mk "$PIN_VER" RC3 "$WORK/rc3" 3
+RC3_SHA="$(sha256sum "$WORK/rc3" | cut -d' ' -f1)"
+mkdir -p "$WORK/v3"
+{ echo "MIHOMO_VER=\"$PIN_VER\""
+  echo "declare -A PDG_SHA256=( [mihomo-bin-amd64]=\"$RC3_SHA\" [mihomo-bin-arm64]=\"$RC3_SHA\" )"
+  xtv pdg_mihomo_version; xtv pdg_mihomo_is_version; xtv pdg_mihomo_binary_ok
+} > "$WORK/v3/versions.sh"
+r=$(PATH="$WORK/shadow:$PATH" bash -c "
+  source '$WORK/v3/versions.sh' 2>/dev/null || exit 99
+  command -v pdg_mihomo_binary_ok >/dev/null 2>&1 || exit 127
+  pdg_mihomo_binary_ok amd64 '$PIN_VER' '$WORK/rc3'" >/dev/null 2>&1; echo $?)
+case "$r" in
+  127) bad "[命令非零但版本与摘要都对] 判据不存在 —— 未验";;
+  0)   bad "[命令非零但版本与摘要都对] 放行了 —— 退出码没被当成证据的一部分";;
+  *)   ok  "[命令非零但版本与摘要都对] 拒绝(rc=$r) —— 退出码是证据的一部分";;
+esac
+
+# 未知架构 / 缺钉值 一律拒绝(fail-closed)
+cp "$WORK/official" "$BIN/mihomo"; chmod 755 "$BIN/mihomo"
+# 这两格同样要把 127 与"拒绝"分开 —— 否则判据不存在时它们也报绿。
+judge(){ # $1=标签 $2=rc
+  case "$2" in
+    127) bad "[$1] 判据不存在 —— 这一格**未验**, 不是通过";;
+    0)   bad "[$1] 放行了 —— 无从对照时必须拒绝(fail-closed)";;
+    *)   ok  "[$1] 拒绝(无从对照, rc=$2)";;
+  esac
+}
+r=$(PATH="$WORK/shadow:$PATH" bash -c "
+  source '$WORK/v/versions.sh' 2>/dev/null || exit 99
+  command -v pdg_mihomo_binary_ok >/dev/null 2>&1 || exit 127
+  pdg_mihomo_binary_ok riscv64 '$PIN_VER' '$BIN/mihomo'" >/dev/null 2>&1; echo $?)
+judge "未知架构" "$r"
+r=$(bash -c "MIHOMO_VER='$PIN_VER'; declare -A PDG_SHA256=()
+  $(xtv pdg_mihomo_version)
+  $(xtv pdg_mihomo_is_version)
+  $(xtv pdg_mihomo_binary_ok)
+  command -v pdg_mihomo_binary_ok >/dev/null 2>&1 || exit 127
+  pdg_mihomo_binary_ok amd64 '$PIN_VER' '$BIN/mihomo'" >/dev/null 2>&1; echo $?)
+judge "缺钉值" "$r"
+
+echo
+echo "══ 3. 判据问的是**绝对路径**, 不是 PATH ══"
+[[ "$(grep -c '/usr/local/bin/mihomo' "$ROOT/lib/versions.sh" || true)" != 0 ]] \
+  && ok "versions.sh 里出现了 systemd 执行的那个绝对路径" \
+  || bad "判据里没有绝对路径 —— 那它问的还是 PATH"
+# 生产源码(去注释后)不得再用只比版本的老判据决定装不装
+# ⚠️ 这里**不能**用 `… | grep -q …` 作条件: 本文件开头有 set -o pipefail, 而 grep -q
+# 一命中就关掉管道 → 上游 sed 收到 SIGPIPE 退 141 → pipefail 把整条管道判成失败 →
+# 条件**整个反转**。第一版就是这么写的, 结果两条断言在生产代码明明没改的情况下报绿。
+# 改用计数: 先把结果收进变量, 管道跑完再判。
+cnt(){ sed 's/#.*//' "$1" | grep -c "$2" || true; }   # 去注释后的命中数
+[[ "$(cnt "$ROOT/install.sh" 'pdg_mihomo_is_version')" == 0 ]] \
+  && ok "install.sh 的跳过判据已换成内容级判据" \
+  || bad "install.sh 仍用 pdg_mihomo_is_version 决定跳过下载(只比自报版本)"
+[[ "$(cnt "$ROOT/deploy/bot/pdg.sh" 'pdg_mihomo_is_version')" == 0 ]] \
+  && ok "_update_core_binary 的跳过判据已换成内容级判据" \
+  || bad "_update_core_binary 仍用 pdg_mihomo_is_version 决定跳过换核"
+[[ "$(cnt "$ROOT/install.sh" 'mihomo-bin-')" != 0 ]] \
+  && ok "install.sh 落盘后按 mihomo-bin-* 二次核验" || bad "install.sh 落盘后没有二次核验"
+
+echo
+echo "══ 4. 顶层「已是最新」短路不得堵死修复路径 ══"
+# 现场: 仓库精确在最新 tag、工作树干净、已装项目文件逐个一致, 但内核二进制内容漂移。
+# 这一格必须跑**完整 cmd_update**, 只测 helper 证明不了短路会不会先答话。
+sed -n '/^cmd_update(){/,/^}/p'               "$ROOT/deploy/bot/pdg.sh" >  "$WORK/upd.sh"
+for f in _update_release_relation _update_in_sync _pdg_same_file _core_bindir _update_mosdns_preflight; do
+  sed -n "/^$f(){/,/^}/p" "$ROOT/deploy/bot/pdg.sh" >> "$WORK/upd.sh"
+done
+RT="$WORK/rt"; REPO="$WORK/repo"; mkdir -p "$RT" "$REPO/lib" "$REPO/deploy/bot" "$REPO/deploy/cert"
+cp "$ROOT/lib/versions.sh" "$REPO/lib/versions.sh"
+printf 'pdg_install_runtime_modules(){ return 0; }\npdg_platform_modules(){ echo "deploy/bot/x.py x.py 644"; }\nPDG_RUNTIME_DIR="%s"\n' "$RT" > "$REPO/lib/modules.sh"
+echo xpy > "$REPO/deploy/bot/x.py"; cp "$REPO/deploy/bot/x.py" "$RT/x.py"
+for f in deploy/cert/proxy-gateway-open-cert-http.sh deploy/cert/proxy-gateway-restore-firewall.sh deploy/bot/pdg-set-token.sh deploy/bot/pdg.sh; do
+  mkdir -p "$REPO/$(dirname "$f")"; echo "$f" > "$REPO/$f"; done
+cp "$REPO/deploy/cert/proxy-gateway-open-cert-http.sh"   "$BIN/proxy-gateway-open-cert-http.sh"
+cp "$REPO/deploy/cert/proxy-gateway-restore-firewall.sh" "$BIN/proxy-gateway-restore-firewall.sh"
+cp "$REPO/deploy/bot/pdg-set-token.sh" "$BIN/pdg-set-token"; cp "$REPO/deploy/bot/pdg.sh" "$BIN/pdg"
+( cd "$REPO" && git init -qb main && git config user.email t@t && git config user.name t \
+  && git config commit.gpgsign false && git add -A && git commit -qm v1 && git tag -a v9.9.9 -m v9.9.9 ) >/dev/null 2>&1
+mk "$PIN_VER" DRIFTED-CONTENT "$BIN/mihomo"        # 自报版本正确, 内容不是官方那份
+# _update_in_sync 现在同时问 mihomo 与 mosdns 两条。要让这一格**只**说明 mihomo 那条,
+# 就得先把 mosdns 那条弄成通过 —— 否则把 mihomo 判据整个删掉, 短路照样不成立(mosdns
+# 先失败了), 这一格就永远绿。负控揭穿过这一点。
+if [[ -x /usr/local/bin/mosdns ]]; then
+  cp /usr/local/bin/mosdns "$BIN/mosdns" 2>/dev/null && chmod 755 "$BIN/mosdns"
+fi
+if bash -c "source '$ROOT/lib/versions.sh'; m=\$(dpkg --print-architecture 2>/dev/null || echo amd64)
+            pdg_mosdns_binary_ok \"\$m\" \"\$MOSDNS_VER\" '$BIN/mosdns'" 2>/dev/null; then
+  ok "前提: 沙箱里的 mosdns 已是钉死版(这一格才只反映 mihomo 那一条)"
+else
+  bad "前提不成立: 沙箱 mosdns 不是钉死版 —— 这一格的结论会被 mosdns 判据混淆, 判为未验"
+fi
+cat > "$WORK/h.sh" <<EOF
+REPO_DIR="$REPO"; REPO_URL="file:///dev/null"; ENVF="$WORK/none.env"
+PDG_CORE_BINDIR="$BIN"; PDG_RUNTIME_DIR="$RT"
+need_root(){ :; }; _lock(){ :; }; c_g(){ echo "\$*"; }; c_y(){ echo "\$*"; }; sleep(){ :; }
+_pdg_platform(){ echo android; }; _pdg_core(){ echo mihomo; }; _pdg_bot_cred(){ echo unset; }
+pdg_fetch_release_tags(){ return 0; }
+cmd_snapshot(){ echo SNAPSHOT >> "$WORK/side.log"
+  _PDG_SNAP_CREATED="$WORK/snap"; mkdir -p "\$_PDG_SNAP_CREATED"
+  : | gzip > "\$_PDG_SNAP_CREATED/snap.tar.gz"; return 0; }
+cmd_rollback(){ echo ROLLBACK >> "$WORK/side.log"; return 0; }
+_update_core_binary(){ echo CORE_STEP >> "$WORK/side.log"; return 0; }
+_update_mosdns_binary(){ return 0; }
+install(){ echo "install \$*" >> "$WORK/side.log"; return 0; }
+systemctl(){ echo "systemctl \$*" >> "$WORK/side.log"; return 0; }
+python3(){ case "\$*" in *py_compile*) return 0;; *doctor.py*) echo '[{"level":"ok","check":"x","detail":"y"}]';; *) command python3 "\$@";; esac; }
+mihomo(){ return 0; }; nft(){ return 0; }
+bash(){ [[ "\$*" == *__migrate* ]] && { echo migrate >> "$WORK/side.log"; return 0; }; command bash "\$@"; }
+_pdg_bot_cred(){ echo unset; }
+EOF
+: > "$WORK/side.log"
+out=$(PATH="$WORK/shadow:$PATH" bash -c "source '$WORK/h.sh'; source '$WORK/upd.sh'; cmd_update" 2>&1) || true
+printf '%s\n' "$out" > "$WORK/upd.out"
+if grep -q CORE_STEP "$WORK/side.log"; then
+  ok "内核内容漂移时 update 不再被「已是最新」短路挡住(走到了换核这一步)"
+else
+  bad "内核内容漂移时没走到换核这一步。链路末尾: $(tail -3 <<<"$out" | tr '\n' ' ')"
+fi
+
+echo "────────────────────────────────────────"
+echo "$(basename "$0"): 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-mihomo-integrity.sh
+++ b/tests/test-mihomo-integrity.sh
@@ -164,8 +164,14 @@ for f in deploy/cert/proxy-gateway-open-cert-http.sh deploy/cert/proxy-gateway-r
 cp "$REPO/deploy/cert/proxy-gateway-open-cert-http.sh"   "$BIN/proxy-gateway-open-cert-http.sh"
 cp "$REPO/deploy/cert/proxy-gateway-restore-firewall.sh" "$BIN/proxy-gateway-restore-firewall.sh"
 cp "$REPO/deploy/bot/pdg-set-token.sh" "$BIN/pdg-set-token"; cp "$REPO/deploy/bot/pdg.sh" "$BIN/pdg"
-( cd "$REPO" && git init -qb main && git config user.email t@t && git config user.name t \
-  && git config commit.gpgsign false && git add -A && git commit -qm v1 && git tag -a v9.9.9 -m v9.9.9 ) >/dev/null 2>&1
+# 会写 ref/config 的 git 一律走 e2e_git(见 test-e2e-repo-guard.py 与 07-31 那次事故)。
+git init -qb main "$REPO" >/dev/null 2>&1
+e2e_git "$REPO" config user.email t@t        >/dev/null 2>&1
+e2e_git "$REPO" config user.name t           >/dev/null 2>&1
+e2e_git "$REPO" config commit.gpgsign false  >/dev/null 2>&1
+e2e_git "$REPO" add -A                       >/dev/null 2>&1
+e2e_git "$REPO" commit -qm v1                >/dev/null 2>&1
+e2e_git "$REPO" tag -a v9.9.9 -m v9.9.9      >/dev/null 2>&1
 mk "$PIN_VER" DRIFTED-CONTENT "$BIN/mihomo"        # 自报版本正确, 内容不是官方那份
 # _update_in_sync 现在同时问 mihomo 与 mosdns 两条。要让这一格**只**说明 mihomo 那条,
 # 就得先把 mosdns 那条弄成通过 —— 否则把 mihomo 判据整个删掉, 短路照样不成立(mosdns

--- a/tests/test-mihomo-real-swap.sh
+++ b/tests/test-mihomo-real-swap.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 真实换核: 前像 v1.19.29 → 钉死版 v1.19.30, 走**真的** _update_core_binary。
+#
+# 为什么不能用桩糊过去: 换核路径上唯一有意义的断言是"落盘的那个文件等于官方钉值",
+# 而放一个自报目标版本的桩, 短路判据当场返回 0 —— 整条路径根本不会被执行, 测试却是绿的。
+# 所以这里: 目标二进制是**真的** v1.19.30(tests/.bin/mihomo, 由 prepare-mihomo.sh 按
+# lib/versions.sh 的 SHA256 下载并校验, 每个 CI run 只下一次, 本测试**不新增公网下载**),
+# 取件由本地桩喂那份真二进制, 内容钉值取**真的** lib/versions.sh。
+#
+# 容器/真 systemd 那一层不在这里: systemctl 由桩模拟(与 test-core-swap.sh 同一套)。
+# 本支验的是"取件→双重校验→落盘→配置检查→稳定判定→失败逐字节还原"这条链。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-mihswap.XXXXXX")"
+[[ -n "${PDG_KEEP_TMP:-}" ]] || trap 'rm -rf "$WORK"' EXIT
+[[ -n "${PDG_KEEP_TMP:-}" ]] && echo "[i] 保留现场: $WORK"
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"
+# shellcheck source=lib/versions.sh
+source "$ROOT/lib/versions.sh"
+
+REAL="${PDG_TEST_MIHOMO:-$ROOT/tests/.bin/mihomo}"
+if [[ ! -x "$REAL" ]]; then
+  if [[ -n "${PDG_TEST_STRICT:-}${CI:-}" ]]; then
+    bad "拿不到钉死版 mihomo —— 严格模式下这是失败, 不是跳过。备一份: bash tests/prepare-mihomo.sh"
+    echo "通过 $pass, 失败 $nfail"; exit 1
+  fi
+  echo "[SKIP] 没有钉死版 mihomo(bash tests/prepare-mihomo.sh 可备好) —— 这是未验, 不是通过"; exit 0
+fi
+MARCH="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
+PIN_BIN="${PDG_SHA256[mihomo-bin-$MARCH]:-}"
+[[ -n "$PIN_BIN" ]] || { bad "lib/versions.sh 里没有 [mihomo-bin-$MARCH]"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+[[ "$(sha256sum "$REAL" | cut -d' ' -f1)" == "$PIN_BIN" ]] \
+  && ok "前提: tests/.bin/mihomo 就是钉死版(内容 == [mihomo-bin-$MARCH])" \
+  || { bad "tests/.bin/mihomo 与钉值不符 —— 夹具本身不可信, 后面的断言都不算数"; echo "通过 $pass, 失败 $nfail"; exit 1; }
+
+xt(){ sed -n "/^$1(){/,/^}/p" "$ROOT/deploy/bot/pdg.sh"; }
+BIN="$WORK/bin"; CFG="$WORK/etc-mihomo"; mkdir -p "$BIN" "$CFG" "$WORK/shadow"
+# 一份真 mihomo 认的最小配置(配置检查那一步跑的是**真内核**)
+cat > "$CFG/config.yaml" <<'Y'
+mixed-port: 17899
+mode: rule
+log-level: silent
+external-controller: ''
+rules:
+  - MATCH,DIRECT
+Y
+printf 'BROKEN: [[[\n' > "$CFG/broken.yaml"
+# PATH 影子: 自报目标版本、内容完全无关。它**不得**影响任何判定。
+printf '#!/bin/sh\ncase "$1" in -v) echo "Mihomo Meta v1.19.30 linux amd64";; -t) exit 0;; esac\nexit 0\n' \
+  > "$WORK/shadow/mihomo"; chmod 755 "$WORK/shadow/mihomo"
+# 前像: 自报 v1.19.29 的旧核(内容与钉值无关) —— 短路判据必须因此**不**短路
+mkold(){ printf '#!/bin/sh\n# OLD-v1.19.29\ncase "$1" in -v) echo "Mihomo Meta v1.19.29 linux amd64";; esac\nexit 0\n' > "$BIN/mihomo"; chmod 755 "$BIN/mihomo"; }
+mkold; OLD_SHA="$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)"; chmod 755 "$BIN/mihomo"
+OLD_MODE="$(stat -c%a "$BIN/mihomo")"; OLD_OWN="$(stat -c%u:%g "$BIN/mihomo")"
+
+# 取件桩: 把**真** mihomo 重新 gzip 成"下载物"。归档钉值随之算出来注入临时 versions.sh;
+# 二进制钉值用**真的**那一份 —— 决定性断言("落盘内容 == 官方钉值")因此没有被稀释。
+gzip -nc "$REAL" > "$WORK/m.gz"
+ARCH_SHA="$(sha256sum "$WORK/m.gz" | cut -d' ' -f1)"
+mkdir -p "$WORK/repo/lib"
+{ echo "MIHOMO_VER=\"$MIHOMO_VER\""
+  echo "declare -A PDG_SHA256=( [mihomo-$MARCH]=\"$ARCH_SHA\" [mihomo-bin-$MARCH]=\"$PIN_BIN\" )"
+  sed -n '/^pdg_mihomo_version(){/,/^}/p'   "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_mihomo_is_version(){/,/^}/p' "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_mihomo_binary_ok(){/,/^}/p' "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_verify_sha256(){/,/^}/p'    "$ROOT/lib/versions.sh"
+} > "$WORK/repo/lib/versions.sh"
+
+# 夹具落盘再 source。**不能**把抽出来的函数塞进 bash -c 的单引号串 —— _core_listeners
+# 与 _pdg_sha 里本身就有单引号(awk '...' / cut -d' '), 会当场撑破外层引号变成语法错。
+# 第一版就是这么写的: bash -c 直接 rc=2 什么都没跑, 而"旧核没被动"那几条断言照样报绿 ——
+# 又一格假绿。所以每一格现在都要先确认夹具**真的执行过**, 再谈还原。
+# ⚠️ 顺序要紧: **先抽生产函数, 后写桩**。
+# xt 用 `/^NAME(){/,/^}/` 抽取, 而 _core_bindir 在 pdg.sh 里是**单行函数** —— 它那一行没有
+# 独立的 `}` 收尾, sed 的结束锚点于是跑到**下一个**函数的末尾, 把真的 _core_config_check
+# (里面写死 /etc/mihomo)一起抽了进来。桩若写在前面就会被它覆盖, 表现是"真内核说配置不兼容"。
+: > "$WORK/h.sh"
+for f in _core_bindir _pdg_sha _core_stash_kernel _core_restore_prev _core_kernel_stable \
+         _core_listeners _core_swap_verify _update_core_binary; do
+  xt "$f" >> "$WORK/h.sh"
+done
+{
+  echo 'c_g(){ echo "$*"; }; c_y(){ echo "$*"; }; sleep(){ :; }'
+  echo "curl(){ local o=\"\"; while [[ \$# -gt 0 ]]; do [[ \"\$1\" == -o ]] && { o=\"\$2\"; shift; }; shift; done; cp '$WORK/m.gz' \"\$o\"; }"
+  echo "_core_config_check(){ \"\$2/mihomo\" -t -d '$CFG' -f \"$CFG/\$CFGF\" > '$WORK/cfgchk.log' 2>&1; }"
+  echo "systemctl(){ if [[ \"\$1\" == is-active ]]; then"
+  echo "               if grep -q OLD-v1.19.29 '$BIN/mihomo' 2>/dev/null; then echo active; else echo \"\$NEWACT\"; fi"
+  echo "             elif [[ \"\$1\" == show ]]; then echo 0; fi; return 0; }"
+} >> "$WORK/h.sh"
+echo 'HARNESS_OK=1' >> "$WORK/h.sh"
+bash -n "$WORK/h.sh" 2>/dev/null && ok "夹具可解析(函数抽取没被引号撑破)" \
+  || bad "夹具本身语法错 —— 后面所有断言都不算数"
+
+run(){ # $1=配置检查用哪份(config.yaml|broken.yaml) $2=新核起来后稳不稳(active|failed)
+  : > "$WORK/log"
+  # 用显式 env 而不是前缀赋值: 前缀里出现 WORK="$WORK" 时 shellcheck 会判 SC2097/SC2098
+  # (它看不出右边的 $WORK 是父进程的值), 而 CI 的 lint 是 --severity=warning, 会红。
+  env PATH="$WORK/shadow:$PATH" REPO_DIR="$WORK/repo" PDG_CORE_BINDIR="$BIN" \
+      CFGF="$1" NEWACT="$2" WORK="$WORK" \
+      bash -c "source '$WORK/h.sh'; [[ \"\${HARNESS_OK:-}\" == 1 ]] || exit 90; _update_core_binary" \
+      > "$WORK/log" 2>&1
+  echo $?
+}
+ran(){ [[ "$1" != 90 && "$1" != 2 && "$1" != 127 ]]; }   # 夹具自己没炸
+
+echo
+echo "══ 1. 成功换核: 前像 v1.19.29 → 钉死版 $MIHOMO_VER ══"
+mkold; rc=$(run config.yaml active)
+NEW_SHA="$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)"
+[[ "$rc" == 0 ]] && ok "返回 0" || bad "返回 $rc: $(tail -2 "$WORK/log" | tr '\n' ' ')"
+[[ "$NEW_SHA" == "$PIN_BIN" ]] && ok "落盘内容 **== 官方钉值** ${PIN_BIN:0:12}…" || bad "落盘 ${NEW_SHA:0:12}… != 钉值 ${PIN_BIN:0:12}…"
+[[ "$("$BIN/mihomo" -v 2>/dev/null | head -1)" == *"$MIHOMO_VER"* ]] \
+  && ok "绝对路径上的版本变成 $MIHOMO_VER" || bad "版本没换过来"
+compgen -G "$BIN/.mihomo.pdg-prev.*" >/dev/null && bad "旧核备份残留(应在确认可用后删掉)" || ok "旧核备份已清理"
+grep -q '已装并重启' "$WORK/log" && ok "报了已装并重启" || bad "没报已装并重启"
+
+echo
+echo "══ 2. PATH 影子不得影响结果 ══"
+# 影子自报的正是目标版本。若判据还问 PATH, 上面那次就会被短路成"已是最新", 根本不会换。
+grep -q '更新 mihomo 内核' "$WORK/log" \
+  && ok "尽管 PATH 上有自报 $MIHOMO_VER 的影子, 仍然真的走了取件换核" \
+  || bad "被 PATH 影子短路了 —— 判据还在问 PATH"
+
+echo
+echo "══ 3. 新核配置检查失败 → 逐字节还原旧核 ══"
+mkold; rc=$(run broken.yaml active)
+ran "$rc" && ok "夹具确实执行了(rc=$rc)" || bad "夹具没能执行(rc=$rc) —— 这一节**未验**, 下面的还原断言不算数"
+grep -q '更新 mihomo 内核' "$WORK/log" && ok "确实进了换核路径" || bad "根本没进换核路径"
+[[ "$rc" != 0 ]] && ok "返回非 0(rc=$rc)" || bad "配置检查失败却返回 0"
+[[ "$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)" == "$OLD_SHA" ]] && ok "旧核内容逐字节还原" || bad "旧核内容没还原"
+[[ "$(stat -c%a "$BIN/mihomo")" == "$OLD_MODE" ]] && ok "旧核 mode 还原($OLD_MODE)" || bad "mode 变了"
+[[ "$(stat -c%u:%g "$BIN/mihomo")" == "$OLD_OWN" ]] && ok "旧核属主还原" || bad "属主变了"
+compgen -G "$BIN/.mihomo.pdg-prev.*" >/dev/null && bad "留下了 .prev 半套状态" || ok "无 .prev 残留"
+grep -q '已装并重启' "$WORK/log" && bad "失败却报了成功文案" || ok "没有错误的成功文案"
+
+echo
+echo "══ 4. 新核起来后不稳定 → 同样完整还原 ══"
+mkold; rc=$(run config.yaml failed)
+ran "$rc" && ok "夹具确实执行了(rc=$rc)" || bad "夹具没能执行(rc=$rc) —— 这一节**未验**, 下面的还原断言不算数"
+grep -q '更新 mihomo 内核' "$WORK/log" && ok "确实进了换核路径" || bad "根本没进换核路径"
+[[ "$rc" != 0 ]] && ok "返回非 0(rc=$rc)" || bad "不稳定却返回 0"
+[[ "$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)" == "$OLD_SHA" ]] && ok "旧核内容逐字节还原" || bad "旧核内容没还原"
+compgen -G "$BIN/.mihomo.pdg-prev.*" >/dev/null && bad "留下了 .prev 半套状态" || ok "无 .prev 残留"
+grep -q '已装并重启' "$WORK/log" && bad "失败却报了成功文案" || ok "没有错误的成功文案"
+
+echo
+echo "══ 5. 已是钉死版时短路(且是按**内容**短路, 不是按自报版本) ══"
+install -m755 "$REAL" "$BIN/mihomo"
+: > "$WORK/log"; rc=$(run config.yaml active)
+{ [[ "$rc" == 0 ]] && ! grep -q '更新 mihomo 内核' "$WORK/log"; } \
+  && ok "内容已等于钉值 → 短路, 不取件" || bad "已是钉死版却仍然取件(rc=$rc)"
+printf '\n# tampered\n' >> "$BIN/mihomo"      # 版本仍自报 v1.19.30, 内容变了
+: > "$WORK/log"; rc=$(run config.yaml active)
+{ [[ "$rc" == 0 ]] && grep -q '更新 mihomo 内核' "$WORK/log" \
+  && [[ "$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)" == "$PIN_BIN" ]]; } \
+  && ok "自报版本仍对但内容被改 → **不短路**, 重下并修回钉值" \
+  || bad "内容漂移被当成已是最新跳过了(rc=$rc) —— 只比版本的老毛病回来了"
+
+echo
+echo "══ 6. 归档校验过了、解压产物却不是钉值 → 落盘**之前**就要拦住 ══"
+# 这一格是"落盘前二次核验"唯一的牙齿。上面几格里归档与二进制天然一致(归档就是那个二进制
+# 压出来的), 所以把落盘前那道校验整个删掉, 它们照样绿 —— 负控当场揭穿过。
+# 这里造一个**内容不同但归档钉值对得上**的下载物: 归档那关会过, 只有二进制那关能拦。
+printf '#!/bin/sh\n# IMPOSTOR\ncase "$1" in -v) echo "Mihomo Meta %s linux amd64";; -t) exit 0;; esac\nexit 0\n' \
+  "$MIHOMO_VER" > "$WORK/impostor"; chmod 755 "$WORK/impostor"
+gzip -nc "$WORK/impostor" > "$WORK/m.gz"
+IMP_ARCH_SHA="$(sha256sum "$WORK/m.gz" | cut -d' ' -f1)"
+{ echo "MIHOMO_VER=\"$MIHOMO_VER\""
+  echo "declare -A PDG_SHA256=( [mihomo-$MARCH]=\"$IMP_ARCH_SHA\" [mihomo-bin-$MARCH]=\"$PIN_BIN\" )"
+  sed -n '/^pdg_mihomo_version(){/,/^}/p'    "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_mihomo_is_version(){/,/^}/p' "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_mihomo_binary_ok(){/,/^}/p'  "$ROOT/lib/versions.sh"
+  sed -n '/^pdg_verify_sha256(){/,/^}/p'     "$ROOT/lib/versions.sh"
+} > "$WORK/repo/lib/versions.sh"
+mkold; OLD2="$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)"
+rc=$(run config.yaml active)
+[[ "$rc" != 0 ]] && ok "归档过、二进制不符 → 返回非 0(rc=$rc)" || bad "冒牌二进制被放行了"
+[[ "$(sha256sum "$BIN/mihomo" | cut -d' ' -f1)" == "$OLD2" ]] \
+  && ok "冒牌二进制**从未落盘**(旧核逐字节未动)" || bad "冒牌二进制已经写进 /usr/local/bin 了"
+grep -qE '内容与钉值不符|二进制' "$WORK/log" && ok "报错点明是二进制内容不符" \
+  || bad "报错没点明是哪一层: $(tail -2 "$WORK/log" | tr '\n' ' ')"
+
+echo "────────────────────────────────────────"
+echo "$(basename "$0"): 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-p2-runtime-fixes.sh
+++ b/tests/test-p2-runtime-fixes.sh
@@ -168,6 +168,22 @@ ctl "$(grep -c 'CY:.*不完整' <<<"$o_new")" "$(grep -c 'CY:.*不完整' <<<"$o
 mkrepo(){                               # $1=latest|behind|dirty; 打印仓库路径
   local d="$WORK/repo$1"; rm -rf "$d"; mkdir -p "$d"
   cp -a "$ROOT/lib" "$ROOT/deploy" "$d"/ 2>/dev/null || return 1
+  # ── 内核二进制桩 + 把沙箱仓库的钉值改成桩的摘要 ────────────────────────────
+  # 必须在**提交之前**做。改在提交之后, 工作树就脏了, 而「已是最新」短路的条件之一正是
+  # `git diff --quiet HEAD` —— 于是短路永远不成立, 表现成"新判据把短路弄坏了"(踩过一次)。
+  # 这个 job(lint)上没有真内核: 既没有 mosdns 夹具, 也没跑 prepare-mihomo。所以造壳,
+  # 并只把**钉值**换成本地的; 判据本体仍是生产那一份, 与 test-update-mosdns-preflight 同法。
+  mkdir -p "$WORK/kstub"
+  local _mv _osv
+  _mv="$(sed -n 's/^MIHOMO_VER="\([^"]*\)".*/\1/p' "$d/lib/versions.sh" | head -1)"
+  _osv="$(sed -n 's/^MOSDNS_VER="\([^"]*\)".*/\1/p' "$d/lib/versions.sh" | head -1)"
+  printf '#!/bin/sh\ncase "$1" in -v) echo "Mihomo Meta %s linux amd64";; esac\nexit 0\n' "$_mv" \
+    > "$WORK/kstub/mihomo"; chmod 755 "$WORK/kstub/mihomo"
+  printf '#!/bin/sh\ncase "$1" in version) echo "mosdns %s-0-gstub";; esac\nexit 0\n' "$_osv" \
+    > "$WORK/kstub/mosdns"; chmod 755 "$WORK/kstub/mosdns"
+  # 分隔符不能用 |: 模式里的 (amd64|arm64) 会把 s 命令提前截断(踩过一次)
+  sed -i -E "s#^  \[mihomo-bin-(amd64|arm64)\]=\"[0-9a-f]*\"#  [mihomo-bin-\1]=\"$(sha256sum "$WORK/kstub/mihomo" | cut -d' ' -f1)\"#" "$d/lib/versions.sh"
+  sed -i -E "s#^  \[mosdns-bin-(amd64|arm64)\]=\"[0-9a-f]*\"#  [mosdns-bin-\1]=\"$(sha256sum "$WORK/kstub/mosdns" | cut -d' ' -f1)\"#" "$d/lib/versions.sh"
   git -C "$d" init -q 2>/dev/null    # init 不动 ref, 也没法走 e2e_git(它要求目标已是仓库)
   e2e_git "$d" add -A >/dev/null 2>&1
   e2e_git "$d" -c user.email=t@t -c user.name=t commit -q -m c1
@@ -201,6 +217,18 @@ deploy_from(){                          # $1=仓库 → 按 manifest 把文件�
   install -m755 "$r/deploy/cert/proxy-gateway-restore-firewall.sh" "$WORK/bin/" 2>/dev/null || return 1
   install -m755 "$r/deploy/bot/pdg-set-token.sh" "$WORK/bin/pdg-set-token" 2>/dev/null || return 1
   install -m755 "$r/deploy/bot/pdg.sh"           "$WORK/bin/pdg"           2>/dev/null || return 1
+  # 内核二进制也算"已装文件": _update_in_sync 现在会问 pdg_mihomo_binary_ok /
+  # pdg_mosdns_binary_ok —— 「已是最新」意味着这台机器是**健康**的, 内核内容也得对上钉值。
+  # 桩由 mkrepo 造好(它必须在**提交之前**改钉值, 见那里的说明), 这里只负责装上去。
+  install -m755 "$WORK/kstub/mihomo" "$WORK/bin/mihomo" 2>/dev/null || return 1
+  install -m755 "$WORK/kstub/mosdns" "$WORK/bin/mosdns" 2>/dev/null || return 1
+  # 自证夹具真的成立 —— 钉值改没改对, 用生产判据自己问一遍
+  ( set +u; source "$r/lib/versions.sh"
+    a=$(dpkg --print-architecture 2>/dev/null || echo amd64)
+    mver="$(sed -n 's/^MIHOMO_VER="\([^"]*\)".*/\1/p' "$r/lib/versions.sh" | head -1)"
+    mosver="$(sed -n 's/^MOSDNS_VER="\([^"]*\)".*/\1/p' "$r/lib/versions.sh" | head -1)"
+    pdg_mihomo_binary_ok "$a" "$mver" "$WORK/bin/mihomo" \
+      && pdg_mosdns_binary_ok "$a" "$mosver" "$WORK/bin/mosdns" ) || return 1
 }
 
 drv_update(){                           # $1=pdg.sh $2=仓库 → 输出 + 副作用记录

--- a/tools/bump-kernel.sh
+++ b/tools/bump-kernel.sh
@@ -14,10 +14,16 @@
 # 规则、事务、回滚全走一遍 —— 那才是"这一版会不会弄坏什么"的答案来源。sing-box 1.13 砍掉
 # sniff_override_destination 那次, 正是这一层看见的。
 #
-# 信任锚仍是上游官方 Release 页(两家都不发布校验和文件, 所以是 TOFU: 首次下载即信任)。
-# 这个脚本不改变信任模型, 只是把"下载→核对→誊写"这条链自动化, 并在誊写前多做两道核对:
-#   · 本机架构那份: 真跑一次二进制, 比对它自报的版本 —— 防"哈希算对了但对象贴错了";
-#   · 跑不动的那份: 读 ELF 头的机器类型 —— 防"两次都下成了同一个架构"。
+# 信任模型(不要读成比实际更强):
+#   · 两家上游**都不发布独立的签名校验文件**(没有 .asc / .sig / minisign / SHA256SUMS.asc)。
+#   · GitHub 的 Release API 会给出**服务器侧计算的 sha256 asset digest**。这是一条
+#     **额外的交叉证据** —— 它能挡住"传输途中被改""下错了资产""本地解压出了岔子"这几类,
+#     但它**不构成独立的签名信任链**: 文件与摘要由同一方托管, 同一方被攻破时两者会一起变。
+#   · 所以底子仍是 TOFU(首次下载即信任), 这个脚本不改变信任模型, 只是把"下载→核对→誊写"
+#     自动化, 并在誊写前多做几道核对:
+#       - 官方 asset digest 交叉核对(有就必须一致, 不一致直接拒绝写文件);
+#       - 本机架构那份: 真跑一次二进制, 比对自报版本 —— 防"哈希算对了但对象贴错了";
+#       - 跑不动的那份: 读**完整 ELF 头**(magic/class/endian/e_machine)—— 防"两次下成同一架构"。
 # ─────────────────────────────────────────────────────────────────────────────
 set -uo pipefail
 
@@ -53,7 +59,10 @@ esac
 
 [[ -f "$VERSIONS" ]] || die "找不到 $VERSIONS"
 
-# 工作树必须干净 —— 否则这次改写会和别人的改动混进同一笔, 事后分不清哪行是谁写的。
+# **目标文件**必须干净 —— 否则这次改写会和别人对同一文件的改动混进一笔, 事后分不清哪行是谁写的。
+# 注意措辞: 这里查的**只有 lib/versions.sh 这一个文件**, 不是整个工作区 —— 工作区里同时
+# 有别的改动是常态, 拿它当门会让工具在正常开发中根本用不了。旧注释把范围说大了, 与实现
+# 不符; 现在文案与实现一致。
 # 只在 $ROOT **就是某个仓库的顶层**时才查: 否则(比如测试把 ROOT 指到临时目录, 而那个
 # 临时目录恰好落在另一个仓库里)git 会向上找到**无关的**仓库, 把沙箱自己的文件看成未跟踪,
 # 于是工具拒绝干活 —— 判的根本不是同一件事。
@@ -98,12 +107,51 @@ _fetch(){                       # $1=组件 $2=版本 $3=架构 $4=输出目录
 }
 FETCH="${PDG_BUMP_FETCHER:-}"
 
-# ELF 头里的 e_machine(偏移 18, 小端 2 字节): amd64=0x3E, arm64=0xB7。
-# 跑不动的那个架构就靠它 —— 光信 URL 的话, "两次都下成同一个架构"不会被发现。
-_elf_machine_ok(){
-  local f="$1" want="$2" m
-  m="$(od -An -tx1 -j18 -N2 "$f" 2>/dev/null | tr -d ' \n')"
-  case "$want" in amd64) [[ "$m" == "3e00" ]];; arm64) [[ "$m" == "b700" ]];; *) return 1;; esac
+# PDG_BUMP_SKIP_VERIFY 只对**测试取件器**有效。正式的官方下载路径不得被它绕过 —— 否则它
+# 就是一个"跳过全部证据"的环境变量后门, 而这个脚本的产出正是供应链钉值。
+# 这一问必须在取件**之前**: 放在取件之后的话, 官方路径会先因为"取件失败"而 die, 守卫
+# 永远不会被执行到, 看着有、实际等于没有。
+if [[ -n "${PDG_BUMP_SKIP_VERIFY:-}" && -z "$FETCH" ]]; then
+  die "PDG_BUMP_SKIP_VERIFY 只能与 PDG_BUMP_FETCHER(测试取件器)同时使用; 官方下载路径不接受跳过校验"
+fi
+
+# 跑不动的那个架构只能靠 ELF 头。**读完整的头**, 不是只读偏移 18 的两个字节:
+#   0-3  magic      7f 45 4c 46  (\x7fELF)   —— 只看 e_machine 的话, 一个随手伪造 18-19
+#   4    EI_CLASS   02 = ELF64                   两字节的**非 ELF 文件**就能过关
+#   5    EI_DATA    01 = 小端
+#   6    EI_VERSION 01
+#   18-19 e_machine  小端: amd64=0x003e(3e00), arm64=0x00b7(b700)
+_elf_header_ok(){
+  local f="$1" want="$2" h magic cls endian ver mach
+  h="$(od -An -tx1 -N20 "$f" 2>/dev/null | tr -d ' \n')"
+  [[ "${#h}" -ge 40 ]] || { say "  ELF 头读不满 20 字节"; return 1; }
+  magic="${h:0:8}"; cls="${h:8:2}"; endian="${h:10:2}"; ver="${h:12:2}"; mach="${h:36:4}"
+  [[ "$magic"  == "7f454c46" ]] || { say "  不是 ELF(magic=$magic)"; return 1; }
+  [[ "$cls"    == "02" ]]       || { say "  不是 ELF64(EI_CLASS=$cls)"; return 1; }
+  [[ "$endian" == "01" ]]       || { say "  不是小端(EI_DATA=$endian)"; return 1; }
+  [[ "$ver"    == "01" ]]       || { say "  EI_VERSION=$ver(期望 01)"; return 1; }
+  case "$want" in
+    amd64) [[ "$mach" == "3e00" ]] || { say "  e_machine=$mach, 不是 x86-64"; return 1; };;
+    arm64) [[ "$mach" == "b700" ]] || { say "  e_machine=$mach, 不是 AArch64"; return 1; };;
+    *) return 1;;
+  esac
+}
+
+# ── ⑦ 官方 asset digest 交叉核对 ────────────────────────────────────────────
+# 按**精确资产名**取。这一步不能用通配: mihomo 同一个 tag 下 amd64 家族就有 20+ 个相似名
+# (-compatible- / -v1- / -v2- / -v3- / -go120- / -go123-, 外加 .deb/.rpm/.pkg.tar.zst),
+# 通配一下就会抓到另一个文件, 而它同样"下载成功、哈希算得出来"。
+_asset_name(){ case "$1" in mihomo) echo "mihomo-linux-$3-$2.gz";; mosdns) echo "mosdns-linux-$3.zip";; esac; }
+_official_digest(){             # $1=组件 $2=版本 $3=架构 → stdout: sha256 十六进制(取不到则空)
+  local comp="$1" ver="$2" arch="$3" repo name out
+  case "$comp" in mihomo) repo=MetaCubeX/mihomo;; mosdns) repo=IrineSistiana/mosdns;; *) return 0;; esac
+  name="$(_asset_name "$comp" "$ver" "$arch")"
+  command -v gh >/dev/null 2>&1 || return 0
+  # 精确匹配 tag 与资产名; 命中数必须恰好 1
+  out="$(gh api "repos/$repo/releases/tags/$ver" \
+        --jq "[.assets[] | select(.name==\"$name\") | .digest] | @tsv" 2>/dev/null)" || return 0
+  [[ "$(wc -w <<<"$out")" == 1 ]] || return 0
+  printf '%s\n' "${out#sha256:}"
 }
 
 declare -A ARCHIVE_SHA BIN_SHA
@@ -117,6 +165,18 @@ for arch in amd64 arm64; do
   [[ -s "$d/archive" && -s "$d/binary" ]] || die "取件产物为空($arch)"
 
   if [[ -z "${PDG_BUMP_SKIP_VERIFY:-}" ]]; then
+    # 官方 digest 交叉核对(只在走官方下载、且 API 给得出 digest 时)
+    if [[ -z "$FETCH" ]]; then
+      _dg="$(_official_digest "$COMP" "$VER" "$arch")"
+      if [[ -n "$_dg" ]]; then
+        _got="$(sha256sum "$d/archive" | cut -d' ' -f1)"
+        [[ "$_got" == "$_dg" ]] \
+          || die "$arch 归档与官方 asset digest 不一致 —— 拒绝写文件。实得 $_got, 官方 $_dg"
+        say "  $arch 官方 asset digest ✓ 交叉核对一致"
+      else
+        say "  $arch 官方 asset digest: 取不到(无 gh / 该资产未提供)—— 少一条交叉证据, 其余核对照做"
+      fi
+    fi
     if [[ "$arch" == "$HOST_ARCH" ]]; then
       # 本机能跑: 直接问它自己是哪一版 —— 这是"哈希是否贴错对象"唯一的硬证据
       got="$("$d/binary" -v 2>/dev/null || "$d/binary" version 2>/dev/null || true)"
@@ -125,9 +185,9 @@ for arch in amd64 arm64; do
         || die "$arch 自报版本是 ${got:-读不出}, 不是 $VER —— 拒绝把这份哈希写进去"
       say "  $arch 自报版本 ✓ $VER"
     else
-      _elf_machine_ok "$d/binary" "$arch" \
-        || die "$arch 的产物不是该架构的 ELF —— 可能两次下成了同一个架构"
-      say "  $arch ELF 机器类型 ✓(本机跑不动, 只能验到这一层)"
+      _elf_header_ok "$d/binary" "$arch" \
+        || die "$arch 的产物不是该架构的 ELF64 —— 可能两次下成了同一个架构, 或根本不是 ELF"
+      say "  $arch ELF 头 ✓ magic/class/endian/e_machine 全中(本机跑不动, 只能验到这一层)"
     fi
   fi
 
@@ -137,51 +197,66 @@ for arch in amd64 arm64; do
   [[ "$COMP" == mosdns ]] && say "  $arch 二进制 sha256 = ${BIN_SHA[$arch]}"
 done
 
-# ── 改写: 逐行**替换**, 不追加 ────────────────────────────────────────────────
+# ── 改写: 全程在**同目录的暂存副本**上做, 验完再原子替换 ───────────────────
+# 为什么不能逐次直写正式文件: 这个脚本要改 3~6 行, 其中大多数是 64 位十六进制。中途任何
+# 一次替换失败(锚点没命中 / 磁盘满 / 被打断), 正式文件就停在"版本换了、第二个哈希没换"
+# 这种半套状态 —— 而那正是最坏的一种: 装机会 die 在 SHA 校验上, 报错指向供应链异常,
+# 现场根本看不出是工具写了一半。
+#
+# 暂存文件必须与目标**同目录**: mktemp 默认落 /tmp, 跨文件系统时 mv 不是原子的(会退化成
+# 复制+删除, 中途被打断同样留下半个文件)。同目录 + mv 才有 rename(2) 的原子性。
+#
 # 锚点用**行首字面量**匹配(index), 不用正则 —— 这不是风格问题:
 # `awk -v pat='^  \[mihomo-amd64\]='` 里的 `\[` 会被 awk 的 -v 当转义序列处理。gawk 把它
 # 变成裸 `[`, 于是 pat 成了字符类, 什么都匹配不上; mawk 保持原样, 照常匹配。同一份脚本在
 # Debian(mawk)上全绿、在 GitHub runner(gawk)上静默不改那两行 —— 版本号换了、哈希没换,
 # 而且没有任何报错。ENVIRON[] 取值不做转义处理, index() 也不碰正则, 两头都堵上。
-_sub(){                          # $1=行首字面量前缀 $2=整行新内容
+BEFORE_SHA="$(sha256sum "$VERSIONS" | cut -d' ' -f1)"     # ① 前像, 收尾要拿它对账
+STAGE="$(mktemp "${VERSIONS}.pdg-bump.XXXXXX")" || die "建不出暂存文件(与目标同目录)"
+# 任何非正常退出都不许留下暂存物, 也不许动正式文件
+trap 'rm -f "$STAGE" 2>/dev/null; rm -rf "$WORK" 2>/dev/null' EXIT
+cat "$VERSIONS" > "$STAGE" || die "拷贝前像到暂存失败"
+chmod --reference="$VERSIONS" "$STAGE" 2>/dev/null || true
+
+_sub(){                          # $1=行首字面量前缀 $2=整行新内容 —— **只改 $STAGE**
   local pre="$1" new="$2" n tmp
-  n=$(P="$pre" awk 'index($0, ENVIRON["P"])==1 {c++} END{print c+0}' "$VERSIONS")
+  n=$(P="$pre" awk 'index($0, ENVIRON["P"])==1 {c++} END{print c+0}' "$STAGE")
   [[ "$n" == 1 ]] || die "锚点命中 $n 次(期望 1): '$pre' —— versions.sh 换写法了, 工具要跟着改"
-  tmp="$(mktemp)"
-  P="$pre" N="$new" awk 'index($0, ENVIRON["P"])==1 { print ENVIRON["N"]; next } { print }' \
-    "$VERSIONS" > "$tmp" && cat "$tmp" > "$VERSIONS" && rm -f "$tmp"
+  tmp="$(mktemp "${STAGE}.step.XXXXXX")" || die "建不出中间文件"
+  if ! P="$pre" N="$new" awk 'index($0, ENVIRON["P"])==1 { print ENVIRON["N"]; next } { print }' \
+       "$STAGE" > "$tmp"; then rm -f "$tmp"; die "改写失败: '$pre'"; fi
+  mv -f "$tmp" "$STAGE" || { rm -f "$tmp"; die "暂存替换失败: '$pre'"; }
 }
 # 版本常量那一行: 保留行尾原有注释, 只换引号里的值
 _verline="$(K="$VER_KEY" V="$VER" awk '
-  index($0, ENVIRON["K"] "=")==1 { sub(/"[^"]*"/, "\"" ENVIRON["V"] "\""); print; exit }' "$VERSIONS")"
+  index($0, ENVIRON["K"] "=")==1 { sub(/"[^"]*"/, "\"" ENVIRON["V"] "\""); print; exit }' "$STAGE")"
 [[ -n "$_verline" ]] || die "取不到 $VER_KEY 那一行"
 _sub "${VER_KEY}=" "$_verline"
 for arch in amd64 arm64; do
   _sub "  [${COMP}-${arch}]=" "  [${COMP}-${arch}]=\"${ARCHIVE_SHA[$arch]}\""
-  if [[ "$COMP" == mosdns ]]; then
-    _sub "  [${COMP}-bin-${arch}]=" "  [${COMP}-bin-${arch}]=\"${BIN_SHA[$arch]}\""
-  fi
+  # mihomo 与 mosdns 现在都钉解压后二进制(mihomo 的那两条是本轮补的)
+  _sub "  [${COMP}-bin-${arch}]=" "  [${COMP}-bin-${arch}]=\"${BIN_SHA[$arch]}\""
 done
 
-bash -n "$VERSIONS" || die "改写后 $VERSIONS 语法坏了 —— 请 git checkout 还原后报告"
-
-# 写完读回来自查。这是钉供应链哈希的工具, "我以为我写对了"不算证据 —— 逐项把文件里的值
-# 读出来与刚算的比, 不一致就把**两个值都摆出来**再退出, 而不是留一个静默写错的钉值。
-_readback(){                     # $1=键名 → 打印文件里那一份
-  grep -oE "^  \[$1\]=\"[0-9a-f]*\"" "$VERSIONS" | head -1 | grep -oE '[0-9a-f]{16,}' | head -1
-}
-_rb="$(grep -oE "^${VER_KEY}=\"[^\"]*\"" "$VERSIONS" | head -1 | sed -e 's/.*="//' -e 's/"$//')"
-[[ "$_rb" == "$VER" ]] || die "回读 $VER_KEY = '${_rb:-<空>}', 期望 '$VER'"
+# ── 全部验完, 才谈替换正式文件 ──────────────────────────────────────────────
+bash -n "$STAGE" || die "改写后语法坏了 —— 正式文件未动"
+_readback(){ grep -oE "^  \[$1\]=\"[0-9a-f]*\"" "$STAGE" | head -1 | grep -oE '[0-9a-f]{16,}' | head -1; }
+_rb="$(grep -oE "^${VER_KEY}=\"[^\"]*\"" "$STAGE" | head -1 | sed -e 's/.*="//' -e 's/"$//')"
+[[ "$_rb" == "$VER" ]] || die "回读 $VER_KEY = '${_rb:-<空>}', 期望 '$VER' —— 正式文件未动"
 for arch in amd64 arm64; do
   _rb="$(_readback "${COMP}-${arch}")"
   [[ "$_rb" == "${ARCHIVE_SHA[$arch]}" ]] \
-    || die "回读 [${COMP}-${arch}] = '${_rb:-<空>}', 期望 '${ARCHIVE_SHA[$arch]}'"
-  if [[ "$COMP" == mosdns ]]; then
-    _rb="$(_readback "${COMP}-bin-${arch}")"
-    [[ "$_rb" == "${BIN_SHA[$arch]}" ]] \
-      || die "回读 [${COMP}-bin-${arch}] = '${_rb:-<空>}', 期望 '${BIN_SHA[$arch]}'"
-  fi
+    || die "回读 [${COMP}-${arch}] = '${_rb:-<空>}', 期望 '${ARCHIVE_SHA[$arch]}' —— 正式文件未动"
+  _rb="$(_readback "${COMP}-bin-${arch}")"
+  [[ "$_rb" == "${BIN_SHA[$arch]}" ]] \
+    || die "回读 [${COMP}-bin-${arch}] = '${_rb:-<空>}', 期望 '${BIN_SHA[$arch]}' —— 正式文件未动"
 done
+# 正式文件到这一刻必须仍然等于前像 —— 若不等, 说明有别的东西在改它, 停手
+[[ "$(sha256sum "$VERSIONS" | cut -d' ' -f1)" == "$BEFORE_SHA" ]] \
+  || die "改写期间 $VERSIONS 被别的东西动过 —— 拒绝覆盖"
+mv -f "$STAGE" "$VERSIONS" || die "原子替换失败 —— 正式文件未动"
+STAGE=""                       # 已经搬走, 别在 trap 里删掉正式文件
+trap 'rm -rf "$WORK" 2>/dev/null' EXIT
 say "  回读自查 ✓ 文件里的值与刚算的逐项一致"
 
 say ""


### PR DESCRIPTION
## Summary

- mihomo 的安装/换核短路从「只看 PATH 上的自报版本」改成「绝对路径 + 退出码 + 自报版本 + 解压后二进制摘要」，判据 `pdg_mihomo_binary_ok` 与 `install.sh`、doctor 同源。
- doctor 不再对任何可解析的版本报绿：拆成 `check_core_version`（自报版本）与 `check_mihomo_binary`（文件内容），缺失/版本不符/摘要不符 → fail，无从对照 → warn 且明说无结论。
- 顶层 `pdg update` 的「已是最新 / 已装文件一致」门不再把内核内容漂移的机器挡在修复之外。
- 真实换核有测试：成功、配置检查失败回退、启动不稳定回退，三态都验旧核逐字节还原、无 `.prev` 残留、无错误成功文案。
- `tools/bump-kernel.sh` 改为「同目录候选文件 → 全部验完 → 原子替换」，并把 GitHub asset digest 作为**额外交叉证据**（不是独立签名信任链）。

### 范围扩张说明

`_update_in_sync` 的同一处缺陷同样影响 mosdns：顶层短路只比项目文件，不看内核二进制。本轮把 **mosdns 一并纳入顶层完整性门**。

**没有**修改 mosdns 的解析行为、版本、配置或换版路径。

### 本轮追加的两个 E2E 夹具闭包

1. **`e2e_git` 收口**：两处新夹具原本裸调 `git config/add/commit`，绕过 `tests/test-e2e-repo-guard.py`（该守卫源于 07-31 共享仓库 tag/remote 被改写的事故）。
2. **mihomo 夹具钉值闭包**：`e2e_fetch_mihomo` 补齐取件闭包；五支自带 shell 桩的用例（`e2e-install` / `e2e-upgrade-from-release` / `e2e-rescue-migration-lock` / `e2e-update` / `e2e-update-preserve-userdata`）统一改用 `e2e_seed_mihomo_bin`，语义对齐 `e2e_seed_mosdns_bin`；新增静态守卫，桩再长回来即转红。

取件复用既有机制：mihomo 并入**同一个 producer job、同一个 artifact**，消费者用 `install-mihomo-artifact.sh` 做四层复核。全 run 官方 Release 取件 **1 次**，每个 matrix 格 **0 次**。

## Old red runs (保留，未 rerun)

| run | head | 结论 | 根因 |
|---|---|---|---|
| `33348976467` | `0ca9af4` | failure，6 job | 夹具绕过 `e2e_git`；mihomo 取件无钉值闭包 |
| `33353591548` | `244a5ca` | failure，5 job | 五支用例内联 shell 桩（`sha256("stub")=725c546b990dd1b4`） |
| `33363778997` | `612ac10` | failure，23 job | 我给容器 job 的新步骤误加 `sudo`（镜像里没有） |

三者均保持 `attempt=1`，未 rerun。

## Tests — exact-head run `33366253410`

- `workflow_dispatch`，`attempt=1`，head `39e763e821f213a1280c6e4373f76bc95434366b`
- **31/31 jobs success；622/622 steps success；failure 0，skipped 0**
- 此前红过的六个 job 全部 success：`lint`、`e2e-serial`、`E2E e2e-install.sh`、`E2E e2e-upgrade-from-release.sh`、`E2E e2e-rescue-migration-lock.sh`、同 (iOS)
- 日志实证：repo guard 通过；mihomo 四层复核执行 **24 次**（mosdns 29 次）；`prepare-mihomo.sh` 全 run 下载 **1 次**；夹具播种 0 失败；无 `FATAL`；无残留
- 日志里 8 处 `[FAIL]`/「内容与官方钉值不一致」全部落在 `[OK]` 行内，是负向用例**引用的期望错误文案**，非真实失败

与 main 基线 `33304488435` 的集合差异：job 名 +1/−1（producer 由 `取件 mosdns` 改名为 `取件 mosdns + mihomo`，非删除）；(job,step) +37/−10，其中 9 条"删除"是该 job 改名后同名步骤换归属，1 条是 `lint` 由「自己准备 mihomo」改为「消费 artifact」。**没有任何既有 step 被真正移除。**

新增测试（CI 内执行）：mihomo 完整性闭包 17、doctor 四态 23、真实换核 27、E2E mihomo 夹具闭包 40、bump 工具 71（含新增 22）、repo guard 11。

**负控仅本地执行，未进 CI**：mihomo 完整性负控 22/0（14 变异格）、E2E 夹具闭包负控 15/0（10 变异格 + 2 反向对照）。它们会反复改写工作区里的生产文件，不适合进 CI。

## Provider POC — 未落生产

- v1.19.30「严格校验 Clash 通配符导致 provider 被拒」的前提**未能复现**：domain 与 classical 两种 behavior 下九种通配符写法全部被接受；非法内容是被**静默丢弃**而非拒绝。
- `mihomo -t` **不证明 provider 内容已加载**：provider 文件根本不存在时它仍打印 "test is successful" rc=0（对照：配置本身语法错时 `-t` 确实 rc=1）。
- 服务 active 不证明 provider 有效：五种破坏形态服务全部 active。
- 唯一运行期证据是 `127.0.0.1:9090` 的 `/providers/rules`，而 `secret` 只在面板开启时写入 → 默认部署无认证；且 `ruleCount` 分不出「N 条有意义」与「N 条垃圾」。
- 因此 **`check_rulesets()` 一个字节未改**；`-ext-ctl-unix` 属后续架构裁决，不在本 PR。

## Known boundaries（均未解决）

- provider 运行期证据与 `-ext-ctl-unix` 待架构裁决
- `check_rulesets` 的「格式均可被 mihomo 加载」文案仍不够真实
- `install.sh` 的 mihomo `curl` 缺独立错误分类（下载失败/截断与摘要不符报成同一种错），单独挂 P2，本 PR 未混入
- 仓库另有约 63 处 `pipefail + grep -q` 同形态（`grep -q` 命中即关管道 → 上游 SIGPIPE → 条件反转），未在本 PR 批量修
- 本机无 PyYAML（`test-ci-mosdns-topology.py` 本地红、CI 真实覆盖）、本机无 Docker（容器 E2E 证据全部来自 exact-head CI）
