### PR TITLE
test(fixture): 一支测试悄悄改行去下载了 (v1.11.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,27 @@ jobs:
       - name: "校验并安装钉定 mosdns (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
         run: sudo -E bash tests/install-mosdns-artifact.sh /tmp/mosdns-fixture
 
+      # 需要真内核的测试共用这一份, 放到 tests/.bin/。**必须排在所有用例之前** —— 它以前
+      # 紧挨着自己的消费者放在半程, 而 test-migrate-drop-singbox.sh 排在它前面就跑了。
+      # v1.11.7 把装核判据收紧成"问绝对路径上的真文件 + 内容摘要"之后, 那支用例的沙箱根里
+      # 没有钉死版可播, 判据恒假 → 每跑一次真去 GitHub 下 8 次 mihomo。它不报错、断言数不变、
+      # 照样全绿, 只是从确定性测试退化成网络运气的函数, 直到 run 33455929038 撞上一次
+      # connection reset 才红。**备件排在哪一步, 本身就是判据的一部分。**
+      # 取件**不在这里做** —— 走与 mosdns
+      # 同一个 artifact(producer 每 run 每架构只取一次件), 这里只做四层复核后装到位。
+      # 以前这一步自己跑准备脚本, 那样全 run 就有两处取件(这里一处、producer 一处),
+      # 而 tests/test-rescue-sets.py 正是钉着"只准备一次"这条(判据按字面数出现次数,
+      # 所以这段注释也不能把那条命令原样写出来)。
+      # CI 上必须**严格模式** —— 缺二进制要判失败, 不许把关键校验变成绿灯跳过。
+      # 这一步**不需要 sudo**(与同 job 的 mosdns 步不同): 它装到工作区的 tests/.bin/,
+      # 不写 /usr/local/bin。容器里的 e2e 各 job 则是本来就 root、镜像里没有 sudo。
+      - name: "校验并安装钉定 mihomo 到 tests/.bin (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
+        run: |
+          set -euo pipefail
+          mkdir -p tests/.bin
+          bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture "" "$PWD/tests/.bin/mihomo"
+
+
 
       - name: Python 语法 (py_compile)
         run: python3 -m py_compile deploy/bot/*.py tests/*.py
@@ -472,6 +493,9 @@ jobs:
       - name: "pipefail + grep -q 条件反转守卫 (只拦真风险: 整体透传 >64KiB 文件)"
         run: python3 tests/test-pipefail-grepq-guard.py
 
+      - name: "沙箱夹具不得偷偷联网 (抽了含 curl 的生产函数就必须自带禁令桩)"
+        run: python3 tests/test-fixture-network-guard.py
+
       - name: "E2E 夹具必须播真 mosdns (shell 假桩被生产判据拒绝 / 真钉定二进制被接受 / 夹具不联网)"
         run: python3 tests/test-e2e-mosdns-fixture.py
 
@@ -745,20 +769,6 @@ jobs:
 
       - name: "渲染判废默认安全 (pdgtx 缺失/损坏/旧版时 str/repr/审计均不含用户值)"
         run: python3 tests/test-render-refusal.py
-
-      # 需要真内核的测试共用这一份, 放到 tests/.bin/。取件**不在这里做** —— 走与 mosdns
-      # 同一个 artifact(producer 每 run 每架构只取一次件), 这里只做四层复核后装到位。
-      # 以前这一步自己跑准备脚本, 那样全 run 就有两处取件(这里一处、producer 一处),
-      # 而 tests/test-rescue-sets.py 正是钉着"只准备一次"这条(判据按字面数出现次数,
-      # 所以这段注释也不能把那条命令原样写出来)。
-      # CI 上必须**严格模式** —— 缺二进制要判失败, 不许把关键校验变成绿灯跳过。
-      # 这一步**不需要 sudo**(与同 job 的 mosdns 步不同): 它装到工作区的 tests/.bin/,
-      # 不写 /usr/local/bin。容器里的 e2e 各 job 则是本来就 root、镜像里没有 sudo。
-      - name: "校验并安装钉定 mihomo 到 tests/.bin (自算 SHA / manifest 交叉 / 自报版本 / 生产判据)"
-        run: |
-          set -euo pipefail
-          mkdir -p tests/.bin
-          bash tests/install-mihomo-artifact.sh /tmp/mosdns-fixture "" "$PWD/tests/.bin/mihomo"
 
       - name: "mihomo 完整性闭包 (绝对路径+退出码+自报版本+内容摘要; PATH 影子无效; 内容漂移仍可修)"
         run: bash tests/test-mihomo-integrity.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 本项目按语义化 `v1.x` tag 正式发布;以下按版本/日期记录主要变化,完整提交见 git 历史。
 
+## 2026-09-01 — v1.11.8(一支测试悄悄改行去下载了)
+
+**只动测试与 CI, 不动任何生产代码。** 装机、更新、换核、迁移的行为一字未改。
+
+### main 上那个红灯不是 flake
+
+`f47c74ab` 的 lint 红在 `tests/test-migrate-drop-singbox.sh` 第 2 格, 表层是
+`curl: (35) Recv failure: Connection reset by peer`。根因在 v1.11.7:
+
+那一版把 `_activate_mihomo_core` 的跳过判据从 `pdg_mihomo_is_version`(只问自报版本、走 PATH)
+换成 `pdg_mihomo_binary_ok`(问绝对路径上的真文件 + 内容摘要)。**生产侧这是对的**, 它堵的正是
+上一版列的那个后门。但这支测试的 `mihomo()` 只是个 shell 函数桩、沙箱根里从来没有那个文件,
+判据于是恒假 —— 它从 v1.11.7 起**每跑一次就真去 GitHub 下 8 次 mihomo**(约 100MB/run)。
+
+这个退化没有任何信号: 不报错、断言数不变、照样 18/0。它只是从"确定性测试"变成了"网络运气的
+函数"。v1.11.7 那次绿、PR #53 那次绿, 在这一格上都是运气而不是证据。同时这也违反了本项目
+自己定的一条: 不给每个 job 新增 Release 下载。
+
+### 顺手挖出的第二处: 一道 P0 门在这支测试里一直是空操作
+
+`_pdg_nft_foreign_input_chains` 与 `_nft_apply_main` 定义在 `pdg.sh` 里, 但既没被抽进沙箱闭包、
+也没打桩。缺失的函数返回 127, 而 127 会被下游判据当成一个**普通返回值**吞掉:
+
+- 前者的契约是 `0`=发现别的 input base chain、`2`=判不了、其余=干净。127 从 `==2` 和 `==0`
+  两个分支之间穿过去 → 被当成"现场干净"。于是"迁移前发现外来 input 链就必须中止"这道 P0 门
+  (v1.6.0 加的)在这支测试的全部 18 格里都没跑过。
+- 后者是回滚时把恢复出来的 `nftables.conf` 真正应用回内核。缺桩 = 回滚只拷了文件、从没应用,
+  而只看 backend 标记的断言照样绿。
+
+两道门在别处仍有覆盖(`tests/e2e-custom-nft.sh` / `tests/test-nft-input-scan.py`), 所以是
+"这支单元测试从没真跑过它们", 不是"没人管"。
+
+### 改了什么
+
+- **`tests/test-migrate-drop-singbox.sh`**: 沙箱根里播**真的钉死版 mihomo**(装前验源、装后再验,
+  判据用生产那一个 `pdg_mihomo_binary_ok`, 不是"能跑就行"); 补上两个漏掉的桩; 新增
+  `_pdg_nft_foreign_input_chains` 的正反用例(发现外来链 → 中止且现场未被改动; 判不了 → 同样
+  中止, 不当成干净)与两条"回滚真的把 nft 应用回去了"。18 → 26 格。
+- **夹具自证两条**(不验业务, 只验前提): 全程零联网 —— harness 里的 `curl` 是**记账 + 失败**的
+  禁令桩, 谁再让沙箱联网, 断言直接点名 URL; 闭包完整 —— 任何一次 `command not found` 都记硬
+  失败, 127 不会再被判据当普通返回值吞掉。第二条在本轮当场就逮出了 `_nft_apply_main`。
+- **`tests/test-fixture-network-guard.py`**(新, 静态守卫): 凡是把"函数体里有 curl"的生产函数抽进
+  沙箱执行的 lint 用例, 必须自带 curl 禁令桩。规则只覆盖真有联网能力的闭包, 不搞人人都要绕的
+  形式主义; 判据源自己也有自检(认不出 `_activate_mihomo_core` 含 curl 就判自己失效)。
+- **`.github/workflows/ci.yml`**: 把 lint 里"装钉定 mihomo 到 `tests/.bin`"那一步**前移到所有用例
+  之前**。件本来就在同一个 artifact 里(producer 每 run 每架构只取一次), 以前它紧挨着自己的
+  消费者放在半程, 而这支用例排在它前面就跑了。**备件排在哪一步, 本身就是判据的一部分。**
+- **`tests/negctl/migrate-singbox-fixture-negative-controls.py`**(新, 本地跑不进 CI): 9 格负控 +
+  正控 + 反向对照, 逐格改坏播种/闭包/P0 门/静态守卫, 要求目标测试变红**且红在该红的那一条上**。
+  本轮 14/0 —— 其中两格先红在我自己写错的预期上, 改的是负控不是代码。
+
+### 证据
+
+`test-migrate-drop-singbox.sh` 26/0, PATH 上挂 curl 探针实测**真实网络调用 0 次**(修复前同一棵树
+实测 8 次); 负控 14/0; 静态守卫 4/0; `test-ci-mosdns-topology.py` 68/0(真解析 YAML);
+lint 全量 205 支回归。
+
 ## 2026-08-31 — v1.11.7(mihomo 的完整性判据一直在说谎)
 
 **建议升。** 没有配置格式变化, 升完不需要做任何事。这一版**不动任何运行行为** —— 改的是

--- a/tests/negctl/migrate-singbox-fixture-negative-controls.py
+++ b/tests/negctl/migrate-singbox-fixture-negative-controls.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""test-migrate-drop-singbox.sh 的夹具闭包 + 迁移前 P0 门 的负控。
+
+起因(v1.11.9): v1.11.7 把 _activate_mihomo_core 的跳过判据换成 pdg_mihomo_binary_ok 之后,
+这支测试的 shell 桩不再满足判据 —— 它从此**每跑一次真去 GitHub 下 8 次 mihomo**, 却仍然
+18/0。它没有报错, 只是从"确定性测试"退化成"网络运气的函数", 直到 main 上撞了一次
+connection reset 才红。同一支里还藏着第二处: _pdg_nft_foreign_input_chains 与
+_nft_apply_main 既没抽也没打桩, 返回 127 被下游判据当普通返回值吞掉。
+
+所以这里验的不是业务, 是**前提**: 播种、闭包、P0 门三样, 任一样被改坏, 那支测试必须变红,
+而且要红在该红的那一条上。
+
+本脚本反复改写工作区里的文件, 只在本地手工跑, **不进 CI**。
+"""
+import hashlib
+import io
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PDG = os.path.join(ROOT, "deploy/bot/pdg.sh")
+TST = os.path.join(ROOT, "tests/test-migrate-drop-singbox.sh")
+GUARD = os.path.join(ROOT, "tests/test-fixture-network-guard.py")
+
+
+def sha(p):
+    h = hashlib.sha256()
+    with io.open(p, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+def run(script=TST):
+    """跑目标测试, 回 (rc, [FAIL 行])。PATH 上挂 curl 探针: 夹具真联网了这里也能看见。"""
+    env = dict(os.environ)
+    env.setdefault("PDG_TEST_MIHOMO", os.path.join(ROOT, "tests/.bin/mihomo"))
+    cmd = [sys.executable, script] if script.endswith(".py") else ["bash", script]
+    r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                       errors="replace", env=env, timeout=900)
+    out = r.stdout + r.stderr
+    fails = [l for l in out.splitlines() if l.startswith("[FAIL]")]
+    return r.returncode, fails
+
+
+# (名字, 文件, 原文, 改成, 期望红里出现的关键词)
+CELLS = [
+    # ── 夹具前提 ──────────────────────────────────────────────────────────
+    # 完整还原历史缺陷形态: 播种整段拿掉(装 + 装后再验), 沙箱根里就没有 mihomo 这个文件,
+    # pdg_mihomo_binary_ok 恒假 → 生产代码真去取件 → 禁令桩记账 → 末尾那条断言点名。
+    ("沙箱不再播种钉死版 mihomo(历史缺陷形态)", TST,
+     '  install -m755 "$MIHOMO_SRC" "$SB/usr/local/bin/mihomo" \\\n'
+     '    || { echo "[FAIL] 播种 mihomo 到沙箱失败"; exit 1; }\n'
+     '  _mihomo_ok "$SB/usr/local/bin/mihomo" \\\n'
+     '    || { echo "[FAIL] 播种后的 mihomo 过不了生产判据 pdg_mihomo_binary_ok"; exit 1; }',
+     '  :',
+     "夹具联网了"),
+
+    ("播种的是个自报版本对、内容不对的桩", TST,
+     '  install -m755 "$MIHOMO_SRC" "$SB/usr/local/bin/mihomo" \\\n'
+     '    || { echo "[FAIL] 播种 mihomo 到沙箱失败"; exit 1; }',
+     '  printf \'#!/bin/sh\\necho "Mihomo Meta $MIHOMO_VER"\\n\' > "$SB/usr/local/bin/mihomo"\n'
+     '  chmod 755 "$SB/usr/local/bin/mihomo"',
+     "生产判据"),
+
+    ("P0 判据函数的桩被拿掉", TST,
+     '_pdg_nft_foreign_input_chains(){\n'
+     '  case "${FOREIGN_RC:-1}" in\n'
+     '    0) echo "table inet myfw (chain input, hook input priority filter 0)"; return 0;;\n'
+     '    2) echo "找不到 nftscan.py(判据脚本缺失), 无法确认防火墙链冲突"; return 2;;\n'
+     '    *) return 1;;\n'
+     '  esac\n'
+     '}',
+     ':',
+     "闭包漏桩"),
+
+    ("回滚用的 _nft_apply_main 桩被拿掉", TST,
+     '_nft_apply_main(){ echo applied >> "$SB/nft-applied"; return "${NFT_APPLY_RC:-0}"; }',
+     ':',
+     "闭包漏桩"),
+
+    ("P0 桩恒报「现场干净」(门被架空)", TST,
+     '    0) echo "table inet myfw (chain input, hook input priority filter 0)"; return 0;;\n'
+     '    2) echo "找不到 nftscan.py(判据脚本缺失), 无法确认防火墙链冲突"; return 2;;',
+     '',
+     "2b"),
+
+    # ── 生产侧: 这两格证明新增用例咬的是真代码, 不是自己的桩 ────────────────
+    ("生产侧: 发现外来 input 链却不再中止", PDG,
+     '  if [[ "$_frc" == 0 ]]; then\n'
+     '    c_y "检测到自定义 input base chain, 无法保证与 PDG 默认拒绝策略(policy drop)兼容 → 中止迁移。"',
+     '  if false; then\n'
+     '    c_y "检测到自定义 input base chain, 无法保证与 PDG 默认拒绝策略(policy drop)兼容 → 中止迁移。"',
+     "2b"),
+
+    ("生产侧: 「判不了」被当成「干净」", PDG,
+     '  if [[ "$_frc" == 2 ]]; then',
+     '  if false; then',
+     "2c"),
+
+    ("生产侧: nft 回滚只拷文件不再应用", PDG,
+     'cp /etc/nftables.conf.scbak /etc/nftables.conf; _nft_apply_main; }',
+     'cp /etc/nftables.conf.scbak /etc/nftables.conf; }',
+     "4c"),
+]
+
+# 静态守卫自己的负控: 把 curl 禁令桩拿掉, 守卫必须点名这支
+GUARD_CELL = ("守卫: 抽了含 curl 的生产函数却没有禁令桩", TST,
+              'curl(){ echo "curl $*" >> "$NETLOG"; echo "curl: 夹具禁止联网" >&2; return 7; }',
+              ':',
+              "test-migrate-drop-singbox.sh")
+
+
+def cell(name, path, old, new, kw, script=TST):
+    src = io.open(path, encoding="utf-8").read()
+    hits = src.count(old)
+    if hits != 1:
+        return False, "[FAIL] [%s] 锚点命中 %d 次(期望 1) —— 被测文件换写法了, 负控要跟着改" % (name, hits)
+    before = sha(path)
+    io.open(path, "w", encoding="utf-8").write(src.replace(old, new))
+    try:
+        rc, fails = run(script)
+    finally:
+        io.open(path, "w", encoding="utf-8").write(src)
+    if sha(path) != before:
+        return False, "[FAIL] [%s] 还原后摘要对不上 —— 负控自己弄脏了工作树" % name
+    if rc == 0:
+        return False, "[FAIL] [%s] 改坏了却仍然全绿 —— 那条断言没有牙齿" % name
+    hit = (not kw) or any(kw in l for l in fails)
+    tail = "" if not kw else (", 且点到「%s」" % kw if hit else ", 但**没**点到「%s」" % kw)
+    line = "[%s]   [%s] 变红 %d 条%s" % ("OK" if hit else "FAIL", name, len(fails), tail)
+    if not hit:
+        line += "\n       红在别处, 前 3 条: %s" % fails[:3]
+    return hit, line
+
+
+def main():
+    npass = nfail = 0
+    print("══ 正控: 不改任何东西, 必须全绿且零联网 ══")
+    rc, fails = run()
+    if rc == 0:
+        print("[OK]   正控绿"); npass += 1
+    else:
+        print("[FAIL] 正控本来就是红的(%d 条) —— 后面负控都不算数" % len(fails))
+        for l in fails[:5]:
+            print("       " + l)
+        return 1
+    if os.path.exists(GUARD):
+        rc, fails = run(GUARD)
+        if rc == 0:
+            print("[OK]   正控: 静态守卫绿"); npass += 1
+        else:
+            print("[FAIL] 静态守卫本来就是红的: %s" % fails[:3]); nfail += 1
+
+    print("\n══ 负控: %d 格 ══" % (len(CELLS) + (1 if os.path.exists(GUARD) else 0)))
+    for c in CELLS:
+        ok, line = cell(*c)
+        print(line)
+        npass += 1 if ok else 0
+        nfail += 0 if ok else 1
+    if os.path.exists(GUARD):
+        n, p, o, w, k = GUARD_CELL
+        ok, line = cell(n, p, o, w, k, script=GUARD)
+        print(line)
+        npass += 1 if ok else 0
+        nfail += 0 if ok else 1
+
+    print("\n══ 反向对照: 只加注释不得凭空造出失败 ══")
+    for path in (PDG, TST):
+        src = io.open(path, encoding="utf-8").read()
+        before = sha(path)
+        io.open(path, "a", encoding="utf-8").write(
+            "\n# 无关注释: _pdg_nft_foreign_input_chains curl MIHOMO_SRC _nft_apply_main\n")
+        try:
+            rc, f = run()
+        finally:
+            io.open(path, "w", encoding="utf-8").write(src)
+        if rc == 0 and sha(path) == before:
+            print("[OK]   [%s] 追加纯注释后仍全绿, 还原后摘要一致" % os.path.basename(path))
+            npass += 1
+        else:
+            print("[FAIL] [%s] 纯注释造出了失败(%d 条)或未还原" % (os.path.basename(path), len(f)))
+            nfail += 1
+
+    print("\n══ 收尾 ══")
+    for p in (PDG, TST):
+        print("  %-34s sha256 %s…" % (os.path.basename(p), sha(p)[:16]))
+    rc, _ = run()
+    print("  还原后目标测试: %s" % ("绿" if rc == 0 else "红"))
+    npass += 1 if rc == 0 else 0
+    nfail += 0 if rc == 0 else 1
+
+    print("\n" + "─" * 40)
+    print("通过 %d, 失败 %d" % (npass, nfail))
+    return 1 if nfail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test-fixture-network-guard.py
+++ b/tests/test-fixture-network-guard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""沙箱夹具不得偷偷联网。
+
+起因(v1.11.9): tests/test-migrate-drop-singbox.sh 把生产的 _activate_mihomo_core 抽进沙箱跑。
+v1.11.7 把那里的跳过判据从 pdg_mihomo_is_version(只问自报版本、走 PATH)收紧成
+pdg_mihomo_binary_ok(问绝对路径上的真文件 + 内容摘要)之后, 夹具里的 shell 桩不再满足判据 ——
+于是这支 lint 测试**每跑一次就真去 GitHub 下 8 次 mihomo**。它不报错、断言数不变、照样 18/0,
+只是从"确定性测试"变成了"网络运气的函数"。直到 main 的 run 33455929038 撞上一次
+`curl: (35) Recv failure: Connection reset by peer` 才红。
+
+生产侧那个改动是对的(它堵的是供应链后门), 坏掉的是夹具。这类退化没有报错、没有信号,
+唯一能防的办法是把约束写成规则:
+
+  **凡是把「函数体里有 curl」的生产函数抽进沙箱执行的 lint 用例, 必须自带 curl 禁令桩。**
+
+禁令桩让"沙箱联网"从一件静悄悄的事变成一条点名 URL 的断言。规则只覆盖真正有联网能力的
+闭包 —— 抽了别的函数的用例不受影响, 免得变成一条人人都要绕的形式主义。
+"""
+import io
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PDG = os.path.join(ROOT, "deploy/bot/pdg.sh")
+TESTS_DIR = os.path.join(ROOT, "tests")
+
+npass = nfail = 0
+
+
+def ok(m):
+    global npass
+    print("[OK]   " + m)
+    npass += 1
+
+
+def bad(m):
+    global nfail
+    print("[FAIL] " + m)
+    nfail += 1
+
+
+def fn_bodies(path):
+    """pdg.sh 里 `name(){` 到下一个顶格 `}` 之间的函数体。"""
+    lines = io.open(path, encoding="utf-8").read().splitlines()
+    out, i = {}, 0
+    while i < len(lines):
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\(\)\{\s*$", lines[i])
+        if m:
+            j = i + 1
+            while j < len(lines) and lines[j] != "}":
+                j += 1
+            out[m.group(1)] = "\n".join(lines[i:j + 1])
+            i = j
+        i += 1
+    return out
+
+
+EXTRACT = re.compile(r"sed -n '/\^([A-Za-z_][A-Za-z0-9_]*)\(\)\{/,/\^\}/p'")
+# 命令位上的 curl —— `# curl …` 这种注释不算, `curl_foo` 这种别的名字也不算
+CURL = re.compile(r"(?:^|[\s;(`]|\$\(|&&|\|\|)curl\s", re.M)
+STUB = re.compile(r"^\s*curl\(\)\{", re.M)
+
+bodies = fn_bodies(PDG)
+if len(bodies) < 50:
+    bad("从 pdg.sh 只解析出 %d 个函数 —— 解析器坏了, 这条守卫等于没跑" % len(bodies))
+else:
+    ok("从 pdg.sh 解析出 %d 个函数体" % len(bodies))
+
+# 判据源自己得有牙齿: 已知含 curl 的那个函数必须被认出来
+if "_activate_mihomo_core" in bodies and CURL.search(bodies["_activate_mihomo_core"]):
+    ok("判据源自检: _activate_mihomo_core 被认出含 curl(联网能力可判)")
+else:
+    bad("判据源自检失败: _activate_mihomo_core 没被认成含 curl —— 规则会全体放行")
+
+offenders, checked = [], []
+for name in sorted(os.listdir(TESTS_DIR)):
+    if not name.startswith("test-") or not name.endswith(".sh"):
+        continue
+    p = os.path.join(TESTS_DIR, name)
+    src = io.open(p, encoding="utf-8").read()
+    risky = [n for n in EXTRACT.findall(src) if n in bodies and CURL.search(bodies[n])]
+    if not risky:
+        continue
+    checked.append((name, risky))
+    if not STUB.search(src):
+        offenders.append((name, risky))
+
+if not checked:
+    bad("一支「抽了含 curl 的生产函数」的用例都没找到 —— 抽取写法变了, 守卫已失效")
+else:
+    ok("扫到 %d 支把含 curl 的生产函数抽进沙箱的用例: %s"
+       % (len(checked), ", ".join("%s(%s)" % (n, ",".join(r)) for n, r in checked)))
+
+if offenders:
+    bad("这些用例把含 curl 的生产函数抽进沙箱却没有 curl 禁令桩(会静默联网): "
+        + "; ".join("%s → %s" % (n, ",".join(r)) for n, r in offenders))
+else:
+    ok("它们都带了 curl 禁令桩")
+
+print("─" * 40)
+print("通过 %d, 失败 %d" % (npass, nfail))
+sys.exit(1 if nfail else 0)

--- a/tests/test-migrate-drop-singbox.sh
+++ b/tests/test-migrate-drop-singbox.sh
@@ -10,11 +10,26 @@
 #   成功路径则要真把 sing-box 运行时清干净(unit + 二进制)并落定 backend=mihomo。
 #
 # 沙箱化: 抽出真实函数, 只把绝对路径字面量重定向到临时根, 其余打桩。
+#
+# 夹具的两条硬约束(都是踩出来的, 不是原则):
+#   ① **不许联网**。v1.11.7 把 _activate_mihomo_core 的跳过判据从 pdg_mihomo_is_version
+#      (只问自报版本、走 PATH)换成 pdg_mihomo_binary_ok(问绝对路径上的真文件 + 内容摘要)。
+#      生产侧这是对的, 但本文件的 mihomo() 只是个 shell 函数桩、沙箱根里从来没有那个文件
+#      —— 判据于是恒假, 这支测试从那时起**每跑一次就真去 GitHub 下 8 次 mihomo**。它不报错,
+#      只是从"确定性测试"退化成"网络运气的函数", 直到 run 33455929038 撞上 connection reset
+#      才红。现在沙箱根里播真的钉死版, 且 harness 里的 curl 是禁令桩: 谁再让它联网, 末尾
+#      那条断言点名 URL。
+#   ② **闭包不许漏桩**。漏掉的函数返回 127, 而 127 会被下游判据当成一个普通返回值吞掉——
+#      _pdg_nft_foreign_input_chains 缺桩时正是如此: 它的契约是 0=有外来链、2=判不了、
+#      其余=干净, 127 从 ==2 和 ==0 两个分支之间穿过去, 于是"迁移前发现别的 input base
+#      chain 就必须中止"这道 P0 门在全部用例里都是空操作, 而测试照样 18/0。现在任何一次
+#      command not found 都记硬失败, 这道门本身也有了正反用例。
 # ─────────────────────────────────────────────────────────────────────────────
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+: > "$WORK/net.log"; : > "$WORK/notfound.log"
 pass=0; nfail=0
 ok(){ echo "[OK]   $1"; pass=$((pass+1)); }
 bad(){ echo "[FAIL] $1"; nfail=$((nfail+1)); }
@@ -34,6 +49,37 @@ sed -i -e 's#\$SB/usr/local/bin/sing-box run -c \$SB/etc/sing-box/config#/usr/lo
 # 已经自己认 PDG_ROOT_PREFIX 的路径不要再叠一层沙箱前缀(叠了会变成 $SB$SB/… 而永远不存在,
 # 断言就成了空转 —— 文件"没被删"只是因为函数压根没找到它)
 sed -i -e 's#\$pfx\$SB/#$pfx/#g' -e 's#\${PDG_ROOT_PREFIX:-}\$SB/#${PDG_ROOT_PREFIX:-}/#g' "$WORK/fn.sh"
+
+# ── 钉死版 mihomo 的来源(只找, 不取件) ───────────────────────────────────────
+# 判据用生产那一个(pdg_mihomo_binary_ok), 不是"能跑就行": 自报版本对、内容不对的桩必须被拒。
+MARCH="$(dpkg --print-architecture 2>/dev/null)"; [[ "$MARCH" == arm64 ]] || MARCH=amd64
+_mihomo_ok(){   # $1=路径
+  # shellcheck source=/dev/null
+  ( . "$ROOT/lib/versions.sh" 2>/dev/null \
+    && pdg_mihomo_binary_ok "$MARCH" "$MIHOMO_VER" "$1" ) >/dev/null 2>&1
+}
+MIHOMO_SRC=""
+_find_mihomo(){
+  local c
+  for c in "${PDG_TEST_MIHOMO:-}" "$ROOT/tests/.bin/mihomo" /usr/local/bin/mihomo /opt/pdg-e2e-bin/mihomo; do
+    [[ -n "$c" && -f "$c" ]] || continue
+    _mihomo_ok "$c" && { MIHOMO_SRC="$c"; return 0; }   # 先验源: 只在装完验挡不住"装了个坏的"
+  done
+  return 1
+}
+if ! _find_mihomo; then
+  # CI(PDG_TEST_STRICT=1)一律不取件: 件由 job 的「校验并安装钉定 mihomo」从本次 run 的
+  # artifact 装好。在这里放一条"找不到就 curl 一把"的回退, 等于把每 run 一次取件的约束
+  # 又放开成每 job 一次 —— 这支测试变回网络运气的函数, 正是这次要修掉的东西。
+  if [[ -n "${PDG_TEST_STRICT:-}" ]]; then
+    echo "[FAIL] 拿不到钉死版 mihomo($MARCH), 且严格模式下夹具不许自己取件。" >&2
+    echo "       CI 应由「校验并安装钉定 mihomo」步骤备好; 本机跑: bash tests/prepare-mihomo.sh" >&2
+    echo "通过 0, 失败 1"; exit 1
+  fi
+  # 开发者本机: 备一次件(走仓库既有的校验流程), 之后所有用例共用 tests/.bin/mihomo。
+  bash "$ROOT/tests/prepare-mihomo.sh" >/dev/null 2>&1 || true
+  _find_mihomo || { echo "[FAIL] 备件后仍拿不到钉死版 mihomo($MARCH)"; echo "通过 0, 失败 1"; exit 1; }
+fi
 
 mk(){   # $1=当前 backend 标记; 造出"仍是 sing-box 的老机器"现场
   SB="$WORK/root"; rm -rf "$SB"
@@ -61,6 +107,12 @@ LimitNOFILE=1048576
 [Install]
 WantedBy=multi-user.target
 U
+  # 沙箱根里放一份**真的**钉死版 mihomo。少了它, _activate_mihomo_core 的 pdg_mihomo_binary_ok
+  # 判据恒假 → 每格用例都会真去 GitHub 下载(见文件头 ①)。装完再验一次: 只验源挡不住装坏。
+  install -m755 "$MIHOMO_SRC" "$SB/usr/local/bin/mihomo" \
+    || { echo "[FAIL] 播种 mihomo 到沙箱失败"; exit 1; }
+  _mihomo_ok "$SB/usr/local/bin/mihomo" \
+    || { echo "[FAIL] 播种后的 mihomo 过不了生产判据 pdg_mihomo_binary_ok"; exit 1; }
   export SB
 }
 
@@ -78,9 +130,26 @@ _core_kernel_restore(){ :; }
 _pdg_platform(){ echo android; }
 pdg_verify_sha256(){ return 0; }
 cp(){ command cp "$@" 2>/dev/null || true; }
+# 迁移前那道 P0 硬门槛的判据源。它定义在 pdg.sh 里、却没被抽进 fn.sh —— 缺桩就是 127, 而
+# 127 从 ==2 和 ==0 两个分支之间穿过去被当成"现场干净", 这道门就成了空操作(见文件头 ②)。
+# 契约: 0=发现别的 input base chain, 2=读不到运行中 ruleset(判不了), 其余=干净。
+# 默认给 1(干净), 好让既有用例的语义一字不变。
+_pdg_nft_foreign_input_chains(){
+  case "${FOREIGN_RC:-1}" in
+    0) echo "table inet myfw (chain input, hook input priority filter 0)"; return 0;;
+    2) echo "找不到 nftscan.py(判据脚本缺失), 无法确认防火墙链冲突"; return 2;;
+    *) return 1;;
+  esac
+}
+# 夹具不许联网(见文件头 ①)。这不是"挡一下", 是**记账 + 失败**: 谁让沙箱里的生产代码去取件,
+# 末尾那条断言就把 URL 点出来。
+curl(){ echo "curl $*" >> "$NETLOG"; echo "curl: 夹具禁止联网" >&2; return 7; }
+# 回滚时把恢复出来的 nftables.conf 真正应用回内核。同样是 pdg.sh 里有、fn.sh 里没有的函数:
+# 缺桩 = 127, 于是"回滚"只把文件拷回去、从没应用过, 而只看 backend 标记的断言照样绿。
+_nft_apply_main(){ echo applied >> "$SB/nft-applied"; return "${NFT_APPLY_RC:-0}"; }
 mihomo(){
   case "${1:-}" in
-    -v) echo "Mihomo Meta $MIHOMO_VER";;             # 已是钉死版本, 跳过下载
+    -v) echo "Mihomo Meta $MIHOMO_VER";;   # 只服务按名字调的 -v; 跳过下载靠的是 mk() 播下的真二进制
     -t) [[ -n "${MIHOMO_T_FAIL:-}" ]] && { echo "$MIHOMO_T_ERR" >&2; return 1; }; return 0;;
   esac
   return 0
@@ -97,13 +166,18 @@ EOF
 }
 
 run(){  # $1=env $2=要调的函数
+  local _o
   # shellcheck disable=SC2086
-  env SB="$SB" PDG_ROOT_PREFIX="$SB" $1 bash -c "set -uo pipefail
+  _o=$(env SB="$SB" PDG_ROOT_PREFIX="$SB" NETLOG="$WORK/net.log" $1 bash -c "set -uo pipefail
 REPO_DIR='$ROOT'
 $(harness)
 source '$ROOT/lib/versions.sh' 2>/dev/null
 source '$WORK/fn.sh'
-$2; echo \"RC=\$?\"" 2>&1
+$2; echo \"RC=\$?\"" 2>&1)
+  # 闭包漏桩 → 127, 会被下游判据当成普通返回值吞掉(见文件头 ②)。不管当格断言碰巧过不过,
+  # 一律记账、末尾统一点名 —— 这条比任何单格断言都重要: 它盯的是"用例还在验东西"本身。
+  grep -F 'command not found' <<<"$_o" >> "$WORK/notfound.log" 2>/dev/null || true
+  printf '%s\n' "$_o"
 }
 
 # ── 1. 有出口无法转换 → 列出是哪几个出口 + 非0 + 回滚标记(绝不静默丢出口) ──
@@ -122,6 +196,28 @@ out=$(run "RENDER_MODE=raise" migrate_drop_singbox)
 { grep -q 'ValueError' <<<"$out" && grep -q '缺 server 字段' <<<"$out" && grep -q 'RC=1' <<<"$out"; } \
   && ok "渲染异常: 带出异常类型与原始信息 + 非0" || bad "2: out=$out"
 
+# ── 2b/2c. 迁移前的 P0 硬门槛: 现场还有别的 input base chain → 动任何东西之前中止 ──
+# (921e961) PDG 的 input chain 是 policy drop; 同一个 hook 上并存的别家 base chain 都会执行,
+# 任一条 drop 包就没了 —— 用户的放行看着还在, 端口实际不通。这种失效比直接报错更难查, 所以
+# 判据判不出干净就不许往下走。这道门在本文件里曾经是**空操作**: 判据函数既没抽也没打桩,
+# 返回 127 穿过两个分支被当成"干净"(见文件头 ②), 全部用例照样绿。
+mk singbox
+out=$(run "RENDER_MODE=ok FOREIGN_RC=0" migrate_drop_singbox)
+{ grep -q '检测到自定义 input base chain' <<<"$out" && grep -q 'RC=1' <<<"$out"; } \
+  && ok "有其它 input base chain: 中止迁移 + 非0" || bad "2b: out=$out"
+{ [[ "$(cat "$SB/etc/privdns-gateway/backend")" == singbox ]] \
+  && [[ -e "$SB/usr/local/bin/sing-box" && -e "$SB/etc/systemd/system/sing-box.service" ]] \
+  && ! grep -q 'RC=0' <<<"$out"; } \
+  && ok "有其它 input base chain: 现场未被改动(标记未翻, sing-box 运行时原样)" || bad "2b2: out=$out"
+
+# 判不了 ≠ 干净: 读不到运行中的 ruleset(非 root / nft 不可用)时, 内存里的冲突链没进视野。
+mk singbox
+out=$(run "RENDER_MODE=ok FOREIGN_RC=2" migrate_drop_singbox)
+{ grep -q '无法确认现场是否存在其它 input base chain' <<<"$out" && grep -q 'RC=1' <<<"$out"; } \
+  && ok "读不到运行中 ruleset: 按「无法确认」中止, 不当成干净" || bad "2c: out=$out"
+[[ "$(cat "$SB/etc/privdns-gateway/backend")" == singbox ]] \
+  && ok "读不到运行中 ruleset: backend 未翻(现场未被改动)" || bad "2c2: backend=$(cat "$SB/etc/privdns-gateway/backend")"
+
 # ── 3. mihomo -t 不过 → 带出 mihomo 自己的报错 ──
 mk singbox
 out=$(run "RENDER_MODE=ok MIHOMO_T_FAIL=1 MIHOMO_T_ERR=rule_9_is_invalid_xyz" migrate_drop_singbox)
@@ -135,6 +231,8 @@ out=$(run "RENDER_MODE=ok NFT_RC=1" migrate_drop_singbox)
   && ok "nft 失败: 报明原因 + 非0" || bad "4: out=$out"
 [[ "$(cat "$SB/etc/privdns-gateway/backend")" == singbox ]] \
   && ok "nft 失败: backend 标记已回滚" || bad "4b"
+[[ -s "$SB/nft-applied" ]] \
+  && ok "nft 失败: 回滚把 nftables 真正应用回去了(不只是把文件拷回来)" || bad "4c: _nft_apply_main 没被调到"
 
 # ── 5. 内核起不来 → 回滚并附上日志线索 ──
 mk singbox
@@ -143,6 +241,8 @@ out=$(run "RENDER_MODE=ok ACTIVATE_RC=1" migrate_drop_singbox)
   && ok "内核起不来: 回滚 + 附内核日志线索 + 非0" || bad "5: out=$out"
 [[ -e "$SB/usr/local/bin/sing-box" ]] \
   && ok "内核起不来: sing-box 二进制未删(还能退回去)" || bad "5b: sing-box 被误删"
+[[ -s "$SB/nft-applied" ]] \
+  && ok "内核起不来: 回滚把 nftables 真正应用回去了" || bad "5c: _nft_apply_main 没被调到"
 
 # ── 6. 一切正常 → 迁移成功, sing-box 运行时清干净, backend 落定 mihomo ──
 mk singbox
@@ -191,6 +291,15 @@ mk singbox; tp_unit; printf 'PDG-SINGBOX-OWNED v1\ncreated=2026-01-01T00:00:00Z\
 out=$(run "RENDER_MODE=ok" migrate_drop_singbox)
 [[ ! -e "$SB/etc/systemd/system/sing-box.service" ]] \
   && ok "带归属标记: 认定为本项目安装 → 正常清理" || bad "8d: 归属标记未生效"
+
+# ── 夹具自证: 这支用例还是不是"确定性测试" ───────────────────────────────────
+# 这两条不验业务, 只验前提。前提塌了的时候上面每一格都还能绿 —— 那正是要防的形态。
+[[ ! -s "$WORK/net.log" ]] \
+  && ok "全程零联网(沙箱里的 curl 一次都没被调到)" \
+  || bad "夹具联网了, 用例已退化成网络运气的函数: $(sort -u "$WORK/net.log" | head -2 | tr '\n' ' ')"
+[[ ! -s "$WORK/notfound.log" ]] \
+  && ok "闭包完整: 一条 command not found 都没有(没有 127 被判据当普通返回值吞掉)" \
+  || bad "闭包漏桩: $(grep -oE '[A-Za-z0-9_]+: command not found' "$WORK/notfound.log" | sort -u | tr '\n' ' ')"
 
 echo "────────────────────────────────────────"
 echo "通过 $pass, 失败 $nfail"


### PR DESCRIPTION
修 `main` 上 `33455929038` 的红灯。**只动测试与 CI,生产代码一字未改** —— 装机、更新、换核、迁移的行为完全不变,线上两台不受影响。

## 那个红灯不是 flake

`f47c74ab` 的 lint 红在 `tests/test-migrate-drop-singbox.sh` 第 2 格,表层是 `curl: (35) Recv failure: Connection reset by peer`。根因在 v1.11.7:

那一版把 `_activate_mihomo_core` 的跳过判据从 `pdg_mihomo_is_version`(只问自报版本、走 PATH)换成 `pdg_mihomo_binary_ok`(问**绝对路径上的真文件** + 内容摘要)。**生产侧这是对的**,它堵的正是那一版要堵的供应链后门。但这支测试的 `mihomo()` 只是个 shell 函数桩、沙箱根里从来没有那个文件,新判据第一条 `-x "$bin"` 就不成立 → 判据恒假 → 它从 v1.11.7 起**每跑一次就真去 GitHub 下 8 次 mihomo**(约 100MB/run),在 lint 上,每个 run。

**这个退化没有任何信号**:不报错、断言数不变(18)、照样 18/0。它只是从"确定性测试"变成了"网络运气的函数"。v1.11.7 那次绿、#53 那次绿,在这一格上都是运气而不是证据。同时它也违反了本项目自己定的一条:不给每个 job 新增 Release 下载。

复现方式(PATH 上挂记账 curl,对 `git archive f47c74ab` 取出的原树跑):修复前 **8 次**,修复后 **0 次**。

## 顺手挖出的第二处:一道 P0 门在这支测试里一直是空操作

`_pdg_nft_foreign_input_chains` 与 `_nft_apply_main` 定义在 `pdg.sh` 里,但既没被抽进沙箱闭包、也没打桩。缺失的函数返回 **127**,而 127 会被下游判据当成一个**普通返回值**吞掉:

- 前者契约是 `0`=发现别的 input base chain、`2`=判不了、其余=干净。127 从 `==2` 和 `==0` 两个分支之间穿过去 → 被当成"现场干净"。于是"迁移前发现外来 input 链就必须中止"这道 P0 门(`921e961`,v1.6.0)在这支测试的全部 18 格里都没跑过。
- 后者是回滚时把恢复出来的 `nftables.conf` 真正应用回内核。缺桩 = 回滚只拷了文件、从没应用,而只看 backend 标记的断言照样绿。

两道门在别处仍有覆盖(`tests/e2e-custom-nft.sh` / `tests/test-nft-input-scan.py`),所以是"这支单元测试从没真跑过它们",不是"没人管"。

**`_nft_apply_main` 是新加的记账断言当场逮出来的** —— 我原本只知道前一个。

## 改了什么

- **`tests/test-migrate-drop-singbox.sh`(18 → 26 格)**:沙箱根里播**真的钉死版 mihomo**(装前验源、装后再验,判据用生产那一个 `pdg_mihomo_binary_ok`,不是"能跑就行");补上两个漏桩;新增 P0 门的正反用例(发现外来链 → 中止**且现场未被改动**;判不了 → 同样中止,不当成干净)与两条"回滚真的把 nft 应用回去了"。
- **夹具自证两条**(不验业务,只验前提 —— 前提塌了的时候上面每一格都还能绿):
  - 全程零联网 —— harness 里的 `curl` 是**记账 + 失败**的禁令桩,谁再让沙箱联网,断言直接点名 URL;
  - 闭包完整 —— 任何一次 `command not found` 都记硬失败,127 不会再被判据当普通返回值吞掉。
- **`tests/test-fixture-network-guard.py`(新,静态守卫)**:凡是把"函数体里有 curl"的生产函数抽进沙箱执行的 lint 用例,必须自带 curl 禁令桩。规则只覆盖真有联网能力的闭包 —— 要是覆盖所有 17 支抽函数的测试,就会变成人人都要绕的形式主义。判据源自己也有自检(认不出 `_activate_mihomo_core` 含 curl 就判自己失效)。
- **`.github/workflows/ci.yml`**:把 lint 里"装钉定 mihomo 到 `tests/.bin`"那一步**前移到所有用例之前**。件本来就在同一个 artifact 里(producer 每 run 每架构只取一次),以前它紧挨着自己的消费者放在半程,而这支用例排在它前面就跑了。**备件排在哪一步,本身就是判据的一部分。** 没有新增任何取件:`prepare-mihomo.sh` 出现次数仍是 1,`upload-artifact` 仍是 1。
- **`tests/negctl/migrate-singbox-fixture-negative-controls.py`(新,本地跑,不进 CI)**:9 格负控 + 正控 + 反向对照,逐格改坏播种/闭包/P0 门/静态守卫,要求目标测试变红**且红在该红的那一条上**。

## 证据

CI:`33465457684`(`workflow_dispatch`,head `803b3ac`,`attempt=1`)—— **31/31 jobs、625/625 steps 全绿**。日志逐条核过,不只是看颜色:

- `sing-box→mihomo 迁移回归` **通过 26, 失败 0**
- `[OK] 全程零联网(沙箱里的 curl 一次都没被调到)`
- `[OK] 闭包完整: 一条 command not found 都没有`
- P0 门四条 + 回滚两条全部 `[OK]`
- 新守卫 通过 4, 失败 0
- **lint 日志里 `releases/download` 出现次数:0**

本地:负控 **14/0**(其中两格先红在我自己写错的预期上,改的是负控不是代码);lint 全量 **205 支**回归,整轮真实网络调用 11 次、**全是 `http://127.0.0.1:81/probe`**(probe81 打本机),外网取件 0;`test-ci-mosdns-topology.py` **68/0**(装 venv pyyaml 真解析 YAML);STRICT + 备件缺失 → `rc=1`、零联网、消息说清怎么补件。

## 一条自己的教训

第一次"本地复现"是无效的:`/home/codex/privdns-gateway` 停在 `feat/dns-adblock`、落后 main **123 个提交**,跑的是旧代码,于是得出"本地 curl 0 次、只有 CI 有问题"的错误结论。改用 `git archive f47c74ab` 取树重跑才复现出 8 次。已写进 HANDOFF §9.17。

🤖 Generated with [Claude Code](https://claude.com/claude-code)