### PR TITLE
fix(doctor): read mihomo runtime provider state for ruleset evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,6 +938,9 @@ jobs:
       - name: "规则集证据等级 (静态形态 ≠ 已加载; 损坏不许当没配置; 不读 controller/不发请求)"
         run: python3 tests/test-ruleset-evidence.py
 
+      - name: "规则集运行期证据 (读 mihomo 管理面; 未加载/0 条判失败, 读不到仍只说无结论)"
+        run: python3 tests/test-ruleset-runtime-evidence.py
+
       # 弃用期内 runner 会把 node20 的 action 强行拉到 node24 上跑 —— 流程照常绿, 只是每个
       # job 都打一条 warning。那种"不红只是提醒"的形态最容易被放过, 直到某天 runner 不再兜底。
       - name: "action 运行时守卫 (没有 action 停在已弃用的 Node 20 上; 不认识的 action 判失败)"

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1856,6 +1856,66 @@ def check_mitm():
         return ("fail", "WLOC 服务", "mihomo 缺 MITM-OUT 出站或 gs-loc 路由(重开一次 WLOC 重渲染内核)")
     return ("ok", "WLOC 服务", "pdg-mitm active + CA + mitm_hijack + mihomo MITM 路由 就位")
 
+# ── mihomo 管理面(external-controller)的只读查询 ────────────────────────────
+# 只做 GET, 只在**回环**地址上做。判据宁可"无结论"也不主动去连非回环的管理端口:
+# 那是控制面, 能改配置、切出站, 不该由一条自检去外连。
+def _clash_ctrl():
+    """解析 mihomo 的 external-controller。回环才给 base_url。
+
+    返回 (base_url, why)。base_url 为 None 时 why 说明为什么没有结论。
+    配置既可能是 JSON 形态(带引号的键)也可能是 YAML, 所以按文本抽, 不引 yaml 依赖。"""
+    try:
+        txt = open(MIHOMO_CFG, encoding="utf-8", errors="replace").read()
+    except OSError as e:
+        return None, "读不到 mihomo 配置(%s)" % (e.strerror or e.errno)
+    # JSON(键在行中)与 YAML(键在行首)两种形态都要认: 前缀允许行首、`{`、`,` 或空白。
+    m = re.search(r'(?:^|[{,\s])"?external-controller"?\s*:\s*"?([^"\s,}]+)"?', txt, re.M)
+    if not m:
+        return None, "mihomo 未配置 external-controller"
+    host, _, port = m.group(1).strip().rpartition(":")
+    host = (host or "127.0.0.1").strip("[]")
+    if not port.isdigit():
+        return None, "external-controller 形态不可解析"
+    if host not in ("127.0.0.1", "::1", "localhost", ""):
+        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"
+    return "http://127.0.0.1:%s" % port, ""
+
+
+def _clash_secret():
+    """管理面的 secret。mihomo 放顶层 `secret`; 老的 sing-box 放 experimental.clash_api.secret。
+    读不到就返回空串 —— 回环且未设 secret 时本来就无需鉴权。**只用于加请求头, 不记录、不回显。**"""
+    try:
+        m = re.search(r'(?:^|[{,\s])"?secret"?\s*:\s*"([^"]*)"',
+                      open(MIHOMO_CFG, encoding="utf-8", errors="replace").read(), re.M)
+        if m and m.group(1):
+            return m.group(1)
+    except OSError:
+        pass
+    try:
+        return (json.load(open(SB)).get("experimental", {}).get("clash_api", {}) or {}).get("secret") or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _clash_rule_providers(timeout=4):
+    """只读取运行期的 rule provider 状态。返回 (providers, None) 或 (None, 无结论原因)。"""
+    base, why = _clash_ctrl()
+    if not base:
+        return None, why
+    try:
+        req = urllib.request.Request(base + "/providers/rules")
+        sec = _clash_secret()
+        if sec:
+            req.add_header("Authorization", "Bearer " + sec)
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            data = json.load(r)
+    except Exception as e:  # noqa: BLE001  连不上/非 2xx/超时/应答不是 JSON, 一律无结论
+        return None, "读不到管理面(%s)" % type(e).__name__
+    if not isinstance(data, dict) or not isinstance(data.get("providers"), dict):
+        return None, "管理面应答里没有 providers 对象"
+    return data["providers"], None
+
+
 def check_rulesets():
     """规则集的**静态形态**有没有已知不兼容 —— 只能说到这里, 说不到"已加载"。
 
@@ -1873,9 +1933,17 @@ def check_rulesets():
     `pdg doctor` 的总退出码(更新自检只按 level=="fail" 计数), 所以它不会挡住任何人,
     只是不再替运行期打包票。
 
-    要真证明"已加载", 需要一个安全的运行期查询接口(mihomo 管理面), 那是**架构待决项**:
-    本项不新增 HTTP 管理端口、不读现有 9090、不开 ext-ctl-unix、不拿 `mihomo -t` 的配置
-    语法通过冒充 provider 已加载、也不去访问 provider 地址做在线探测。只读, 不改任何东西。
+    现在它**会去读运行期**: mihomo 的 external-controller 提供 `/providers/rules`, 给出每个
+    rule provider 的 name/behavior/format/ruleCount/updatedAt。判据据此分三种结论:
+
+      · 每个声明的规则集都能找到同名 provider 且 ruleCount>0 → **ok**(报总条数与最旧更新时间);
+      · 声明了却没有同名 provider, 或 provider 解析出 0 条 → **fail**(规则被静默丢弃, 分流是死的);
+      · 管理面读不到/非 2xx/应答不是预期结构/缺 ruleCount → 仍然 **warn 且明说无结论**。
+        "试过了"不等于可以退回 ok。
+
+    边界仍然守死: **只 GET, 只连回环**。external-controller 不在回环或没配置 → warn, 判据
+    不主动去连非回环的管理端口(那是控制面, 能改配置、切出站)。不新增管理端口、不开
+    ext-ctl-unix、不拿 `mihomo -t` 的语法通过冒充已加载、不去访问 provider 地址做在线探测。
 
     mihomo 读不了 sing-box 的二进制 `.srs`; 这类**老机器遗留**的规则集会让渲染器把对应规则
     丢弃 → _core_apply/迁移一律判失败。那一类仍然判 fail 并直说该怎么办。"""
