### PR TITLE
fix(install): name download failures and pin the real pipefail risk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,12 @@ jobs:
       - name: "换内核工具契约 (只改钉值不提交/两种钉值形状/取件后核对版本与架构/离线改写)"
         run: bash tests/test-bump-kernel-tool.sh
 
+      - name: "装机取件的错误分类 (下载失败/空产物/内容不符报成三种话; 两个内核对称)"
+        run: bash tests/test-download-error-classification.sh
+
+      - name: "pipefail + grep -q 条件反转守卫 (只拦真风险: 整体透传 >64KiB 文件)"
+        run: python3 tests/test-pipefail-grepq-guard.py
+
       - name: "E2E 夹具必须播真 mosdns (shell 假桩被生产判据拒绝 / 真钉定二进制被接受 / 夹具不联网)"
         run: python3 tests/test-e2e-mosdns-fixture.py
 

--- a/install.sh
+++ b/install.sh
@@ -456,7 +456,15 @@ systemctl enable --now vnstat >/dev/null 2>&1 || true   # 网卡流量统计(轻
 if ! pdg_mosdns_binary_ok "$MARCH" "$MOSDNS_VER" /usr/local/bin/mosdns; then
   c_g "下载 mosdns $MOSDNS_VER ($MARCH)…"
   t=$(mktemp -d)
-  curl -fsSL "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-${MARCH}.zip" -o "$t/m.zip"
+  # 取件这一步要有自己的具名失败。裸 curl 的两种坏形态都会让人查错方向:
+  #   · curl 真失败(DNS 不通 / 404 / 超时)→ set -e 在这一行静默中止, EXIT trap 去回滚,
+  #     用户看到的只有"回滚"和 curl 的数字退出码, 从头到尾没有一句说是取件挂了;
+  #   · curl 返回 0 但产物是空的(磁盘满 / 传输被截成 0 字节)→ 空文件的 SHA 当然不符,
+  #     于是报成"供应链异常", 读起来像被投毒, 实际只是没下下来。
+  curl -fsSL "https://github.com/IrineSistiana/mosdns/releases/download/${MOSDNS_VER}/mosdns-linux-${MARCH}.zip" -o "$t/m.zip" \
+    || { rm -rf "$t"; die "下载 mosdns $MOSDNS_VER ($MARCH) 失败(网络不通 / 该版本不存在 / 超时)。这不是校验问题, 是没取到件。"; }
+  [[ -s "$t/m.zip" ]] \
+    || { rm -rf "$t"; die "下载 mosdns $MOSDNS_VER ($MARCH) 得到空文件(磁盘满? 传输被截断?)。同样不是校验问题。"; }
   pdg_verify_sha256 "$t/m.zip" "${PDG_SHA256[mosdns-$MARCH]:-}" "mosdns $MOSDNS_VER ($MARCH)" \
     || { rm -rf "$t"; die "mosdns 二进制校验未通过 → 拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)"; }
   _stash_bin /usr/local/bin/mosdns || die "备份既有 mosdns 失败 → 中止(不在无法回退的前提下覆盖二进制)。"
@@ -486,7 +494,11 @@ CORE_SVC=mihomo
 if ! pdg_mihomo_binary_ok "$MARCH" "$MIHOMO_VER" /usr/local/bin/mihomo; then
   c_g "下载 mihomo $MIHOMO_VER ($MARCH)…"
   t=$(mktemp -d)
-  curl -fsSL "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-${MARCH}-${MIHOMO_VER}.gz" -o "$t/mihomo.gz"
+  # 与 mosdns 那一处对称: 取件失败与"下到的东西不对"必须报成两种话。
+  curl -fsSL "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VER}/mihomo-linux-${MARCH}-${MIHOMO_VER}.gz" -o "$t/mihomo.gz" \
+    || { rm -rf "$t"; die "下载 mihomo $MIHOMO_VER ($MARCH) 失败(网络不通 / 该版本不存在 / 超时)。这不是校验问题, 是没取到件。"; }
+  [[ -s "$t/mihomo.gz" ]] \
+    || { rm -rf "$t"; die "下载 mihomo $MIHOMO_VER ($MARCH) 得到空文件(磁盘满? 传输被截断?)。同样不是校验问题。"; }
   pdg_verify_sha256 "$t/mihomo.gz" "${PDG_SHA256[mihomo-$MARCH]:-}" "mihomo $MIHOMO_VER ($MARCH)" \
     || { rm -rf "$t"; die "mihomo 归档校验未通过 → 拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)"; }
   gunzip -c "$t/mihomo.gz" > "$t/mihomo"

