### PR TITLE
fix(ci): move the artifact actions off the deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           json.dump(m,open("artifact/manifest.json","w"))' \
             "$PDG_LEGACY_MOSDNS_VER" "${PDG_LEGACY_SHA256[mosdns-$ARCH]}" "$LG_GOT" "$LG_VER"
           cat artifact/manifest.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.name.outputs.artifact }}
           path: artifact/
@@ -145,7 +145,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -991,7 +991,7 @@ jobs:
           test "$(command -v systemctl)" = /usr/bin/systemctl || test "$(command -v systemctl)" = /bin/systemctl
       - name: "推导 artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1033,7 +1033,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1148,7 +1148,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1196,7 +1196,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1420,7 +1420,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1529,7 +1529,7 @@ jobs:
       # 没有第二个答案。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -1575,7 +1575,7 @@ jobs:
       # job 日志上一个字都看不见(审计时才发现它也是消费者)。现在与别的消费者同路。
       - name: "推导 mosdns artifact 名"
         run: echo "MOSDNS_ARTIFACT=$(bash tests/mosdns-artifact-name.sh)" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,6 +894,11 @@ jobs:
       - name: "CI 覆盖守卫 (每个测试文件都必须真的被本 workflow 调用)"
         run: python3 tests/test-ci-coverage.py
 
+      # 弃用期内 runner 会把 node20 的 action 强行拉到 node24 上跑 —— 流程照常绿, 只是每个
+      # job 都打一条 warning。那种"不红只是提醒"的形态最容易被放过, 直到某天 runner 不再兜底。
+      - name: "action 运行时守卫 (没有 action 停在已弃用的 Node 20 上; 不认识的 action 判失败)"
+        run: python3 tests/test-action-runtime.py
+
       - name: "clean-root 安装产物自足 (移出仓库/隔离解释器/无源码兜底)"
         run: python3 tests/test-clean-root.py
 

--- a/tests/negctl/mosdns-artifact-negative-controls.py
+++ b/tests/negctl/mosdns-artifact-negative-controls.py
@@ -86,7 +86,7 @@ def suite(wd, cmds):
     return failures(out)
 
 
-CONSUMER_DL = '''      - uses: actions/download-artifact@v4
+CONSUMER_DL = '''      - uses: actions/download-artifact@v8
         with:
           name: ${{ env.MOSDNS_ARTIFACT }}
           path: /tmp/mosdns-fixture