@@ -1911,9 +1979,43 @@ def check_rulesets():
         return ("fail", name, "这些是 sing-box 二进制 .srs, mihomo 读不了 → 分流不会生效, "
                               "且会挡住 `pdg update`: " + "、".join(stale[:6])
                               + "。请在 bot「📑 分流管理」里删掉它们, 换成 .list/.txt/.yaml/.mrs。")
-    return ("warn", name, "%d 个: 静态元数据里未发现已知不兼容格式。"
-                          "但本项**没有读取 mihomo 运行期 provider 状态**, 因此不能证明这些规则"
-                          "已经被加载、下载成功或解析出条目 —— 只说明形态上没问题。" % len(meta))
+    # 静态形态没问题之后, 去管理面取**运行期证据**。取不到就仍然说"无结论" —— 试过了不等于
+    # 可以退回 ok; 取到了才可能给 ok, 而且必须逐个规则集对得上。
+    provs, why = _clash_rule_providers()
+    if provs is None:
+        return ("warn", name, "%d 个: 静态元数据里未发现已知不兼容格式。"
+                              "**运行期 provider 状态本次不可得**(%s), 因此仍不能证明这些规则"
+                              "已被 mihomo 加载、下载成功或解析出条目 —— 只说明形态上没问题。"
+                              % (len(meta), why))
+    missing, empty, incomplete, total, oldest = [], [], [], 0, None
+    for rs_name, info in meta.items():
+        label = str((info.get("label") if isinstance(info, dict) else None) or rs_name)
+        p = provs.get(rs_name)
+        if not isinstance(p, dict):
+            missing.append(label); continue
+        cnt = p.get("ruleCount")
+        if not isinstance(cnt, int) or isinstance(cnt, bool):
+            incomplete.append(label); continue
+        if cnt <= 0:
+            empty.append(label); continue
+        total += cnt
+        u = str(p.get("updatedAt") or "")
+        if u and (oldest is None or u < oldest):
+            oldest = u
+    if incomplete:
+        # 字段缺了就是**读不出条数**, 与读不到管理面同级: 无结论, 不判故障也不给 ok。
+        return ("warn", name, "%d 个: 管理面应答里这些规则集没有可解析的 ruleCount, "
+                              "运行期条数无结论: %s" % (len(meta), "、".join(incomplete[:6])))
+    if missing:
+        return ("fail", name, "这些规则集在配置里声明了, 但 mihomo 运行期**没有对应的 provider** "
+                              "—— 规则被静默丢弃, 分流对它们是死的: " + "、".join(missing[:6])
+                              + "。请在 bot「📑 分流管理」里重建, 或检查 provider 地址是否可达。")
+    if empty:
+        return ("fail", name, "这些规则集在运行期**解析出 0 条规则**(下载失败或内容为空), "
+                              "分流对它们同样是死的: " + "、".join(empty[:6])
+                              + "。请检查 provider 地址与内容, 或在 bot 里重建。")
+    return ("ok", name, "%d 个, 运行期均已加载, 共 %d 条规则%s。"
+                        % (len(meta), total, ("; 最旧一次更新 " + oldest[:19]) if oldest else ""))
 
 
 # ── 分流优先级: 自动生成的规则不许静默压过用户点名的域名规则 ──────────────────