--- a/tests/test-download-error-classification.sh
+++ b/tests/test-download-error-classification.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 装机取件必须把"下载没成"和"下到的东西不对"分开报。
+#
+# 修之前 install.sh 的两处取件都是裸 curl, 没有自己的错误检查:
+#
+#     curl -fsSL "https://…/mosdns-linux-${MARCH}.zip" -o "$t/m.zip"
+#     pdg_verify_sha256 "$t/m.zip" …
+#
+# 于是有两种很不一样的故障, 用户都看不出是取件出的问题:
+#   · curl 真失败(DNS 不通 / 404 / 超时) → `set -euo pipefail` 在那一行直接中止 →
+#     EXIT trap 跑 rollback。用户看到的是"回滚"和 curl 的数字退出码(6/22/28), 从头到尾
+#     没有一行说"下载失败"。排错方向会被带偏到安装逻辑上。
+#   · curl 返回 0 但内容不对(代理错误页 / 缓存 / curl 没察觉的截断) → 掉进 SHA 校验,
+#     报"拒绝安装(供应链异常, 或版本与 lib/versions.sh 不符)" —— 读起来像被投毒, 实际
+#     可能只是网络给了一份垃圾。
+#
+# 两个内核对称: mosdns 与 mihomo 的取件都要具名。
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/pdg-dlerr.XXXXXX")"; trap 'rm -rf "$WORK"' EXIT
+pass=0; nfail=0
+ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
+bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
+# shellcheck source=tests/repoguard.sh
+source "$ROOT/tests/repoguard.sh"
+
+SRC="$ROOT/install.sh"
+decom(){ sed -E 's/^[[:space:]]*#.*$//' "$SRC"; }
+
+echo "══ 1. 两处取件都要有自己的错误检查 ══"
+# 判据落在**去注释后的代码**上: 注释里出现 curl 不算数。
+for comp in mosdns mihomo; do
+  line="$(decom | grep -nE "curl -fsSL \"https://github\.com/[A-Za-z]+/$comp/releases" | head -1)"
+  if [[ -z "$line" ]]; then bad "[$comp] 找不到取件那一行(install.sh 换写法了?)"; continue; fi
+  n="${line%%:*}"
+  # 只取 curl **这一条语句**(跟着反斜杠续行走), 不把下一条命令算进来。
+  # 第一版取了固定 3 行, 于是 pdg_verify_sha256 那行的 `|| {` 被当成了 curl 的错误处置,
+  # 在生产代码根本没改的情况下报 [OK]。
+  # curl 这一条语句本身(跟着反斜杠续行走)—— 用来判"curl 有没有自己的错误处置"。
+  # 不能取固定行数: 第一版取 3 行, 把下一条 pdg_verify_sha256 的 `|| {` 当成了 curl 的,
+  # 于是生产代码没改也报 [OK]。
+  stmt="$(decom | awk -v s="$n" 'NR>=s { print; if ($0 !~ /\\$/) exit }')"
+  # 取件到校验**之间**的全部代码 —— 用来判"有没有检查产物非空"。非空检查是紧随其后的
+  # 另一条语句, 落在 stmt 之外, 所以这两问要用两个窗口。
+  blk="$(decom | awk -v s="$n" 'NR>=s { if ($0 ~ /pdg_verify_sha256/) exit; print }')"
+  if grep -qE '\|\| *(die|\{)' <<<"$stmt"; then ok "[$comp] curl 有显式错误处置"
+  else bad "[$comp] curl 后面没有错误处置 —— 失败时靠 set -e 静默中止, 用户看不到是取件挂了"; fi
+  if grep -qE '下载|取件' <<<"$stmt"; then ok "[$comp] 失败文案点名「下载/取件」"
+  else bad "[$comp] 失败文案没点名取件这一层"; fi
+  if grep -qE '\-s "\$t/|\[\[ -s ' <<<"$blk"; then ok "[$comp] 检查产物非空(挡住 0 字节/截断成空)"
+  else bad "[$comp] 没检查产物非空"; fi
+done
+
+echo
+echo "══ 2. 行为: 三种故障必须报成三种话 ══"
+# 把取件那一段原样抽出来跑, 不在测试里另抄一份。
+extract(){   # $1=组件 → 打印"curl 行 + 后面 4 行"
+  local comp="$1" n
+  n="$(decom | grep -nE "curl -fsSL \"https://github\.com/[A-Za-z]+/$comp/releases" | head -1 | cut -d: -f1)"
+  [[ -n "$n" ]] || return 1
+  decom | sed -n "${n},$((n+5))p"
+}
+run(){       # $1=组件 $2=curl 行为(fail|empty|garbage) → 输出
+  local comp="$1" mode="$2"
+  local d="$WORK/$comp-$mode"
+  rm -rf "$d"; mkdir -p "$d/bin"
+  case "$mode" in
+    fail)    printf '#!/bin/sh\nexit 6\n' > "$d/bin/curl";;
+    empty)   printf '#!/bin/sh\no=""; p=""; for a in "$@"; do [ "$p" = -o ] && o="$a"; p="$a"; done; : > "$o"; exit 0\n' > "$d/bin/curl";;
+    garbage) printf '#!/bin/sh\no=""; p=""; for a in "$@"; do [ "$p" = -o ] && o="$a"; p="$a"; done; printf garbage > "$o"; exit 0\n' > "$d/bin/curl";;
+  esac
+  chmod 755 "$d/bin/curl"
+  { echo 'set -euo pipefail'
+    echo 'die(){ echo "[x] $*" >&2; exit 1; }'
+    echo 'c_g(){ echo "$*"; }'
+    # 钉值取真的那一份, 于是 garbage 一定不符
+    echo "source '$ROOT/lib/versions.sh'"
+    echo 'MARCH=amd64'
+    echo "t='$d'"
+    echo '_stash_bin(){ return 0; }'
+    echo 'install(){ return 0; }'
+    echo 'unzip(){ return 0; }'
+    echo 'gunzip(){ return 0; }'
+    extract "$comp"
+  } > "$d/run.sh"
+  PATH="$d/bin:$PATH" bash "$d/run.sh" 2>&1
+}
+for comp in mosdns mihomo; do
+  o="$(run "$comp" fail)"
+  if grep -qE '下载|取件' <<<"$o"; then ok "[$comp] curl 失败 → 具名说是取件挂了"
+  else bad "[$comp] curl 失败没有具名(实得: $(tr '\n' ' ' <<<"$o" | cut -c1-70))"; fi
+  # 这一条不能在"输出为空"时也算过 —— 空输出当然不含 SHA 字样, 那是"什么都没说",
+  # 不是"说对了"。必须先要求它真的说了话。
+  if [[ -z "${o// /}" ]]; then bad "[$comp] curl 失败时一个字都没说(被 set -e 静默中止)"
+  elif grep -qE 'SHA256 校验失败' <<<"$o"; then bad "[$comp] curl 失败却报成 SHA 校验失败(诊断被带偏)"
+  else ok "[$comp] curl 失败: 说了话, 且不冒充摘要问题"; fi
+
+  o="$(run "$comp" empty)"
+  if grep -qE '空|截断|下载|取件' <<<"$o"; then ok "[$comp] 产物为空 → 具名"
+  else bad "[$comp] 产物为空没有具名(实得: $(tr '\n' ' ' <<<"$o" | cut -c1-70))"; fi
+
+  o="$(run "$comp" garbage)"
+  if grep -qE 'SHA256 校验失败|校验未通过|不符' <<<"$o"; then ok "[$comp] 内容不对 → 仍然按摘要不符报(这一类没有被改掉)"
+  else bad "[$comp] 内容不对时反而不报摘要问题了(实得: $(tr '\n' ' ' <<<"$o" | cut -c1-70))"; fi
+done
+
+echo "────────────────────────────────────────"
+echo "$(basename "$0"): 通过 $pass, 失败 $nfail"
+[[ "$nfail" == 0 ]]