@@ -96,7 +96,7 @@ MUT = [
      [(CONSUMER_DL,
        '      - name: "直接下载"\n        run: |\n'
        '          curl -fsSL -o /tmp/m.zip '
-       '"https://github.com/IrineSistiana/mosdns/releases/download/v5.3.4/mosdns-linux-amd64.zip"\n', 7)],
+       '"https://github.com/IrineSistiana/mosdns/releases/download/v5.3.4/mosdns-linux-amd64.zip"\n', 8)],
      [T_TOPO]),
     ("② 消费者加回联网 fallback", INS,
      [('[[ -f "$BIN" ]] || die "artifact 里没有 mosdns($BIN)"',
@@ -109,7 +109,7 @@ MUT = [
      [('[[ "v${got_ver:-}" == "$MOSDNS_VER" ]] \\\n  || die', 'true \\\n  || die', 1)],
      [T_TOPO, T_TRIP]),
     ("⑤ 摘掉 needs", CI,
-     [("    needs: prepare-mosdns-fixture\n", "", 7)], [T_TOPO]),
+     [("    needs: prepare-mosdns-fixture\n", "", 8)], [T_TOPO]),
     ("⑥ artifact 名去掉摘要段", NAM,
      [("printf 'mosdns-%s-%s-%s\\n' \"$MOSDNS_VER\" \"$arch\" \"${sha:0:12}\"",
        "printf 'mosdns-%s-%s\\n' \"$MOSDNS_VER\" \"$arch\"", 1)], [T_TRIP]),
@@ -117,11 +117,11 @@ MUT = [
      [('          pdg_mosdns_binary_ok "$ARCH" "$MOSDNS_VER" "$PWD/artifact/mosdns"\n', "", 1)],
      [T_TOPO]),
     ("⑧ 改用 actions/cache", CI,
-     [("      - uses: actions/upload-artifact@v4\n",
+     [("      - uses: actions/upload-artifact@v7\n",
        "      - uses: actions/cache@v4\n", 1)], [T_TOPO]),
     ("⑨ action 改成浮动引用", CI,
-     [("      - uses: actions/download-artifact@v4\n",
-       "      - uses: actions/download-artifact@main\n", 7)], [T_TOPO]),
+     [("      - uses: actions/download-artifact@v8\n",
+       "      - uses: actions/download-artifact@main\n", 8)], [T_TOPO]),
     ("⑩ 只加一行无关注释(反向对照)", INS,
      [("die(){ echo", "# (负控的空转对照, 不改变任何行为)\ndie(){ echo", 1)], [T_TOPO, T_TRIP]),
 ]

--- a/tests/test-action-runtime.py
+++ b/tests/test-action-runtime.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""CI 里的 action 不能跑在已弃用的 Node 运行时上。
+
+为什么需要它: GitHub 2025-09-19 宣布弃用 runner 上的 Node 20。弃用期内 runner 会
+**强行把 node20 的 action 拉到 node24 上跑**, 于是每个 job 都打一条 warning 而流程照常绿 ——
+这正是最容易被放过的形态: 它不红, 只是每次都在提醒, 直到某天 runner 真的不再兜底。
+v1.11.10 那次 run 里 31/32 个 job 都带着这条 warning。
+
+判据只认一件事: `.github/workflows/*.yml` 里每个 `uses:` 钉的大版本, 是否 >= 该 action
+**第一个默认跑 node24 的大版本**。阈值是实测出来的(逐版读上游 action.yml 的 runs.using),
+不是照抄 release note 的措辞 —— 上游把 "支持 node24" 和 "默认用 node24" 分成了两个版本,
+只看 release note 会早一版下结论:
+
+    actions/upload-artifact     v4 node20 · v5 node20 · **v6 node24** · v7 node24
+    actions/download-artifact   v4 node20 · v5 node20 · v6 node20 · **v7 node24** · v8 node24
+
+这支**不联网**: 阈值钉在下面的表里。上游再出新版不影响判据 —— 判的是"有没有低于阈值",
+不是"是不是最新"。跟不跟最新是人的决定, 不该由一支测试每天去问 GitHub。
+
+不认识的 action **判失败, 不放过**: 判据无法对它下结论, 而"跳过"会以绿灯的样子出现。
+新加 action 的人必须在这里登记它的运行时, 那一步正是本条守卫的目的。
+"""
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+WF = os.path.join(ROOT, ".github/workflows")
+
+PASS = [0]
+FAIL = [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("  ✓ %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("  ✗ %s" % m)
+
+
+# action → 第一个 **默认** 跑 node24 的大版本(实测自上游 action.yml 的 runs.using)。
+# 加新 action 时在这里登记; 查法: curl .../<action>/<vN>/action.yml | grep 'using:'
+NODE24_MIN = {
+    "actions/checkout": 5,
+    "actions/upload-artifact": 6,
+    "actions/download-artifact": 7,
+}
+
+# 这些 action 由 runner 内建实现, 不是 JS action, 没有 Node 运行时可言。
+NOT_JS = set()
+
+if not os.path.isdir(WF):
+    bad("找不到 .github/workflows/")
+    print("\n断言 1 项: 通过 0, 失败 1")
+    sys.exit(1)
+
+uses = []          # (文件, 行号, owner/repo, 大版本原文)
+for fn in sorted(os.listdir(WF)):
+    if not fn.endswith((".yml", ".yaml")):
+        continue
+    path = os.path.join(WF, fn)
+    for i, line in enumerate(open(path, encoding="utf-8"), 1):
+        if line.lstrip().startswith("#"):      # 注释里提到的不算登记
+            continue
+        m = re.search(r"uses:\s*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@(\S+)", line)
+        if m:
+            uses.append((fn, i, m.group(1), m.group(2)))
+
+print("== 1. 每个 action 都要能判定运行时 ==")
+unknown = sorted({a for _f, _l, a, _v in uses if a not in NODE24_MIN and a not in NOT_JS})
+if not unknown:
+    ok("%d 处 uses、%d 个不同 action, 全部在运行时登记表里"
+       % (len(uses), len({a for _f, _l, a, _v in uses})))
+else:
+    bad("这些 action 没登记运行时, 判不了(不放过: 跳过等于零覆盖): %s" % "、".join(unknown))
+
+print("\n== 2. 没有 action 停在已弃用的 Node 20 上 ==")
+stale = []
+for fn, ln, act, ver in uses:
+    if act not in NODE24_MIN:
+        continue
+    m = re.match(r"^v(\d+)", ver)
+    if not m:
+        # 钉 SHA 或钉具体小版本时读不出大版本 —— 判不了就判失败, 不猜。
+        stale.append((fn, ln, act, ver, "读不出大版本"))
+        continue
+    major, need = int(m.group(1)), NODE24_MIN[act]
+    if major < need:
+        stale.append((fn, ln, act, ver, "需要 >= v%d 才默认跑 node24" % need))
+
+if not stale:
+    ok("%d 处 uses 全部 >= 各自的 node24 阈值" % len(uses))
+else:
+    for fn, ln, act, ver, why in stale:
+        bad("%s:%d %s@%s —— %s" % (fn, ln, act, ver, why))
+
+print("\n== 3. 同一个 action 在全仓只用一个版本 ==")
+# 版本漂移会让"升级过了"变成半真半假: 一处升了、另一处没升, 而 CI 仍然全绿。
+byact = {}
+for _fn, _ln, act, ver in uses:
+    byact.setdefault(act, set()).add(ver)
+drift = {a: v for a, v in byact.items() if len(v) > 1}
+if not drift:
+    ok("%d 个 action 各自版本唯一" % len(byact))
+else:
+    for a, v in sorted(drift.items()):
+        bad("%s 同时用了 %s —— 版本漂移" % (a, "、".join(sorted(v))))
+
+n = PASS[0] + FAIL[0]
+print("\n断言 %d 项: 通过 %d, 失败 %d" % (n, PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)


### PR DESCRIPTION
## 这是什么

把 CI 里两个仍钉在 **Node 20** 上的 action 升到 node24 版本,并加一支守卫让这件事**永久可判**。只动 CI 与测试,**产品代码一个字节没改**。

GitHub 2025-09-19 弃用了 runner 上的 Node 20。弃用期内 runner **强行把 node20 的 action 拉到 node24 上跑** —— 流程照常绿,只在每个 job 上打一条 warning。v1.11.10 的 main run `33635189300` 里 **31/32 个 job** 都带着它。这种「不红、只是提醒」的形态最容易被一直放过,直到某天 runner 不再兜底。

告警精确点名两个 action;`actions/checkout@v5` 不在名单里 —— 它已经是 node24。

## 版本怎么选的

阈值是**逐版读上游 `action.yml` 的 `runs.using` 实测**出来的,不是照抄 release note —— 上游把「支持 node24」与「默认用 node24」分成了两个版本,只看 release note 会早一版下结论:

```
actions/upload-artifact    v4 node20 · v5 node20 · v6 node24 · v7 node24
actions/download-artifact  v4 node20 · v5 node20 · v6 node20 · v7 node24 · v8 node24
```

最低可解是 upload@v6 / download@v7,但落地即落后一个大版本。选**最新(upload@v7 / download@v8)**,前提是 v4 → 最新之间每条破坏性变更都对着**实际用法**核过了(本仓只用 `name` + `path` + `retention-days`,**按 ID 下载 0 处**):

| 变更 | 对本仓的影响 |
|---|---|
| upload v7 `archive` 参数 | 可选、默认 `true` → 无影响 |
| upload v7 / download v8 改 ESM | 对调用方透明 |
| download v5 单 artifact **按 ID** 下载的路径行为(BREAKING) | **不适用** —— 我们按 name 下载 |
| download v8 `skip-decompress` | 默认不变,我们的 artifact 仍是 zip |
| download v8 摘要不符 **warning → 默认 error** | **加强**。与本仓 fail-closed 取向一致;我们本来就自己重算 SHA256,这是额外的独立判据 |

两者都要求 runner ≥ `2.327.1`,线上是 **`2.337.0`**,且用的是 GitHub 托管 runner(不涉及自建)。

## 两笔提交

1. **`test(ci): expose actions still pinned to the deprecated Node 20`** —— 新增 `tests/test-action-runtime.py` 并登记进 lint job。**不联网**(阈值钉在表里);**不认识的 action 判失败不放过**(判不了就不能放行,新加 action 的人必须来登记运行时);顺带盯「同一 action 全仓只用一个版本」与「钉 SHA / 读不出大版本也判失败」。对当时的 ci.yml:**2 通过 9 失败**,逐行给出 `file:line`。
2. **`fix(ci): move the artifact actions off the deprecated Node 20`** —— 9 处纯版本号替换,`uses:` 计数 **19 → 19** 不变,守卫转 **3 通过 0 失败**。

## 顺带修好三格既有的哑弹负控

`tests/negctl/mosdns-artifact-negative-controls.py` 的 **①⑤⑨ 三格从 v1.11.10 起就没在验任何东西**:锚点期望消费者数 **7**,而 PR #56 新增的 `core-startlimit` 也是消费者,实际已是 **8** —— 命中数对不上时改坏器直接 abort。因为 negctl 是本地手动门、CI 不跑,一直没人发现。正是 HANDOFF §9.11 那个形态。

同一环境下做了基线对照确认这不是本 PR 造成的:**基线 `c85c540` 15 通过 3 失败 → 本 PR 18 通过 0 失败**。⑧⑨ 的 action 版本锚点也随本 PR 一起更新。

## CI

exact-head `workflow_dispatch` run **[33703815440](https://github.com/misaka-cpu/privdns-gateway/actions/runs/33703815440)**,attempt=1,head `48b3311dc5f5d5014da1e9a5fa5155631367a8e6`(精确):**32/32 jobs success,641/641 steps success**,failure / skipped / cancelled 均为 0。

**告警实测:31 个 job → 0 个 job**,本次 run 里不再出现任何 Node 弃用类告警。

**step 数 640 → 641 的完整归因**(不用总数搪塞):

- `download-artifact` 步骤改名 `@v4`→`@v8`:移除 30 / 新增 30
- `upload-artifact` 步骤改名 `@v4`→`@v7`:移除 1 / 新增 1
- **真正被删除的 step:0 个**
- **真正新增的 step:1 个** —— 就是那支守卫
- 另有 lint job 内 24 个步骤序号 +1 位移(插入守卫所致),不是内容变化

step 名之所以变,是因为 GitHub 把 action 版本号写进了步骤名;job 名集合 **0 增 0 减**。

本地:action-runtime / CI 取件拓扑 / e2e 夹具 / CI 覆盖 / release-flow / wording-accuracy / invariants 全绿;py_compile 254 个、`bash -n`、ShellCheck(CI 原样命令与范围)、`git diff --check` 全过;新增 SKIP 0。

## 边界

- 这一版**不改任何产品代码**,不影响 jp/jp2 的运行行为 —— 纯 CI 侧。
- 守卫判的是「有没有低于阈值」,**不是「是不是最新」**。上游再出新版不会让它变红;跟不跟最新是人的决定,不该由一支测试每天去问 GitHub。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