--- a/tests/negctl/ruleset-runtime-evidence-negative-controls.py
+++ b/tests/negctl/ruleset-runtime-evidence-negative-controls.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""负控: **check_rulesets 的运行期证据**这条判据有没有牙。
+
+正控在 tests/test-ruleset-runtime-evidence.py。
+
+这一类退化最难看出来: 退化之后 doctor 仍然"有输出、看着正常" —— 要么把"读不到"说成绿,
+要么把"声明了没加载 / 解析出 0 条"放过去。机器上规则是死的, 报告却是绿的。
+
+五格 + 反向对照:
+
+  ① 读不到管理面时退回 ok        —— 把"无结论"冒充成"已验证";
+  ② 不查"声明了却没同名 provider" —— 规则被静默丢弃却报绿;
+  ③ ruleCount==0 放过            —— "有 provider"被当成"有规则";
+  ④ 去掉回环限制                 —— 判据会去连非回环的控制面(能改配置、切出站的那个口);
+  ⑤ 缺 ruleCount 当成通过        —— 字段缺失被当成证据齐全;
+  ⑥ 只加无关注释(反向对照)       —— 不该产生任何新失败。
+
+④ 的判据落在**理由文案**上而不是 level: 去掉限制之后连非回环也只是连不上, level 照样是
+warn —— 只有理由从「不在回环」变成「读不到管理面」才暴露它真的去连了。
+"""
+import hashlib, os, re, shutil, subprocess, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+TGT = "deploy/bot/checks.py"
+TOUCHED = [ROOT / TGT]
+PASS, FAIL = [0], [0]
+def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
+def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
+def sha(p): return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+def run(c, cwd): return subprocess.run(c, cwd=cwd, capture_output=True, text=True, timeout=1200)
+def failures(out):
+    return {re.sub(r"\s+", " ", l.strip())[:150] for l in out.splitlines()
+            if l.strip().startswith("✗")}
+
+T = ["python3", "tests/test-ruleset-runtime-evidence.py"]
+
+SRC = (ROOT / TGT).read_text(encoding="utf-8")
+def lift(pattern, max_lines=20, flags=re.M | re.S):
+    """从产品源码原样取锚点。
+
+    除了"整段唯一", 还要卡**跨度上限**: `.*?` 若从一个更早的同名起始行开始匹配, 整段照样
+    唯一, 却会把中间几百行一起换掉 —— 那是改坏了别的判据, 不是本格要测的东西。本轮就踩过
+    一次: `if missing:` 在 LAN 面板判据里也有一处, 非贪婪匹配从那儿起跳, 一口气吞掉 821 行。"""
+    m = re.search(pattern, SRC, flags)
+    assert m, pattern
+    g = m.group(0)
+    assert SRC.count(g) == 1, pattern
+    n = g.count("\n") + 1
+    assert n <= max_lines, "锚点跨度 %d 行, 超过上限 %d —— 八成从更早的同名行起跳了: %s" % (n, max_lines, pattern)
+    return g
+
+UNAVAIL   = lift(r'^    provs, why = _clash_rule_providers\(\)\n    if provs is None:\n.*?^                              % \(len\(meta\), why\)\)$')
+MISSING   = lift(r'^    if missing:\n        return \("fail", name, "这些规则集在配置里声明了.*?可达。"\)$')
+EMPTY     = lift(r'^    if empty:\n        return \("fail", name, "这些规则集在运行期.*?重建。"\)$')
+LOOPBACK  = lift(r'^    if host not in \("127\.0\.0\.1", "::1", "localhost", ""\):\n        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
+INCOMPL   = lift(r'^    if incomplete:\n        # 字段缺了.*?incomplete\[:6\]\)\)\)$')
+
+MUT = [
+    ("① 读不到管理面时退回 ok",
+     [(UNAVAIL, '    provs, why = _clash_rule_providers()\n'
+                '    if provs is None:\n'
+                '        return ("ok", name, "%d 个: 形态没问题" % len(meta))', 1)]),
+    ("② 不查「声明了却没同名 provider」",
+     [(MISSING, '    if False:  # 变异: 不再报缺失的 provider\n        pass', 1)]),
+    ("③ ruleCount==0 放过",
+     [(EMPTY, '    if False:  # 变异: 0 条也放过\n        pass', 1)]),
+    ("④ 去掉回环限制(会去连非回环控制面)",
+     [(LOOPBACK, '    if False:\n        return None, "x"  # 变异: 不再限制回环', 1)]),
+    ("⑤ 缺 ruleCount 当成通过",
+     [(INCOMPL, '    if False:  # 变异: 字段缺失也当证据齐全\n        pass', 1)]),
+    ("⑥ 只加无关注释(反向对照)",
+     [(LOOPBACK, "    # 变异: 一条无关注释\n" + LOOPBACK, 1)]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+wd = tmpguard.mkdtemp(prefix="pdg-rsrt-negctl.")
+try:
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)
+    target = Path(wd) / TGT
+    pristine = target.read_text(encoding="utf-8")
+
+    def suite():
+        """返回 (具名失败集合, 是否整支塌掉)。
+
+        改坏之后正控**根本没跑起来**(import 期就 NameError/SyntaxError)时, 它一条 ✗ 也不会
+        打印 —— 那与"判据没牙"长得一模一样。必须分开: 塌掉是夹具/改坏器的问题, 不能记成
+        这一格有牙, 也不能记成无效。"""
+        r = run(T, cwd=wd)
+        out = r.stdout + r.stderr
+        crashed = ("Traceback (most recent call last)" in out) or ("通过 " not in out)
+        return failures(out), crashed
+
+    base, base_crash = suite()
+    if base_crash:
+        bad("基线就跑不起来(正控在未改坏的副本上崩了)"); raise SystemExit(1)
+    if base:
+        bad("基线就不绿(%d 条):" % len(base))
+        for f in sorted(base)[:4]: print("       " + f[:130])
+        raise SystemExit(1)
+    ok("基线绿: 正控在未改坏的副本上 0 条具名失败")
+
+    for label, edits in MUT:
+        mutated, aborted = pristine, False
+        for old, new, want in edits:
+            hits = mutated.count(old)
+            if hits != want:
+                bad("%s → 锚点命中 %d 次, 预期 %d" % (label, hits, want)); aborted = True; break
+            if new == old:
+                bad("%s → 改坏器空转: 替换文本与原文一字不差" % label); aborted = True; break
+            mutated = mutated.replace(old, new, 1)
+        if aborted: continue
+        target.write_text(mutated, encoding="utf-8")
+        if run(["python3", "-m", "py_compile", str(target)], cwd=wd).returncode != 0:
+            bad("%s → 改坏后语法不合法" % label); target.write_text(pristine, encoding="utf-8"); continue
+        got, crashed = suite()
+        added = got - base
+        target.write_text(pristine, encoding="utf-8")
+        if crashed:
+            bad("%s → 改坏后正控整支塌掉(import/语法期就崩), 这一格没测到判据, "
+                "多半是锚点吞掉了别处代码" % label)
+            continue
+        if label.startswith("⑥"):
+            (ok if not added else bad)("%s → %d 条新增(应为 0)" % (label, len(added))); continue
+        if added:
+            ok("%s → 新增具名失败 %d 条" % (label, len(added)))
+            print("       " + sorted(added)[0][:130])
+        else:
+            bad("%s → 锚点命中但 0 条转红, 这一格无效" % label)
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+clean = all(sha(p) == before[p] and os.stat(p).st_mode == modes[p] for p in TOUCHED)
+(ok if clean else bad)("正式树未被污染: checks.py sha256 与 mode 均一致" if clean else "正式树被改动了!")
+print("-" * 62)
+print("ruleset-runtime-evidence-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-ruleset-evidence.py
+++ b/tests/test-ruleset-evidence.py
@@ -19,17 +19,17 @@
 用静态元数据说出来就是假绿。一个写着 `.yaml` 但运行期根本没被加载的 provider, 在这条判据
 下与一切正常的机器长得一模一样。
 
-本轮关掉的是这句假绿文案, **不是**运行期 provider 证据本身。要真证明"已加载", 需要一个
-安全的运行期查询接口(mihomo 的管理面), 那是架构待决项, 本轮不引入: 不新增 HTTP 管理端口、
-不读现有 9090、不偷偷开 ext-ctl-unix、不拿 `mihomo -t` 的配置语法通过冒充 provider 已加载、
-不去访问 provider URL 做在线探测。
+本支关掉的是那句假绿文案。运行期 provider 证据后来补上了(只 GET、只连回环的
+external-controller), 由 tests/test-ruleset-runtime-evidence.py 覆盖; 本支专管
+**运行期不可得**那一侧: 那时仍须 warn, 不许因为"试过了"就退回 ok。
 
 新契约:
   · 明确不兼容(.srs / format=binary / path 以 .srs 结尾)→ 仍然 **fail**;
   · 没有元数据 / 元数据为空 → 仍然 **None**(没配过规则集, 不是问题);
   · 元数据损坏 → **不得静默当成"没配置"**;
-  · 有规则集且静态形态没发现已知不兼容 → **warn**, 并说清"本项未读取运行期 provider 状态,
-    因此不能证明规则已加载";
+  · 有规则集、静态形态没发现已知不兼容、**且运行期证据不可得** → **warn**, 并说清
+    "不能证明规则已加载"(运行期取得到时给 ok 才是对的, 见
+    tests/test-ruleset-runtime-evidence.py);
   · WARN 不改变 `pdg doctor` 的总退出码(更新自检只按 level=="fail" 计数)。
 """
 import importlib.util