--- a/tests/test-pipefail-grepq-guard.py
+++ b/tests/test-pipefail-grepq-guard.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""`set -o pipefail` + `| grep -q` 的条件反转: 守住真实风险, 而不是守住形态。
+
+机理: `grep -q` 一命中就退出并关掉管道。上游如果**还在写**, 就挨 SIGPIPE(退出码 141),
+pipefail 把整条管道判成失败 —— 于是 `if 上游 | grep -q P; then` 在**命中时走 else 分支**,
+条件整个反过来, 而且没有任何报错。
+
+但这不是"只要用了 `| grep -q` 就有问题"。决定因素是**上游的输出量**能不能撑爆管道缓冲
+(Linux 上 64KiB): 输出装得下时上游早就写完退出了, 根本没机会挨 SIGPIPE。本仓实测:
+
+    文件 418 / 20508 字节   → rc=0    (正常)
+    文件 205008 字节        → rc=141  (反转)
+    install.sh 整份透传(72642 字节) → rc=141
+
+注意"读了多大"与"写了多少"是两回事: `sed -n '500p' pdg.sh` 读 416KB 却只输出一行,
+写完就不再写, 永远不会反转。按形态数会得出"仓库里有 60 处债务"的结论 —— 而按真实判据
+(整体透传 >64KiB 文件)数, 是 0 处。这支守卫钉的是后者。
+
+历史: 这个坑在本仓唯一一次真正触发, 是一段新写的测试代码把 install.sh 整份透传给
+`grep -q`, 结果两条断言在生产代码没改的情况下报绿。
+"""
+import io
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+PIPE_BUF = 64 * 1024
+
+PASS = [0]
+FAIL = [0]
+def ok(m): print("[OK]   %s" % m); PASS[0] += 1
+def bad(m): print("[FAIL] %s" % m); FAIL[0] += 1
+
+
+print("══ 1. 判据本身是真的(现场实测, 不背书本)══")
+def probe(nbytes):
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        f.write("MATCHME\n" + ("x" * 40 + "\n") * (nbytes // 41))
+        p = f.name
+    try:
+        r = subprocess.run(["bash", "-c", "set -o pipefail; cat %s | grep -q MATCHME" % p],
+                           capture_output=True)
+        return r.returncode, os.path.getsize(p)
+    finally:
+        os.unlink(p)
+rc_small, sz_small = probe(8 * 1024)
+rc_big, sz_big = probe(512 * 1024)
+(ok if rc_small == 0 else bad)("小于缓冲(%d 字节)时不反转(rc=%d)" % (sz_small, rc_small))
+(ok if rc_big != 0 else bad)("远大于缓冲(%d 字节)时确实反转(rc=%d) —— 判据成立" % (sz_big, rc_big))
+
+print()
+print("══ 2. 哪些文件大到能撑爆缓冲(动态取, 文件长大了自动纳入)══")
+big = {}
+out = subprocess.run(["git", "ls-files"], cwd=ROOT, capture_output=True, text=True).stdout.split()
+for rel in out:
+    p = os.path.join(ROOT, rel)
+    try:
+        sz = os.path.getsize(p)
+    except OSError:
+        continue
+    if sz > PIPE_BUF:
+        big[os.path.basename(rel)] = sz
+print("   共 %d 个(仅列文本类前 6 个): %s" % (
+    len(big), ", ".join("%s(%d)" % (k, v) for k, v in sorted(big.items())[:6])))
+(ok if big else bad)("取到了大文件清单")
+
+print()
+print("══ 3. 扫描: pipefail 脚本里有没有「整体透传大文件 → grep -q」══")
+# 上游被这些形态限制过输出的, 都不算危险: sed -n / 地址范围 / head / grep -m / tail
+LIMITED = re.compile(r"sed\s+-n|/\s*,\s*/|\bhead\b|\btail\b|grep[^|]*\s-m\s*\d")
+PIPEQ = re.compile(r"\|\s*grep\s+-q")
+offenders = []
+scanned = 0
+for fn in sorted(os.listdir(HERE)):
+    if not fn.endswith(".sh"):
+        continue
+    path = os.path.join(HERE, fn)
+    txt = io.open(path, encoding="utf-8", errors="replace").read()
+    if not re.search(r"set\s+-[a-z]*o?\s*pipefail|set\s+-o\s+pipefail", txt):
+        continue
+    for i, line in enumerate(txt.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        code = line.split("#")[0]
+        if not PIPEQ.search(code):
+            continue
+        scanned += 1
+        up = code.split("|")[0]
+        if LIMITED.search(up):
+            continue
+        # 只有**文本处理命令在读这个文件**才算透传。文件名出现在命令行里不等于被透传 ——
+        # `python3 .../pdgtx.py pending` 里 pdgtx.py 是被执行的脚本, 它的输出是 pending
+        # 列表(很小), 不是那 110KB 源码。第一版没区分这一点, 当场报了一个假阳性,
+        # 差一点就去"修"一处根本没问题的代码。
+        for name, sz in big.items():
+            if not re.search(r"(?:^|[;&|(]|\s)(cat|sed|awk|grep|tac|nl|expand|tr|cut)\b[^|]*"
+                             + re.escape(name), up):
+                continue
+            offenders.append("%s:%d  %s(%d 字节) 整体透传" % (fn, i, name, sz))
+            break
+print("   扫了 %d 处 `| grep -q`(仅限开了 pipefail 的脚本)" % scanned)
+if offenders:
+    bad("发现整体透传大文件到 grep -q —— 条件会在命中时反转:")
+    for o in offenders:
+        print("       " + o)
+    print("       改法: 先收进变量再判(out=$(上游); grep -q P <<<\"$out\"),")
+    print("             或用计数(  [[ \"$(上游 | grep -c P || true)\" != 0 ]]  ),")
+    print("             或给上游限量(sed -n / head)。")
+else:
+    ok("没有整体透传大文件到 grep -q 的调用点(%d 处全部安全)" % scanned)
+
+print("-" * 62)
+print("test-pipefail-grepq-guard.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
两项独立的"让失败诚实"的修复，互不依赖，合在一个 PR 是因为它们同源：都在处理"出错时说的话对不对"。

## 1. 装机取件的错误分类（生产改动）

`install.sh` 两处内核取件原本都是裸 `curl`，两种很不一样的故障都看不出是取件出的问题：

- **curl 真失败**（DNS 不通 / 404 / 超时）→ `set -euo pipefail` 在那一行中止 → EXIT trap 去回滚。**实测失败路径一个字都不打印**，用户只看到"回滚"和 curl 的数字退出码。
- **产物为空**（磁盘满 / 截断成 0 字节）→ 掉进摘要校验 → 报「拒绝安装（供应链异常）」。读起来像被投毒，实际只是没下下来。实测确实报成 `SHA256 校验失败`。

两处现在各自具名失败并检查产物非空，文案明说**这不是校验问题，是没取到件**。**下到的东西内容不对时仍然按摘要不符报**——那一类没有被改掉，有断言钉着。

mosdns 与 mihomo 对称处理（原先两处一样都缺）。

## 2. pipefail + `grep -q` 守卫（只加测试）

**这一条是来撤销一个虚报的台账项的，不是来"修 63 处"的。**

机理：`grep -q` 一命中就关管道，上游若**还在写**就挨 SIGPIPE，pipefail 把整条管道判成失败——`if 上游 | grep -q P` 于是在命中时走 else 分支，条件反转且无报错。

但决定因素是**上游的输出量**能否撑爆 64KiB 管道缓冲，不是它读了多大的文件。本仓实测：

```
8KiB   → rc=0    不反转
512KiB → rc=141  反转
sed -n '500p' pdg.sh  读 416KiB 但只输出一行 → 安全
```

按形态数，本仓有 60 处 `| grep -q`；**按真实判据数，是 0 处**。此前几轮报的「约 63 处 pipefail 债务」是按形态数的，属虚报，本 PR 撤销该结论。唯一真正触发过的是一段新写的测试代码（整份透传 install.sh），当时已修。

没有去机械改那 60 处：改动有引入回归的风险，收益是零。改为加守卫钉住判据——它每次运行都**现场实测**判据成立、**动态取** >64KiB 文件清单、只在"文本处理命令整份透传大文件"时判红。

守卫第一版把 `python3 .../pdgtx.py pending` 误报为危险（脚本名匹配上了），差点导致我去改一处根本没问题的代码；判据已收紧为不认解释器参数。

## Tests

exact-head run `33394573087`：`workflow_dispatch`、`attempt=1`、head `e9b3a8c12964079cd517cfdd7fb4231448b41e45`、**31/31 jobs、624/624 steps success，failure/skipped/cancelled 全 0**。

两支新测试在 CI 中**确实被执行并通过**（不是登记了没跑）：`装机取件的错误分类`、`pipefail + grep -q 条件反转守卫`。

与 main 基线 `33380390679` 的集合差异：job 名 +0/−0，(job,step) **+2/−0**，新增的两条正是上面两支登记。日志里 7 处 `[FAIL]` 全部落在 `[OK]` 行内（负向用例引用的期望文案），无 `FATAL`。

本地：错误分类 14/0（负控 7/0）、守卫 4/0（负控 3 格：种真危险形态转红并点名、解释器参数不误报、限量形态不误报）。**负控仅本地执行，未进 CI**——它们要反复改写生产文件。

## 边界

- 本 PR **不动** `deploy/`、`lib/`、`tools/`、README、CHANGELOG（均 0 处改动）。
- 两支新测试的 CI 登记都落在第一笔提交里，而守卫文件由第二笔引入——单独 checkout 第一笔时 CI 会红。分支 head 完整，已发布的提交不改写。
- 仍未解决：provider 运行期证据与 `-ext-ctl-unix` 待架构裁决；`check_rulesets` 文案仍不实；本机无 PyYAML / 无 Docker。