@@ -64,12 +64,16 @@ def ask(meta, raw=None):
             os.remove(p)
     else:
         json.dump(meta, open(p, "w", encoding="utf-8"))
-    old = checks.RS_META
+    # 本支测的是**运行期证据不可得**那一侧的契约, 所以把 MIHOMO_CFG 钉到一个不存在的路径:
+    # 否则结论会随宿主上有没有 mihomo 配置而变(装了并且 provider 齐全时 ok 才是对的,
+    # 那一侧由 tests/test-ruleset-runtime-evidence.py 覆盖)。
+    old, old_cfg = checks.RS_META, checks.MIHOMO_CFG
     checks.RS_META = p
+    checks.MIHOMO_CFG = os.path.join(WD, "no-such-mihomo-config.yaml")
     try:
         return checks.check_rulesets()
     finally:
-        checks.RS_META = old
+        checks.RS_META, checks.MIHOMO_CFG = old, old_cfg
 
 
 print("== 1. 没配过规则集: 保持 None(不是问题, 不该出现在报告里)==")

--- a/tests/test-ruleset-runtime-evidence.py
+++ b/tests/test-ruleset-runtime-evidence.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""`check_rulesets` 要能拿到**运行期证据**, 而不是永远停在"形态没问题"。
+
+v1.11.11 把这条判据从假绿改成 warn, 是对的 —— 它当时确实没读运行期。但那句 warn 是
+**证据缺口**, 不是终点: mihomo 的管理面(external-controller)就摆在那里, `/providers/rules`
+会给出每个 rule provider 的 `name / behavior / format / ruleCount / updatedAt`。拿到它,
+"已加载、多少条、何时更新"就是可证的; 拿不到, 才该继续说"无结论"。
+
+契约(缺一不可):
+
+  · **拿得到且齐全** —— 声明的每个规则集都能在运行期找到同名 provider, 且 ruleCount>0
+    → **ok**, 并报出条数与最旧的 updatedAt;
+  · **声明了却没加载**(运行期缺同名 provider)→ **fail**: 规则被静默丢弃, 分流是死的;
+  · **加载了但 ruleCount==0** → **fail**: 同上, "有这个 provider"不等于"有规则";
+  · **控制面读不到 / 非 200 / JSON 坏 / 字段缺** → **warn 且说明运行期状态不可得**,
+    绝不因为"试过了"就退回 ok;
+  · **external-controller 不是回环 / 没配** → **warn**, 且**不主动去连非回环地址**;
+  · 既有契约一个字不动: `.srs`/`format=binary` 仍 fail; 无元数据/空元数据仍 None;
+    元数据损坏仍 fail。
+
+本测试用**真的 HTTP 服务**绑回环随机端口冒充管理面(不碰 9090、不连任何生产机),
+元数据与配置都在隔离临时目录里。
+"""
+import importlib.util
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
+import tmpguard          # noqa: E402
+
+spec = importlib.util.spec_from_file_location("checks", ROOT / "deploy/bot/checks.py")
+checks = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(checks)
+
+PASS = [0]; FAIL = [0]
+def ok(m):  PASS[0] += 1; print("  ✓ %s" % m)
+def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
+
+WD = tmpguard.mkdtemp(prefix="pdg-rsrt.")
+
+
+class Fake(BaseHTTPRequestHandler):
+    """冒充 mihomo 管理面。只应答 /providers/rules; 行为由 server 上的属性决定。"""
+    def log_message(self, *a): pass
+
+    def do_GET(self):
+        code, body = self.server.plan.get(self.path, (404, b"{}"))
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def serve(plan):
+    srv = HTTPServer(("127.0.0.1", 0), Fake)
+    srv.plan = plan
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def providers_body(items):
+    return json.dumps({"providers": items}).encode()
+
+
+def ask(meta, controller=None, plan=None, raw=None):
+    """把 RS_META 与 MIHOMO_CFG 指到临时文件, 问一次判据。返回 (level,name,msg) 或 None。"""
+    mp = os.path.join(WD, "rulesets.json")
+    if raw is not None:
+        open(mp, "w", encoding="utf-8").write(raw)
+    elif meta is None:
+        if os.path.exists(mp): os.remove(mp)
+    else:
+        json.dump(meta, open(mp, "w", encoding="utf-8"))
+    cp = os.path.join(WD, "mihomo.json")
+    cfg = {}
+    if controller is not None:
+        cfg["external-controller"] = controller
+    json.dump(cfg, open(cp, "w", encoding="utf-8"))
+    old_rs, old_cfg = checks.RS_META, checks.MIHOMO_CFG
+    checks.RS_META, checks.MIHOMO_CFG = mp, cp
+    try:
+        return checks.check_rulesets()
+    finally:
+        checks.RS_META, checks.MIHOMO_CFG = old_rs, old_cfg
+
+
+def lvl(r): return r[0] if r else None
+def msg(r): return r[2] if r else ""
+
+META3 = {"rs_a": {"label": "A", "url": "https://x/a.list"},
+         "rs_b": {"label": "B", "url": "https://x/b.list"},
+         "rs_c": {"label": "C", "url": "https://x/c.list"}}
+FULL = {"rs_a": {"name": "rs_a", "behavior": "Classical", "format": "TextRule",
+                 "ruleCount": 13, "updatedAt": "2026-09-06T13:30:45Z"},
+        "rs_b": {"name": "rs_b", "behavior": "Classical", "format": "TextRule",
+                 "ruleCount": 44, "updatedAt": "2026-09-06T13:30:49Z"},
+        "rs_c": {"name": "rs_c", "behavior": "Classical", "format": "TextRule",
+                 "ruleCount": 129, "updatedAt": "2026-09-06T13:30:10Z"}}
+
+print("== 1. 运行期证据齐全 → 必须给出 ok, 并报条数 ==")
+srv = serve({"/providers/rules": (200, providers_body(FULL))})
+port = srv.server_address[1]
+r = ask(META3, controller="127.0.0.1:%d" % port)
+if lvl(r) == "ok" and "186" in msg(r):
+    ok("三个 provider 均已加载且 ruleCount>0 → ok, 文案含总条数 186: %s" % msg(r)[:80])
+elif lvl(r) == "ok":
+    ok("→ ok(但文案未报总条数): %s" % msg(r)[:90])
+else:
+    bad("运行期齐全却没给 ok: level=%s msg=%s" % (lvl(r), msg(r)[:110]))
+srv.shutdown()
+
+print("== 2. 声明了但运行期没有同名 provider → fail(规则被静默丢弃)==")
+srv = serve({"/providers/rules": (200, providers_body({k: FULL[k] for k in ("rs_a", "rs_b")}))})
+r = ask(META3, controller="127.0.0.1:%d" % srv.server_address[1])
+if lvl(r) == "fail" and ("rs_c" in msg(r) or "C" in msg(r)):
+    ok("缺 rs_c → fail 并点名: %s" % msg(r)[:80])
+else:
+    bad("声明了却没加载, 判据没报 fail: level=%s msg=%s" % (lvl(r), msg(r)[:110]))
+srv.shutdown()
+
+print("== 3. 加载了但 ruleCount==0 → fail ==")
+z = dict(FULL); z["rs_b"] = dict(FULL["rs_b"], ruleCount=0)
+srv = serve({"/providers/rules": (200, providers_body(z))})
+r = ask(META3, controller="127.0.0.1:%d" % srv.server_address[1])
+if lvl(r) == "fail" and ("rs_b" in msg(r) or "B" in msg(r)):
+    ok("ruleCount=0 → fail 并点名: %s" % msg(r)[:80])
+else:
+    bad("ruleCount=0 没被判 fail: level=%s msg=%s" % (lvl(r), msg(r)[:110]))
+srv.shutdown()
+
+print("== 4. 控制面连不上 → warn 且说明运行期不可得(不得退回 ok)==")
+srv = serve({"/providers/rules": (200, providers_body(FULL))})
+dead = srv.server_address[1]; srv.shutdown(); srv.server_close()
+r = ask(META3, controller="127.0.0.1:%d" % dead)
+if lvl(r) == "warn" and ("运行期" in msg(r) or "无结论" in msg(r) or "不可得" in msg(r)):
+    ok("连不上 → warn 且明说运行期状态不可得: %s" % msg(r)[:80])
+else:
+    bad("连不上时判据不对: level=%s msg=%s" % (lvl(r), msg(r)[:110]))
+
+print("== 5. 非 200 / JSON 坏 / 字段缺 → 一律 warn ==")
+bad_cases = [("非 200", {"/providers/rules": (500, b"{}")}),
+             ("JSON 坏", {"/providers/rules": (200, b"{not json")}),
+             ("缺 providers 键", {"/providers/rules": (200, b'{"x":1}')}),
+             ("缺 ruleCount", {"/providers/rules": (200, providers_body(
+                 {k: {kk: vv for kk, vv in v.items() if kk != "ruleCount"} for k, v in FULL.items()}))})]
+allw = True
+for label, plan in bad_cases:
+    srv = serve(plan)
+    r = ask(META3, controller="127.0.0.1:%d" % srv.server_address[1])
+    if lvl(r) != "warn":
+        allw = False; bad("%s → 期望 warn, 实得 %s: %s" % (label, lvl(r), msg(r)[:80]))
+    srv.shutdown()
+if allw:
+    ok("非 200 / JSON 坏 / 缺 providers / 缺 ruleCount 四种都判 warn")
+
+print("== 6. external-controller 非回环或缺失 → warn, 且不主动连非回环 ==")
+r1 = ask(META3, controller="10.0.0.5:9090")
+r2 = ask(META3, controller=None)
+if lvl(r1) == "warn" and lvl(r2) == "warn":
+    ok("非回环与未配置都判 warn(不主动外连): %s / %s" % (msg(r1)[:44], msg(r2)[:44]))
+else:
+    bad("非回环/缺失处理不对: %s / %s" % (lvl(r1), lvl(r2)))
+
+print("== 7. 既有契约不得回退 ==")
+srv = serve({"/providers/rules": (200, providers_body(FULL))})
+p = "127.0.0.1:%d" % srv.server_address[1]
+checks_srs = ask({"rs_x": {"label": "X", "url": "https://x/a.srs"}}, controller=p)
+none1 = ask(None, controller=p)
+none2 = ask({}, controller=p)
+broken = ask(None, controller=p, raw="{not json")
+srv.shutdown()
+probs = []
+if lvl(checks_srs) != "fail": probs.append(".srs 未判 fail(%s)" % lvl(checks_srs))
+if none1 is not None: probs.append("无元数据未返回 None")
+if none2 is not None: probs.append("空元数据未返回 None")
+if lvl(broken) != "fail": probs.append("元数据损坏未判 fail(%s)" % lvl(broken))
+if probs: bad("既有契约回退: " + "; ".join(probs))
+else: ok(".srs→fail / 无元数据→None / 空→None / 损坏→fail 四条既有契约均未回退")
+
+print()
+print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-ruleset-runtime-evidence.py
+++ b/tests/test-ruleset-runtime-evidence.py
@@ -162,10 +162,14 @@ if allw:
 print("== 6. external-controller 非回环或缺失 → warn, 且不主动连非回环 ==")
 r1 = ask(META3, controller="10.0.0.5:9090")
 r2 = ask(META3, controller=None)
-if lvl(r1) == "warn" and lvl(r2) == "warn":
-    ok("非回环与未配置都判 warn(不主动外连): %s / %s" % (msg(r1)[:44], msg(r2)[:44]))
+# 光看 level 不够: 去掉回环限制之后, 连非回环也会连失败 → 照样是 warn, 那这一格就白设了。
+# 判据落在**理由**上 —— 必须是"不在回环"(压根没去连), 而不是"读不到管理面"(连了没连上)。
+p1 = lvl(r1) == "warn" and "不在回环" in msg(r1) and "读不到管理面" not in msg(r1)
+p2 = lvl(r2) == "warn" and "未配置" in msg(r2)
+if p1 and p2:
+    ok("非回环 → warn 且理由是「不在回环」(根本没发起连接); 未配置 → warn 且理由是「未配置」")
 else:
-    bad("非回环/缺失处理不对: %s / %s" % (lvl(r1), lvl(r2)))
+    bad("非回环/缺失处理不对: r1=%s|%s ; r2=%s|%s" % (lvl(r1), msg(r1)[:60], lvl(r2), msg(r2)[:60]))
 
 print("== 7. 既有契约不得回退 ==")
 srv = serve({"/providers/rules": (200, providers_body(FULL))})


### PR DESCRIPTION
`pdg doctor` 的「规则集」一项从 v1.11.11 起一直报 🟡：判据只看 `rulesets.json` 的**静态形态**，
说不出"已被 mihomo 加载"。那个 warn 是**证据缺口**，不是终点——mihomo 的 external-controller
就在那里，`/providers/rules` 会给出每个 rule provider 的 `ruleCount` / `updatedAt`。

生产改动只有 `deploy/bot/checks.py`（+108/−6）。

## 新契约

| 情形 | 结论 |
|---|---|
| 声明的每个规则集都有同名 provider 且 `ruleCount > 0` | **ok** —— 报总条数与最旧更新时间 |
| 声明了却**没有同名 provider** | **fail** —— 规则被静默丢弃，分流对它是死的 |
| provider **解析出 0 条** | **fail** —— "有 provider" ≠ "有规则" |
| 管理面读不到 / 非 2xx / 应答结构不对 / 缺 `ruleCount` | **仍 warn 且明说无结论** |

既有契约一个字不动：`.srs` / `format=binary` 仍 fail；无元数据、空元数据仍 None；元数据损坏仍 fail。

## 边界

- **只 GET，只连回环。** `external-controller` 不在回环或没配置 → warn，判据**不主动去连非回环的
  管理端口**（那是控制面，能改配置、切出站）。
- 不新增管理端口、不开 ext-ctl-unix、不拿 `mihomo -t` 的语法通过冒充已加载、不去访问 provider
  地址做在线探测。
- secret 只用于加请求头，不记录不回显；mihomo 放顶层 `secret`，老 sing-box 放
  `experimental.clash_api.secret`，两处都读。
- 地址与 secret 按文本抽取，JSON 与 YAML 两种形态都认，不引 yaml 依赖。

## 验证

- 新正控 `tests/test-ruleset-runtime-evidence.py` **7/7**：用真的 HTTP 服务绑回环随机端口冒充
  管理面，不碰 9090、不连任何生产机。
- 新负控（**本地手动，未登记 CI**）**8/8**：五个变异各自转红（读不到退回 ok / 不查缺失 provider /
  放过 0 条 / 去掉回环限制 / 缺字段当通过），反向对照 0 新增。
  其中「去掉回环限制」那格的判据落在**理由文案**上——去掉限制后连非回环也只是连不上，level
  照样 warn，只有理由从「不在回环」变成「读不到管理面」才暴露它真去连了。
- 引用 `checks.py` 的 **25 支既有测试全绿**；规则集三支既有测试 28/32/30 未回退。
- 既有 `test-ruleset-evidence.py` 顺带把 `MIHOMO_CFG` 钉到不存在的路径：它测的是**运行期不可得**
  那一侧，否则结论会随宿主上有没有 mihomo 配置而变。

## 已知限制

- **尚未在任何生产机上跑过新判据**（要先发布再更新）。按 jp 现状推断会从 🟡 变 🟢，那是推断不是实测。
- jp2 是 iOS 机，配置可能不同；判据按"读不到就 warn"设计，最坏情况维持现状。
- 本 PR 未发布、未部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
