### PR TITLE
fix(doctor): constrain provider queries and preserve failure severity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,6 +941,9 @@ jobs:
       - name: "规则集运行期证据 (读 mihomo 管理面; 未加载/0 条判失败, 读不到仍只说无结论)"
         run: python3 tests/test-ruleset-runtime-evidence.py
 
+      - name: "管理面查询边界 (拒重定向/禁代理/地址族忠实; 确定性 FAIL 不被 WARN 遮住)"
+        run: python3 tests/test-provider-query-boundary.py
+
       # 弃用期内 runner 会把 node20 的 action 强行拉到 node24 上跑 —— 流程照常绿, 只是每个
       # job 都打一条 warning。那种"不红只是提醒"的形态最容易被放过, 直到某天 runner 不再兜底。
       - name: "action 运行时守卫 (没有 action 停在已弃用的 Node 20 上; 不认识的 action 判失败)"

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """PrivDNS Gateway 只读检查库。doctor.py 跑全部, healthcheck.py 跑子集。
 每个 check() 返回 (level, label, detail), level ∈ 'ok'|'warn'|'fail'|'info'。只读, 不改任何东西。"""
-import os, re, json, hashlib, ipaddress, platform, subprocess, sys, urllib.request
+import os, re, json, hashlib, ipaddress, platform, subprocess, sys, urllib.request, urllib.error
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import nftscan  # noqa: E402  与迁移前置门共用的 input 链冲突判据(单一来源)
@@ -1860,10 +1860,20 @@ def check_mitm():
 # 只做 GET, 只在**回环**地址上做。判据宁可"无结论"也不主动去连非回环的管理端口:
 # 那是控制面, 能改配置、切出站, 不该由一条自检去外连。
 def _clash_ctrl():
-    """解析 mihomo 的 external-controller。回环才给 base_url。
+    """解析 mihomo 的 external-controller。回环才给 base_url, **且地址族原样保留**。
 
     返回 (base_url, why)。base_url 为 None 时 why 说明为什么没有结论。
-    配置既可能是 JSON 形态(带引号的键)也可能是 YAML, 所以按文本抽, 不引 yaml 依赖。"""
+    配置既可能是 JSON 形态(带引号的键)也可能是 YAML, 所以按文本抽, 不引 yaml 依赖。
+
+    地址契约(逐种写清, 不做静默替换 —— 换一个地址就可能换成**另一个监听实例**):
+      · `127.0.0.1:P` / 其它 `127.x.y.z:P` → 回环, 原样用;
+      · `[::1]:P`                          → 回环, 原样用(URL 里保留方括号);
+      · `localhost:P`                      → 原样用 `localhost`, 由解析器决定 v4/v6;
+                                             我们不替它挑一个, 那是替用户改接收端;
+      · `:P`(空 host, 即通配监听)          → **无结论**: 通配不等于回环, 不能假定连上的是本机
+                                             那个实例;
+      · 其它主机名或非回环地址             → 无结论, 不主动连。
+    仓库渲染器生成的是 `127.0.0.1:9090`(见 deploy/bot/sb2mihomo.py), 正常机器落在第一条。"""
     try:
         txt = open(MIHOMO_CFG, encoding="utf-8", errors="replace").read()
     except OSError as e:
@@ -1872,13 +1882,27 @@ def _clash_ctrl():
     m = re.search(r'(?:^|[{,\s])"?external-controller"?\s*:\s*"?([^"\s,}]+)"?', txt, re.M)
     if not m:
         return None, "mihomo 未配置 external-controller"
-    host, _, port = m.group(1).strip().rpartition(":")
-    host = (host or "127.0.0.1").strip("[]")
+    raw = m.group(1).strip()
+    # `[v6]:port` 与 `host:port` 分开切, 否则 IPv6 里的冒号会把地址切碎。
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end < 0:
+            return None, "external-controller 形态不可解析"
+        host, rest = raw[1:end], raw[end + 1:]
+        port = rest[1:] if rest.startswith(":") else ""
+        literal = "[%s]" % host
+    else:
+        host, _, port = raw.rpartition(":")
+        literal = host
     if not port.isdigit():
         return None, "external-controller 形态不可解析"
-    if host not in ("127.0.0.1", "::1", "localhost", ""):
+    if host == "":
+        return None, ("external-controller 是通配监听(:%s) —— 通配不等于回环, "
+                      "本项不据此假定连到的是本机实例" % port)
+    is_loop = host in ("::1", "localhost") or re.match(r"^127\.\d+\.\d+\.\d+$", host)
+    if not is_loop:
         return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"
-    return "http://127.0.0.1:%s" % port, ""
+    return "http://%s:%s" % (literal, port), ""
 
 
 def _clash_secret():
@@ -1897,8 +1921,30 @@ def _clash_secret():
         return ""
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """不跟随任何重定向。
+
+    我们带着 `Authorization` 去问管理面, 而默认 opener 会自动请求 Location —— 那等于把凭据
+    交给**另一个接收端**。这里让重定向直接变成错误, 由调用方判成"无结论"。"""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _clash_opener():
+    """本次查询专属的 opener: **禁用环境代理, 禁止重定向**。
+
+    默认 opener 自带 ProxyHandler(读 http_proxy/HTTP_PROXY/all_proxy 等), 于是环境里有代理
+    时整个请求会交给代理 —— 连同 Authorization。管理面在回环上, 本来就不该经任何代理。
+    `ProxyHandler({})` 传空表即关闭代理查找。**不调 install_opener**: 只影响本次查询,
+    其它检查的网络行为一个字节都不变。"""
+    return urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
+
+
 def _clash_rule_providers(timeout=4):
-    """只读取运行期的 rule provider 状态。返回 (providers, None) 或 (None, 无结论原因)。"""
+    """只读取运行期的 rule provider 状态。返回 (providers, None) 或 (None, 无结论原因)。
+
+    只对配置指向的那个回环地址发一次 GET /providers/rules; 不经代理、不跟重定向。"""
     base, why = _clash_ctrl()
     if not base:
         return None, why
@@ -1907,9 +1953,16 @@ def _clash_rule_providers(timeout=4):
         sec = _clash_secret()
         if sec:
             req.add_header("Authorization", "Bearer " + sec)
-        with urllib.request.urlopen(req, timeout=timeout) as r:
+        with _clash_opener().open(req, timeout=timeout) as r:
             data = json.load(r)
-    except Exception as e:  # noqa: BLE001  连不上/非 2xx/超时/应答不是 JSON, 一律无结论
+    except urllib.error.HTTPError as e:
+        if 300 <= e.code < 400:
+            # 配置指向的那一端把我们支到别处去了。不跟 —— 跟了就等于把凭据送给另一个接收端,
+            # 而它的响应也证明不了**本机这个 mihomo** 的 provider 状态。
+            return None, ("管理面返回重定向(HTTP %d) —— 不跟随, 也不把另一个接收端的响应"
+                          "当作运行期证据" % e.code)
+        return None, "管理面返回 HTTP %d" % e.code
+    except Exception as e:  # noqa: BLE001  连不上/超时/应答不是 JSON, 一律无结论
         return None, "读不到管理面(%s)" % type(e).__name__
     if not isinstance(data, dict) or not isinstance(data.get("providers"), dict):
         return None, "管理面应答里没有 providers 对象"
@@ -1917,10 +1970,11 @@ def _clash_rule_providers(timeout=4):
 
 
 def check_rulesets():
-    """规则集的**静态形态**有没有已知不兼容 —— 只能说到这里, 说不到"已加载"。
+    """规则集: 静态形态 + **运行期 provider 证据**。
 
-    这条判据读的只有 `rulesets.json` 这份元数据, 所以它能证明的仅仅是: 文件读得出来、里面
-    没有明确属于 sing-box 的 `.srs` / `format=binary`、扩展名没命中已知不兼容形态。
+    第一段仍是静态形态: 读 `rulesets.json` 这份元数据 —— 文件读得出来、里面没有明确属于
+    sing-box 的 `.srs` / `format=binary`、扩展名没命中已知不兼容形态。静态这一段**说不到
+    "已加载"**, 所以后面才有第二段: 去管理面取运行期状态(见下)。
 
     它**证明不了**: mihomo 已经读到这些 provider、provider 下载成功、解析出非零条规则、
     运行期配置里真有对应的 RULE-SET、provider 当前没有 error。
@@ -2002,18 +2056,22 @@ def check_rulesets():
         u = str(p.get("updatedAt") or "")
         if u and (oldest is None or u < oldest):
             oldest = u
-    if incomplete:
-        # 字段缺了就是**读不出条数**, 与读不到管理面同级: 无结论, 不判故障也不给 ok。
-        return ("warn", name, "%d 个: 管理面应答里这些规则集没有可解析的 ruleCount, "
-                              "运行期条数无结论: %s" % (len(meta), "、".join(incomplete[:6])))
+    # 顺序要紧: **确定性失败优先**。以前先判 incomplete, 于是"A 已确认缺失 + B 缺 ruleCount"
+    # 整体只报 warn —— 一个已经证实是死规则的 provider, 被另一个 provider 的"无结论"盖掉了。
+    # 无结论不该降低已成立结论的等级; 它只作为附注跟在后面。
+    note = ("; 另有 %s 的 ruleCount 读不出, 那几项本次无结论" % "、".join(incomplete[:6])) if incomplete else ""
     if missing:
         return ("fail", name, "这些规则集在配置里声明了, 但 mihomo 运行期**没有对应的 provider** "
                               "—— 规则被静默丢弃, 分流对它们是死的: " + "、".join(missing[:6])
-                              + "。请在 bot「📑 分流管理」里重建, 或检查 provider 地址是否可达。")
+                              + "。请在 bot「📑 分流管理」里重建, 或检查 provider 地址是否可达。" + note)
     if empty:
         return ("fail", name, "这些规则集在运行期**解析出 0 条规则**(下载失败或内容为空), "
                               "分流对它们同样是死的: " + "、".join(empty[:6])
-                              + "。请检查 provider 地址与内容, 或在 bot 里重建。")
+                              + "。请检查 provider 地址与内容, 或在 bot 里重建。" + note)
+    if incomplete:
+        # 没有确定性失败, 但字段缺了 —— 读不出条数, 与读不到管理面同级: 无结论。
+        return ("warn", name, "%d 个: 管理面应答里这些规则集没有可解析的 ruleCount, "
+                              "运行期条数无结论: %s" % (len(meta), "、".join(incomplete[:6])))
     return ("ok", name, "%d 个, 运行期均已加载, 共 %d 条规则%s。"
                         % (len(meta), total, ("; 最旧一次更新 " + oldest[:19]) if oldest else ""))
 

--- a/deploy/bot/checks.py
+++ b/deploy/bot/checks.py
@@ -1866,13 +1866,16 @@ def _clash_ctrl():
     配置既可能是 JSON 形态(带引号的键)也可能是 YAML, 所以按文本抽, 不引 yaml 依赖。
 
     地址契约(逐种写清, 不做静默替换 —— 换一个地址就可能换成**另一个监听实例**):
-      · `127.0.0.1:P` / 其它 `127.x.y.z:P` → 回环, 原样用;
-      · `[::1]:P`                          → 回环, 原样用(URL 里保留方括号);
-      · `localhost:P`                      → 原样用 `localhost`, 由解析器决定 v4/v6;
-                                             我们不替它挑一个, 那是替用户改接收端;
-      · `:P`(空 host, 即通配监听)          → **无结论**: 通配不等于回环, 不能假定连上的是本机
-                                             那个实例;
-      · 其它主机名或非回环地址             → 无结论, 不主动连。
+      · `127.0.0.1:P` 及 127.0.0.0/8 内其它地址 → 回环, **原地址**照用;
+      · `[::1]:P`                               → 回环, 地址族与方括号都保留;
+      · `localhost:P` 及任何主机名              → **无结论, 且不做解析**。名字解析成什么地址
+                                                  由系统决定(hosts / nsswitch / DNS 都能改),
+                                                  那样"门检查的对象"与"实际连接的对象"就是
+                                                  两回事。**这是有意收紧的支持范围**, 不是
+                                                  没有行为变化;
+      · `:P`(空 host, 即通配监听)               → 无结论: 通配不等于回环;
+      · 非法数字地址(如 127.999.1.1)、非回环地址、非法端口 → 无结论, **零网络尝试**。
+    地址一律交给 `ipaddress` 严格解析后看 `is_loopback`, 不用正则比形状。
     仓库渲染器生成的是 `127.0.0.1:9090`(见 deploy/bot/sb2mihomo.py), 正常机器落在第一条。"""
     try:
         txt = open(MIHOMO_CFG, encoding="utf-8", errors="replace").read()
@@ -1890,19 +1893,24 @@ def _clash_ctrl():
             return None, "external-controller 形态不可解析"
         host, rest = raw[1:end], raw[end + 1:]
         port = rest[1:] if rest.startswith(":") else ""
-        literal = "[%s]" % host
     else:
         host, _, port = raw.rpartition(":")
-        literal = host
-    if not port.isdigit():
-        return None, "external-controller 形态不可解析"
+    if not port.isdigit() or not (0 < int(port) < 65536):
+        return None, "external-controller 的端口不合法(%s)" % (port or "缺失")
     if host == "":
         return None, ("external-controller 是通配监听(:%s) —— 通配不等于回环, "
                       "本项不据此假定连到的是本机实例" % port)
-    is_loop = host in ("::1", "localhost") or re.match(r"^127\.\d+\.\d+\.\d+$", host)
-    if not is_loop:
+    # **严格解析成数字 IP 再看 is_loopback**, 不用正则比形状: ^127\.\d+\.\d+\.\d+$ 这种会
+    # 放行 127.999.1.1 这类非法地址。主机名(含 localhost)一律无结论且**不做解析** —— 名字
+    # 解析出的地址由系统决定(hosts/nsswitch/DNS 都能改), 门检查的对象就会和实际连接的对象脱节。
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return None, ("external-controller 是主机名或非法数字地址 —— 本项只接受"
+                      "**数字回环地址**(127.0.0.0/8 或 ::1), 不对名字做解析")
+    if not ip.is_loopback:
         return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"
-    return "http://%s:%s" % (literal, port), ""
+    return "http://%s:%s" % ((("[%s]" % host) if ip.version == 6 else host), port), ""
 
 
 def _clash_secret():

--- a/tests/negctl/provider-query-boundary-negative-controls.py
+++ b/tests/negctl/provider-query-boundary-negative-controls.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""负控: **管理面查询的接收端边界 + 多故障判定优先级** 这几条判据有没有牙。
+
+正控在 tests/test-provider-query-boundary.py。
+
+这几处退化都不会让 doctor 看起来异常 —— 该绿的照样绿。露馅的地方在别处: 凭据被送到另一个
+接收端、请求打到另一个监听实例、或者一个已经证实是死规则的 provider 被"无结论"盖掉。
+
+四格 + 反向对照, 逐条撤销本轮的修复:
+
+  ① 撤销"禁止重定向"     —— 302 之后会去请求 Location, 并把 Authorization 一起带过去;
+  ② 撤销"禁用环境代理"   —— 环境里有代理时整个请求(连同凭据)交给代理;
+  ③ 撤销"IPv6 地址保留" —— [::1] 又被改写成 127.0.0.1, 可能是另一个监听实例;
+  ④ 撤销"FAIL 优先级"   —— 确定性失败重新被 WARN 遮住;
+  ⑤ 只加无关注释(反向对照) —— 不该产生任何新失败。
+
+①② 的判据落在正控记录的**真实接收次数**上, 不是源码形状。
+"""
+import hashlib, os, re, shutil, subprocess, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+TGT = "deploy/bot/checks.py"
+TOUCHED = [ROOT / TGT]
+PASS, FAIL = [0], [0]
+def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
+def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
+def sha(p): return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+def run(c, cwd): return subprocess.run(c, cwd=cwd, capture_output=True, text=True, timeout=1800)
+def failures(out):
+    return {re.sub(r"\s+", " ", l.strip())[:150] for l in out.splitlines()
+            if l.strip().startswith("✗")}
+
+T = ["python3", "tests/test-provider-query-boundary.py"]
+SRC = (ROOT / TGT).read_text(encoding="utf-8")
+
+
+def lift(pattern, max_lines=20, flags=re.M | re.S):
+    """锚点从产品源码原样取出, 并卡**跨度上限** —— `.*?` 从更早的同名行起跳时整段照样唯一,
+    却会把中间几百行一起换掉(本仓库踩过一次, 见 ruleset-runtime-evidence 负控的注释)。"""
+    m = re.search(pattern, SRC, flags)
+    assert m, pattern
+    g = m.group(0)
+    assert SRC.count(g) == 1, pattern
+    n = g.count("\n") + 1
+    assert n <= max_lines, "锚点跨度 %d 行, 超上限 %d: %s" % (n, max_lines, pattern)
+    return g
+
+
+OPENER  = lift(r'^    return urllib\.request\.build_opener\(urllib\.request\.ProxyHandler\(\{\}\), _NoRedirect\(\)\)$')
+V6KEEP  = lift(r'^    if raw\.startswith\("\["\):\n.*?^        literal = host$')
+PRIO    = lift(r'^    note = \(.*?\n    if missing:$')
+
+MUT = [
+    ("① 撤销「禁止重定向」",
+     [(OPENER, "    return urllib.request.build_opener(urllib.request.ProxyHandler({}))", 1)]),
+    ("② 撤销「禁用环境代理」",
+     [(OPENER, "    return urllib.request.build_opener(_NoRedirect())", 1)]),
+    ("③ 撤销「IPv6 地址保留」(改回硬编码 127.0.0.1)",
+     [(V6KEEP, '    if raw.startswith("["):\n'
+               '        host = raw[1:raw.find("]")]\n'
+               '        port = raw[raw.find("]") + 2:]\n'
+               '        literal = "127.0.0.1"   # 变异: 又改写成 IPv4\n'
+               '    else:\n'
+               '        host, _, port = raw.rpartition(":")\n'
+               '        literal = "127.0.0.1"   # 变异: 同上', 1)]),
+    ("④ 撤销「FAIL 优先级」(incomplete 重新排到前面)",
+     [(PRIO, '    note = ""\n'
+             '    if incomplete:\n'
+             '        return ("warn", name, "%d 个: 变异 —— 无结论重新盖住确定性失败: %s"\n'
+             '                              % (len(meta), "、".join(incomplete[:6])))\n'
+             '    if missing:', 1)]),
+    ("⑤ 只加无关注释(反向对照)",
+     [(OPENER, "    # 变异: 一条无关注释\n" + OPENER, 1)]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+wd = tmpguard.mkdtemp(prefix="pdg-pqb-negctl.")
+try:
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)
+    target = Path(wd) / TGT
+    pristine = target.read_text(encoding="utf-8")
+
+    def suite():
+        """(具名失败集合, 是否整支塌掉)。改坏后正控若在 import/语法期就崩, 一条 ✗ 也不会打印,
+        与"判据没牙"长得一样 —— 必须分开。"""
+        r = run(T, cwd=wd)
+        out = r.stdout + r.stderr
+        crashed = ("Traceback (most recent call last)" in out) or ("通过 " not in out)
+        return failures(out), crashed
+
+    base, base_crash = suite()
+    if base_crash:
+        bad("基线就跑不起来"); raise SystemExit(1)
+    if base:
+        bad("基线就不绿(%d 条):" % len(base))
+        for f in sorted(base)[:4]: print("       " + f[:130])
+        raise SystemExit(1)
+    ok("基线绿: 正控在未改坏的副本上 0 条具名失败")
+
+    for label, edits in MUT:
+        mutated, aborted = pristine, False
+        for old, new, want in edits:
+            hits = mutated.count(old)
+            if hits != want:
+                bad("%s → 锚点命中 %d 次, 预期 %d" % (label, hits, want)); aborted = True; break
+            if new == old:
+                bad("%s → 改坏器空转: 替换文本与原文一字不差" % label); aborted = True; break
+            mutated = mutated.replace(old, new, 1)
+        if aborted: continue
+        target.write_text(mutated, encoding="utf-8")
+        if run(["python3", "-m", "py_compile", str(target)], cwd=wd).returncode != 0:
+            bad("%s → 改坏后语法不合法" % label); target.write_text(pristine, encoding="utf-8"); continue
+        got, crashed = suite()
+        added = got - base
+        target.write_text(pristine, encoding="utf-8")
+        if crashed:
+            bad("%s → 改坏后正控整支塌掉, 这一格没测到判据" % label); continue
+        if label.startswith("⑤"):
+            (ok if not added else bad)("%s → %d 条新增(应为 0)" % (label, len(added))); continue
+        if added:
+            ok("%s → 新增具名失败 %d 条" % (label, len(added)))
+            print("       " + sorted(added)[0][:135])
+        else:
+            bad("%s → 锚点命中但 0 条转红, 这一格无效" % label)
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+clean = all(sha(p) == before[p] and os.stat(p).st_mode == modes[p] for p in TOUCHED)
+(ok if clean else bad)("正式树未被污染: checks.py sha256 与 mode 均一致" if clean else "正式树被改动了!")
+print("-" * 62)
+print("provider-query-boundary-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/negctl/provider-query-boundary-negative-controls.py
+++ b/tests/negctl/provider-query-boundary-negative-controls.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python3
-"""负控: **管理面查询的接收端边界 + 多故障判定优先级** 这几条判据有没有牙。
+"""负控: **管理面查询的接收端边界 / 地址门 / 多故障判定优先级** 这几条判据有没有牙。
 
 正控在 tests/test-provider-query-boundary.py。
 
 这几处退化都不会让 doctor 看起来异常 —— 该绿的照样绿。露馅的地方在别处: 凭据被送到另一个
-接收端、请求打到另一个监听实例、或者一个已经证实是死规则的 provider 被"无结论"盖掉。
+接收端、请求打到另一个监听实例、连到哪里由系统解析器说了算, 或者一个已经证实是死规则的
+provider 被"无结论"盖掉。
 
-四格 + 反向对照, 逐条撤销本轮的修复:
+七格 + 反向对照, 逐条撤销本轮与上一轮的修复:
 
-  ① 撤销"禁止重定向"     —— 302 之后会去请求 Location, 并把 Authorization 一起带过去;
-  ② 撤销"禁用环境代理"   —— 环境里有代理时整个请求(连同凭据)交给代理;
-  ③ 撤销"IPv6 地址保留" —— [::1] 又被改写成 127.0.0.1, 可能是另一个监听实例;
-  ④ 撤销"FAIL 优先级"   —— 确定性失败重新被 WARN 遮住;
-  ⑤ 只加无关注释(反向对照) —— 不该产生任何新失败。
+  ① 撤销「禁止重定向」   —— 302 之后会去请求 Location, 并把 Authorization 一起带过去;
+  ② 撤销「禁用环境代理」 —— 环境里有代理时整个请求(连同凭据)交给代理;
+  ③ 撤销「地址族保留」   —— [::1] 又被改写成 127.0.0.1, 可能是另一个监听实例;
+  ④ 撤销「FAIL 优先级」  —— 确定性失败重新被 WARN 遮住;
+  ⑤ 撤销「名字不放行」   —— localhost 直接放行, 检查对象与实际连接对象脱节;
+  ⑥ 撤销「严格解析地址」 —— 换回 `^127\\.\\d+\\.\\d+\\.\\d+$` 只比形状, 放行 127.999.1.1;
+  ⑦ **改坏测试自己**     —— 地址门那一格误走完整网络查询, 于是去碰不属于本轮的端口;
+  ⑧ 只加无关注释(反向对照) —— 不该产生任何新失败。
 
-①② 的判据落在正控记录的**真实接收次数**上, 不是源码形状。
+①② 的判据落在正控记录的**真实接收次数**上, 不是源码形状。⑦ 改的是测试而不是产品, 命中的是
+正控的收尾格(越界连接记账): 那些连接**全部由测试自带的拦截器在 connect 发包前拒掉**, 一个
+包也不会打到宿主上的任何服务。
 """
 import hashlib, os, re, shutil, subprocess, sys
 from pathlib import Path
@@ -22,8 +28,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import tmpguard          # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
-TGT = "deploy/bot/checks.py"
-TOUCHED = [ROOT / TGT]
+CHECKS = "deploy/bot/checks.py"
+PQB = "tests/test-provider-query-boundary.py"
+TOUCHED = [ROOT / CHECKS, ROOT / PQB]
 PASS, FAIL = [0], [0]
 def ok(m):  PASS[0] += 1; print("[OK]   %s" % m)
 def bad(m): FAIL[0] += 1; print("[FAIL] %s" % m)
@@ -33,46 +40,62 @@ def failures(out):
     return {re.sub(r"\s+", " ", l.strip())[:150] for l in out.splitlines()
             if l.strip().startswith("✗")}
 
-T = ["python3", "tests/test-provider-query-boundary.py"]
-SRC = (ROOT / TGT).read_text(encoding="utf-8")
+T = ["python3", PQB]
+SRC = {rel: (ROOT / rel).read_text(encoding="utf-8") for rel in (CHECKS, PQB)}
 
 
-def lift(pattern, max_lines=20, flags=re.M | re.S):
-    """锚点从产品源码原样取出, 并卡**跨度上限** —— `.*?` 从更早的同名行起跳时整段照样唯一,
-    却会把中间几百行一起换掉(本仓库踩过一次, 见 ruleset-runtime-evidence 负控的注释)。"""
-    m = re.search(pattern, SRC, flags)
-    assert m, pattern
+def lift(rel, pattern, max_lines=20, flags=re.M | re.S):
+    """锚点从源码原样取出, 并卡**跨度上限** —— `.*?` 从更早的同名行起跳时整段照样唯一,
+    却会把中间几百行一起换掉(本仓库踩过一次: 一个 `if missing:` 吞了 821 行)。"""
+    src = SRC[rel]
+    m = re.search(pattern, src, flags)
+    assert m, "%s: %s" % (rel, pattern)
     g = m.group(0)
-    assert SRC.count(g) == 1, pattern
+    assert src.count(g) == 1, "%s: %s" % (rel, pattern)
     n = g.count("\n") + 1
     assert n <= max_lines, "锚点跨度 %d 行, 超上限 %d: %s" % (n, max_lines, pattern)
     return g
 
 
-OPENER  = lift(r'^    return urllib\.request\.build_opener\(urllib\.request\.ProxyHandler\(\{\}\), _NoRedirect\(\)\)$')
-V6KEEP  = lift(r'^    if raw\.startswith\("\["\):\n.*?^        literal = host$')
-PRIO    = lift(r'^    note = \(.*?\n    if missing:$')
+OPENER = lift(CHECKS, r'^    return urllib\.request\.build_opener\(urllib\.request\.ProxyHandler\(\{\}\), _NoRedirect\(\)\)$')
+# 地址族的保留点在**返回那一行**(v1.11.13+ 改成 ipaddress 严格解析后再拼回去)。
+V6KEEP = lift(CHECKS, r'^    return "http://%s:%s" % \(\(\("\[%s\]" % host\) if ip\.version == 6 else host\), port\), ""$')
+VALERR = lift(CHECKS, r'^    try:\n        ip = ipaddress\.ip_address\(host\)\n    except ValueError:\n.*?不对名字做解析"\)$')
+STRICT = lift(CHECKS, r'^    try:\n        ip = ipaddress\.ip_address\(host\)\n.*?^        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
+PRIO   = lift(CHECKS, r'^    note = \(.*?\n    if missing:$')
+GATEQ  = lift(PQB, r'^    p = subprocess\.run\(\[sys\.executable, "-c", CTRL,.*?驱动异常:" \+ \(p\.stdout \+ p\.stderr\)\[:120\]\]$')
 
 MUT = [
-    ("① 撤销「禁止重定向」",
+    ("① 撤销「禁止重定向」", CHECKS,
      [(OPENER, "    return urllib.request.build_opener(urllib.request.ProxyHandler({}))", 1)]),
-    ("② 撤销「禁用环境代理」",
+    ("② 撤销「禁用环境代理」", CHECKS,
      [(OPENER, "    return urllib.request.build_opener(_NoRedirect())", 1)]),
-    ("③ 撤销「IPv6 地址保留」(改回硬编码 127.0.0.1)",
-     [(V6KEEP, '    if raw.startswith("["):\n'
-               '        host = raw[1:raw.find("]")]\n'
-               '        port = raw[raw.find("]") + 2:]\n'
-               '        literal = "127.0.0.1"   # 变异: 又改写成 IPv4\n'
-               '    else:\n'
-               '        host, _, port = raw.rpartition(":")\n'
-               '        literal = "127.0.0.1"   # 变异: 同上', 1)]),
-    ("④ 撤销「FAIL 优先级」(incomplete 重新排到前面)",
+    ("③ 撤销「地址族保留」(又硬编码回 127.0.0.1)", CHECKS,
+     [(V6KEEP, '    return "http://127.0.0.1:%s" % port, ""   # 变异: 地址族被静默改写', 1)]),
+    ("④ 撤销「FAIL 优先级」(incomplete 重新排到前面)", CHECKS,
      [(PRIO, '    note = ""\n'
              '    if incomplete:\n'
              '        return ("warn", name, "%d 个: 变异 —— 无结论重新盖住确定性失败: %s"\n'
              '                              % (len(meta), "、".join(incomplete[:6])))\n'
              '    if missing:', 1)]),
-    ("⑤ 只加无关注释(反向对照)",
+    ("⑤ 撤销「名字不放行」(localhost 直接放行)", CHECKS,
+     [(VALERR, '    try:\n'
+               '        ip = ipaddress.ip_address(host)\n'
+               '    except ValueError:\n'
+               '        if host == "localhost":\n'
+               '            # 变异: 只把名字放行, 真正连到哪里交给系统解析器决定\n'
+               '            return "http://%s:%s" % (host, port), ""\n'
+               '        return None, "external-controller 是主机名或非法数字地址"', 1)]),
+    ("⑥ 撤销「严格解析地址」(换回只比形状的 127.* 正则)", CHECKS,
+     [(STRICT, '    # 变异: 只比形状, 不做地址解析 —— 127.999.1.1 这类非法地址会被放行\n'
+               '    if not re.match(r"^127\\.\\d+\\.\\d+\\.\\d+$", host) and host != "::1":\n'
+               '        return None, "external-controller 不在回环(变异: 只比形状)"\n'
+               '    ip = ipaddress.ip_address("::1" if host == "::1" else "127.0.0.1")', 1)]),
+    ("⑦ 改坏测试自己: 地址门那一格误走完整网络查询", PQB,
+     [(GATEQ, '    # 变异: 本该只调地址解析函数, 却发起完整查询 —— 目标是不属于本轮的端口\n'
+              '    r = query(controller, secret="")\n'
+              '    return [r["base"], r["why"]]', 1)]),
+    ("⑧ 只加无关注释(反向对照)", CHECKS,
      [(OPENER, "    # 变异: 一条无关注释\n" + OPENER, 1)]),
 ]
 
@@ -82,8 +105,7 @@ wd = tmpguard.mkdtemp(prefix="pdg-pqb-negctl.")
 try:
     for sub in ("tests", "deploy", "lib"):
         shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True)
-    target = Path(wd) / TGT
-    pristine = target.read_text(encoding="utf-8")
+    pristine = {rel: (Path(wd) / rel).read_text(encoding="utf-8") for rel in (CHECKS, PQB)}
 
     def suite():
         """(具名失败集合, 是否整支塌掉)。改坏后正控若在 import/语法期就崩, 一条 ✗ 也不会打印,
@@ -102,8 +124,9 @@ try:
         raise SystemExit(1)
     ok("基线绿: 正控在未改坏的副本上 0 条具名失败")
 
-    for label, edits in MUT:
-        mutated, aborted = pristine, False
+    for label, rel, edits in MUT:
+        target = Path(wd) / rel
+        mutated, aborted = pristine[rel], False
         for old, new, want in edits:
             hits = mutated.count(old)
             if hits != want:
@@ -114,24 +137,26 @@ try:
         if aborted: continue
         target.write_text(mutated, encoding="utf-8")
         if run(["python3", "-m", "py_compile", str(target)], cwd=wd).returncode != 0:
-            bad("%s → 改坏后语法不合法" % label); target.write_text(pristine, encoding="utf-8"); continue
+            bad("%s → 改坏后语法不合法" % label); target.write_text(pristine[rel], encoding="utf-8"); continue
         got, crashed = suite()
         added = got - base
-        target.write_text(pristine, encoding="utf-8")
+        target.write_text(pristine[rel], encoding="utf-8")
         if crashed:
             bad("%s → 改坏后正控整支塌掉, 这一格没测到判据" % label); continue
-        if label.startswith("⑤"):
+        if label.startswith("⑧"):
             (ok if not added else bad)("%s → %d 条新增(应为 0)" % (label, len(added))); continue
         if added:
             ok("%s → 新增具名失败 %d 条" % (label, len(added)))
-            print("       " + sorted(added)[0][:135])
+            for f in sorted(added)[:2]:
+                print("       " + f[:135])
         else:
             bad("%s → 锚点命中但 0 条转红, 这一格无效" % label)
 finally:
     shutil.rmtree(wd, ignore_errors=True)
 
 clean = all(sha(p) == before[p] and os.stat(p).st_mode == modes[p] for p in TOUCHED)
-(ok if clean else bad)("正式树未被污染: checks.py sha256 与 mode 均一致" if clean else "正式树被改动了!")
+(ok if clean else bad)("正式树未被污染: checks.py 与正控 py 的 sha256/mode 均一致"
+                       if clean else "正式树被改动了!")
 print("-" * 62)
 print("provider-query-boundary-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
 sys.exit(1 if FAIL[0] else 0)

--- a/tests/negctl/ruleset-runtime-evidence-negative-controls.py
+++ b/tests/negctl/ruleset-runtime-evidence-negative-controls.py
@@ -55,7 +55,9 @@ def lift(pattern, max_lines=20, flags=re.M | re.S):
 UNAVAIL   = lift(r'^    provs, why = _clash_rule_providers\(\)\n    if provs is None:\n.*?^                              % \(len\(meta\), why\)\)$')
 MISSING   = lift(r'^    if missing:\n        return \("fail", name, "这些规则集在配置里声明了.*?可达。" \+ note\)$')
 EMPTY     = lift(r'^    if empty:\n        return \("fail", name, "这些规则集在运行期.*?重建。" \+ note\)$')
-LOOPBACK  = lift(r'^    is_loop = host in \("::1", "localhost"\).*?\n    if not is_loop:\n        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
+# v1.11.13+ 的地址门改成了"严格解析数字 IP 再看 is_loopback"(不再有 is_loop 变量),
+# 锚点跟着挪到 `if not ip.is_loopback:` 这两行。
+LOOPBACK  = lift(r'^    if not ip\.is_loopback:\n        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
 INCOMPL   = lift(r'^    if incomplete:\n        # 没有确定性失败.*?incomplete\[:6\]\)\)\)$')
 
 MUT = [
@@ -68,7 +70,7 @@ MUT = [
     ("③ ruleCount==0 放过",
      [(EMPTY, '    if False:  # 变异: 0 条也放过\n        pass', 1)]),
     ("④ 去掉回环限制(会去连非回环控制面)",
-     [(LOOPBACK, '    is_loop = True  # 变异: 不再限制回环\n    if not is_loop:\n        return None, "x"', 1)]),
+     [(LOOPBACK, '    if False:  # 变异: 不再限制回环\n        return None, "x"', 1)]),
     ("⑤ 缺 ruleCount 当成通过",
      [(INCOMPL, '    if False:  # 变异: 字段缺失也当证据齐全\n        pass', 1)]),
     ("⑥ 只加无关注释(反向对照)",

--- a/tests/negctl/ruleset-runtime-evidence-negative-controls.py
+++ b/tests/negctl/ruleset-runtime-evidence-negative-controls.py
@@ -53,10 +53,10 @@ def lift(pattern, max_lines=20, flags=re.M | re.S):
     return g
 
 UNAVAIL   = lift(r'^    provs, why = _clash_rule_providers\(\)\n    if provs is None:\n.*?^                              % \(len\(meta\), why\)\)$')
-MISSING   = lift(r'^    if missing:\n        return \("fail", name, "这些规则集在配置里声明了.*?可达。"\)$')
-EMPTY     = lift(r'^    if empty:\n        return \("fail", name, "这些规则集在运行期.*?重建。"\)$')
-LOOPBACK  = lift(r'^    if host not in \("127\.0\.0\.1", "::1", "localhost", ""\):\n        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
-INCOMPL   = lift(r'^    if incomplete:\n        # 字段缺了.*?incomplete\[:6\]\)\)\)$')
+MISSING   = lift(r'^    if missing:\n        return \("fail", name, "这些规则集在配置里声明了.*?可达。" \+ note\)$')
+EMPTY     = lift(r'^    if empty:\n        return \("fail", name, "这些规则集在运行期.*?重建。" \+ note\)$')
+LOOPBACK  = lift(r'^    is_loop = host in \("::1", "localhost"\).*?\n    if not is_loop:\n        return None, "external-controller 不在回环 —— 本项不主动连非回环管理端口"$')
+INCOMPL   = lift(r'^    if incomplete:\n        # 没有确定性失败.*?incomplete\[:6\]\)\)\)$')
 
 MUT = [
     ("① 读不到管理面时退回 ok",
@@ -68,7 +68,7 @@ MUT = [
     ("③ ruleCount==0 放过",
      [(EMPTY, '    if False:  # 变异: 0 条也放过\n        pass', 1)]),
     ("④ 去掉回环限制(会去连非回环控制面)",
-     [(LOOPBACK, '    if False:\n        return None, "x"  # 变异: 不再限制回环', 1)]),
+     [(LOOPBACK, '    is_loop = True  # 变异: 不再限制回环\n    if not is_loop:\n        return None, "x"', 1)]),
     ("⑤ 缺 ruleCount 当成通过",
      [(INCOMPL, '    if False:  # 变异: 字段缺失也当证据齐全\n        pass', 1)]),
     ("⑥ 只加无关注释(反向对照)",

--- a/tests/test-provider-query-boundary.py
+++ b/tests/test-provider-query-boundary.py
@@ -25,6 +25,7 @@ v1.11.13 让 `check_rulesets` 去读 mihomo 管理面取运行期证据, 这一�
 不访问公网或生产。**完整查询格会核对连接目标属于本格登记的服务**; 地址门那一格只调地址解析
 函数, 不走网络。超时只用于回收故障夹具, 不作判据。
 """
+import atexit
 import http.server
 import json
 import os
@@ -44,6 +45,9 @@ def ok(m):  PASS[0] += 1; print("  ✓ %s" % m)
 def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
 
 WD = tmpguard.mkdtemp(prefix="pdg-pqb.")
+# 全程记账: 任何一格都不许连**非本轮登记**的端口。拦截器在 connect 前拦下并记账,
+# 这里在收尾统一核对 —— 上一轮就是因为地址格走了完整查询, 去碰了不属于本轮的端口。
+BLOCKED_ALL = []
 TOKEN = "acc-selfmade-token-2f9c41a7"          # 自造, 与任何真实 secret 无关
 
 FULL = {"rs_a": {"name": "rs_a", "ruleCount": 13, "updatedAt": "2026-09-06T13:30:45Z"},
@@ -79,15 +83,46 @@ class Rec(http.server.BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 
+SERVERS = []
+
+
 def serve(mode="ok", providers=None, location=None, family=socket.AF_INET):
+    """起一个**本轮拥有**的回环假服务, 端口交给内核随机分配(绑 0)。"""
     class S(http.server.HTTPServer):
         address_family = family
     host = "127.0.0.1" if family == socket.AF_INET else "::1"
     srv = S((host, 0), Rec)
     srv.mode = mode; srv.providers = providers or FULL; srv.location = location
     srv.hits = []
-    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    srv._th = threading.Thread(target=srv.serve_forever, daemon=True)
+    srv._th.start()
+    SERVERS.append(srv)
     return srv
+
+
+def stop(srv):
+    """shutdown + server_close + 等线程退出; 异常路径也走这里。"""
+    try:
+        srv.shutdown()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        srv.server_close()
+    except Exception:  # noqa: BLE001
+        pass
+    th = getattr(srv, "_th", None)
+    if th is not None:
+        th.join(timeout=5)
+    if srv in SERVERS:
+        SERVERS.remove(srv)
+
+
+@atexit.register
+def _reap_servers():
+    """异常/断言中断也要把假服务收干净 —— 否则线程连同监听端口一直挂着。
+    临时目录由 tmpguard 在它自己的 atexit 里清, 这里只管进程内的服务。"""
+    for srv in list(SERVERS):
+        stop(srv)
 
 
 def addr_of(srv):
@@ -151,10 +186,13 @@ def query(controller, meta=META2, secret=TOKEN, env=None, own=(), fake=None):
                         json.dumps(fake or {})],
                        capture_output=True, text=True, timeout=60, env=e)
     try:
-        return json.loads(p.stdout.strip().splitlines()[-1])
+        out = json.loads(p.stdout.strip().splitlines()[-1])
     except Exception:
-        return {"base": None, "why": "驱动异常", "res": None, "stats": {"getaddrinfo": 0, "connect": [], "blocked": []},
-                "err": (p.stdout + p.stderr)[:300]}
+        out = {"base": None, "why": "驱动异常", "res": None,
+               "stats": {"getaddrinfo": 0, "connect": [], "blocked": []},
+               "err": (p.stdout + p.stderr)[:300]}
+    BLOCKED_ALL.extend((out.get("stats") or {}).get("blocked") or [])
+    return out
 
 
 print("== A1. 管理面回 302: 不得请求 Location, 更不得把 Authorization 交给另一端 ==")
@@ -170,7 +208,7 @@ elif lvl == "warn":
     ok("302 → 目标端 0 次接收, 判据给 warn(不把重定向后的响应当运行期证据)")
 else:
     bad("302 → 目标端未被请求, 但判据给了 %s(应 warn): %s" % (lvl, (r["res"] or ["","",""])[2][:80]))
-conf.shutdown(); other.shutdown()
+stop(conf); stop(other)
 
 print("== A2. 环境里有代理: 仍须直连配置端, 代理接收次数必须为 0 ==")
 proxy = serve(mode="ok", providers={"proxied": {"name": "proxied", "ruleCount": 1}})
@@ -186,7 +224,7 @@ elif conf.hits and lvl == "ok":
     ok("代理 0 次接收, 配置端实收 %d 次, 判据正常给出 ok" % len(conf.hits))
 else:
     bad("代理 0 次, 但配置端实收 %d 次 / 判据 %s" % (len(conf.hits), lvl))
-conf.shutdown(); proxy.shutdown()
+stop(conf); stop(proxy)
 
 print("== A3. 凭据不得出现在文案里 ==")
 conf = serve(mode="ok")
@@ -195,7 +233,7 @@ txt = json.dumps(r, ensure_ascii=False)
 (ok if TOKEN not in txt else bad)("返回结构与文案里不含自造 token")
 got_auth = [h for h in conf.hits if h["auth"] == "Bearer " + TOKEN]
 (ok if got_auth else bad)("配置端确实收到了 Authorization(%d 次) —— 有鉴权路径仍能工作" % len(got_auth))
-conf.shutdown()
+stop(conf)
 
 print("== B. 地址门(只调地址解析函数, 零网络; 端口用不占用的高位号, 不连任何服务)==")
 CTRL = r'''
@@ -224,7 +262,7 @@ GATE = [
     ("127.0.0.1:45001", "http://127.0.0.1:45001", None),
     ("[::1]:45002",     "http://[::1]:45002",     None),
     ("127.0.0.53:45003","http://127.0.0.53:45003", None),
-    ("127.999.1.1:45004", None, "不是合法"),
+    ("127.999.1.1:45004", None, "非法数字地址"),
     ("localhost:45005",   None, "数字回环"),
     ("10.0.0.5:45006",    None, "不在回环"),
     (":45007",            None, "通配"),
@@ -267,7 +305,7 @@ try:
         ok("[::1] 上的假管理面实收 %d 次, 判据给 ok —— IPv6 目标真的连通了" % len(s6.hits))
     else:
         bad("IPv6 实连未成立: 接收 %d 次, 判据 %s, base=%s why=%s" % (len(s6.hits), lvl, r["base"], r["why"]))
-    s6.shutdown()
+    stop(s6)
 except OSError as e:
     print("  [SKIP] 本环境 IPv6 回环不可用(%s) —— 实连这一格未执行, 不计入通过" % e)
 
@@ -289,7 +327,12 @@ for label, provs, want in cases:
         ok("%-24s → %s" % (label, got))
     else:
         bad("%-24s → 实得 %s, 期望 %s: %s" % (label, got, want, msg[:90]))
-    srv.shutdown()
+    stop(srv)
+
+print("== E. 测试自身的访问范围: 全程只连本轮登记的回环服务 ==")
+(ok if not BLOCKED_ALL else bad)(
+    "拦截器记录的越界连接尝试 %d 条%s" % (len(BLOCKED_ALL),
+    "" if not BLOCKED_ALL else " —— 测试碰了不属于本轮的端口: %s" % BLOCKED_ALL[:4]))
 
 print()
 print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))

--- a/tests/test-provider-query-boundary.py
+++ b/tests/test-provider-query-boundary.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""管理面查询的**接收端边界**与**多故障判定优先级**。
+
+v1.11.13 让 `check_rulesets` 去读 mihomo 管理面取运行期证据, 这一步本身是对的。但那次实现
+留了三个洞, 本支逐个钉死:
+
+  A. **接收端可能不是配置指向的那一个。** 查询走 `urllib.request.urlopen` 的默认 opener,
+     它自带 ProxyHandler(读 `http_proxy`/`HTTP_PROXY` 等环境变量)与 HTTPRedirectHandler。
+     于是: 环境里有代理时请求会交给代理; 管理面回一个 302 时会去请求 Location。
+     而我们**带着 `Authorization: Bearer <secret>`** —— 凭据可能被送到另一个接收端。
+     判据必须落在**真实接收次数与凭据是否越界**上, 不是"源码里有没有 urlopen"。
+
+  B. **地址被静默改写。** `_clash_ctrl` 解析出 host 之后一律返回 `http://127.0.0.1:<port>`,
+     配置写 `[::1]:9090` 也会被打到 IPv4 回环 —— 那可能是**另一个监听实例**。
+
+  C. **确定性 FAIL 被 WARN 遮住。** 判定顺序是 incomplete → missing → empty, 于是"A 缺失 +
+     B 缺 ruleCount"整体只报 WARN, 一个已经证实为死规则的 provider 被一条"无结论"盖掉。
+
+本支所有接收端都是**本轮自己起的回环端口**, 用自造 token, 不碰真实 9090、不用真实 secret、
+不访问公网或生产。超时只用于回收故障夹具, 不作判据。
+"""
+import http.server
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tests"))
+import tmpguard          # noqa: E402
+
+PASS = [0]; FAIL = [0]
+def ok(m):  PASS[0] += 1; print("  ✓ %s" % m)
+def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
+
+WD = tmpguard.mkdtemp(prefix="pdg-pqb.")
+TOKEN = "acc-selfmade-token-2f9c41a7"          # 自造, 与任何真实 secret 无关
+
+FULL = {"rs_a": {"name": "rs_a", "ruleCount": 13, "updatedAt": "2026-09-06T13:30:45Z"},
+        "rs_b": {"name": "rs_b", "ruleCount": 44, "updatedAt": "2026-09-06T13:30:49Z"}}
+META2 = {"rs_a": {"label": "A"}, "rs_b": {"label": "B"}}
+
+
+class Rec(http.server.BaseHTTPRequestHandler):
+    """记录每一次接收: 路径与是否带 Authorization。行为由 server.mode 决定。"""
+    protocol_version = "HTTP/1.1"
+    def log_message(self, *a): pass
+
+    def _record(self):
+        self.server.hits.append({"path": self.path,
+                                 "auth": self.headers.get("Authorization"),
+                                 "host": self.headers.get("Host")})
+
+    def do_GET(self):
+        self._record()
+        m = self.server.mode
+        if m == "redirect":
+            body = b""
+            self.send_response(302)
+            self.send_header("Location", self.server.location)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        body = json.dumps({"providers": self.server.providers}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def serve(mode="ok", providers=None, location=None, family=socket.AF_INET):
+    class S(http.server.HTTPServer):
+        address_family = family
+    host = "127.0.0.1" if family == socket.AF_INET else "::1"
+    srv = S((host, 0), Rec)
+    srv.mode = mode; srv.providers = providers or FULL; srv.location = location
+    srv.hits = []
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+def addr_of(srv):
+    a = srv.server_address
+    return ("[%s]:%d" % (a[0], a[1])) if srv.address_family == socket.AF_INET6 else "%s:%d" % (a[0], a[1])
+
+
+DRIVER = r'''
+import importlib.util, json, os, sys
+spec = importlib.util.spec_from_file_location("checks", sys.argv[1])
+c = importlib.util.module_from_spec(spec); spec.loader.exec_module(c)
+c.MIHOMO_CFG = sys.argv[2]; c.RS_META = sys.argv[3]; c.SB = sys.argv[2] + ".nosuch"
+base, why = c._clash_ctrl()
+r = c.check_rulesets()
+print(json.dumps({"base": base, "why": why, "res": list(r) if r else None}))
+'''
+
+
+def query(controller, meta=META2, secret=TOKEN, env=None, providers_cfg=None):
+    """在**子进程**里跑一次真实查询(代理等环境变量只有新进程才确定生效)。"""
+    cfg = os.path.join(WD, "mihomo.json")
+    d = {}
+    if controller is not None: d["external-controller"] = controller
+    if secret: d["secret"] = secret
+    json.dump(d, open(cfg, "w", encoding="utf-8"))
+    mp = os.path.join(WD, "rulesets.json")
+    json.dump(meta, open(mp, "w", encoding="utf-8"))
+    e = dict(os.environ)
+    for k in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "all_proxy", "no_proxy", "NO_PROXY"):
+        e.pop(k, None)
+    if env: e.update(env)
+    p = subprocess.run([sys.executable, "-c", DRIVER, str(ROOT / "deploy/bot/checks.py"), cfg, mp],
+                       capture_output=True, text=True, timeout=60, env=e)
+    try:
+        return json.loads(p.stdout.strip().splitlines()[-1])
+    except Exception:
+        return {"base": None, "why": "驱动异常", "res": None, "err": (p.stdout + p.stderr)[:300]}
+
+
+print("== A1. 管理面回 302: 不得请求 Location, 更不得把 Authorization 交给另一端 ==")
+other = serve(mode="ok")
+conf = serve(mode="redirect", location="http://%s/providers/rules" % addr_of(other))
+r = query(addr_of(conf))
+lvl = (r["res"] or [None])[0]
+auth_leaked = [h for h in other.hits if h["auth"]]
+if other.hits:
+    bad("重定向目标收到了 %d 次请求(应 0); 其中带 Authorization 的 %d 次 —— 凭据越过了配置指向的接收端"
+        % (len(other.hits), len(auth_leaked)))
+elif lvl == "warn":
+    ok("302 → 目标端 0 次接收, 判据给 warn(不把重定向后的响应当运行期证据)")
+else:
+    bad("302 → 目标端未被请求, 但判据给了 %s(应 warn): %s" % (lvl, (r["res"] or ["","",""])[2][:80]))
+conf.shutdown(); other.shutdown()
+
+print("== A2. 环境里有代理: 仍须直连配置端, 代理接收次数必须为 0 ==")
+proxy = serve(mode="ok", providers={"proxied": {"name": "proxied", "ruleCount": 1}})
+conf = serve(mode="ok")
+paddr = "http://%s" % addr_of(proxy)
+r = query(addr_of(conf), env={"http_proxy": paddr, "HTTP_PROXY": paddr, "all_proxy": paddr})
+lvl = (r["res"] or [None])[0]
+pauth = [h for h in proxy.hits if h["auth"]]
+if proxy.hits:
+    bad("代理收到了 %d 次管理面请求(应 0); 其中带 Authorization 的 %d 次; 配置端实收 %d 次"
+        % (len(proxy.hits), len(pauth), len(conf.hits)))
+elif conf.hits and lvl == "ok":
+    ok("代理 0 次接收, 配置端实收 %d 次, 判据正常给出 ok" % len(conf.hits))
+else:
+    bad("代理 0 次, 但配置端实收 %d 次 / 判据 %s" % (len(conf.hits), lvl))
+conf.shutdown(); proxy.shutdown()
+
+print("== A3. 凭据不得出现在文案里 ==")
+conf = serve(mode="ok")
+r = query(addr_of(conf))
+txt = json.dumps(r, ensure_ascii=False)
+(ok if TOKEN not in txt else bad)("返回结构与文案里不含自造 token")
+got_auth = [h for h in conf.hits if h["auth"] == "Bearer " + TOKEN]
+(ok if got_auth else bad)("配置端确实收到了 Authorization(%d 次) —— 有鉴权路径仍能工作" % len(got_auth))
+conf.shutdown()
+
+print("== B. 地址忠实于配置: [::1] 不得被改写成 127.0.0.1 ==")
+r6 = query("[::1]:9090", secret="")
+base = r6["base"] or ""
+if "127.0.0.1" in base:
+    bad("配置 [::1]:9090 → 实际目标 %s, IPv6 回环被静默改成 IPv4(可能是另一个监听实例)" % base)
+elif "[::1]" in base:
+    ok("配置 [::1]:9090 → 目标保留为 %s" % base)
+else:
+    bad("配置 [::1]:9090 → 目标 %r, 既不是 IPv6 也没给出无结论理由(why=%s)" % (base, r6["why"]))
+r4 = query("127.0.0.1:9091", secret="")
+(ok if (r4["base"] or "").startswith("http://127.0.0.1:9091") else bad)(
+    "IPv4 配置仍忠实: %s" % r4["base"])
+
+print("== B2. IPv6 实连(隔离环境; 不可用则明确记录, 不冒充通过)==")
+try:
+    s6 = serve(family=socket.AF_INET6)
+    r = query(addr_of(s6), secret="")
+    lvl = (r["res"] or [None])[0]
+    if s6.hits and lvl == "ok":
+        ok("[::1] 上的假管理面实收 %d 次, 判据给 ok —— IPv6 目标真的连通了" % len(s6.hits))
+    else:
+        bad("IPv6 实连未成立: 接收 %d 次, 判据 %s, base=%s why=%s" % (len(s6.hits), lvl, r["base"], r["why"]))
+    s6.shutdown()
+except OSError as e:
+    print("  [SKIP] 本环境 IPv6 回环不可用(%s) —— 实连这一格未执行, 不计入通过" % e)
+
+print("== C. 混合异常: 确定性 FAIL 不得被 WARN 遮住 ==")
+cases = [
+    ("A 缺失 + B 缺 ruleCount", {"rs_b": {"name": "rs_b"}}, "fail"),
+    ("A 为 0 条 + B 缺 ruleCount", {"rs_a": {"name": "rs_a", "ruleCount": 0}, "rs_b": {"name": "rs_b"}}, "fail"),
+    ("仅字段不完整", {"rs_a": {"name": "rs_a"}, "rs_b": {"name": "rs_b"}}, "warn"),
+    ("仅缺失", {"rs_a": FULL["rs_a"]}, "fail"),
+    ("仅 0 条", {"rs_a": dict(FULL["rs_a"], ruleCount=0), "rs_b": FULL["rs_b"]}, "fail"),
+    ("全部正常", FULL, "ok"),
+]
+for label, provs, want in cases:
+    srv = serve(mode="ok", providers=provs)
+    r = query(addr_of(srv), secret="")
+    got = (r["res"] or [None])[0]
+    msg = (r["res"] or ["", "", ""])[2]
+    if got == want:
+        ok("%-24s → %s" % (label, got))
+    else:
+        bad("%-24s → 实得 %s, 期望 %s: %s" % (label, got, want, msg[:90]))
+    srv.shutdown()
+
+print()
+print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-provider-query-boundary.py
+++ b/tests/test-provider-query-boundary.py
@@ -16,8 +16,14 @@ v1.11.13 让 `check_rulesets` 去读 mihomo 管理面取运行期证据, 这一�
   C. **确定性 FAIL 被 WARN 遮住。** 判定顺序是 incomplete → missing → empty, 于是"A 缺失 +
      B 缺 ruleCount"整体只报 WARN, 一个已经证实为死规则的 provider 被一条"无结论"盖掉。
 
-本支所有接收端都是**本轮自己起的回环端口**, 用自造 token, 不碰真实 9090、不用真实 secret、
-不访问公网或生产。超时只用于回收故障夹具, 不作判据。
+  D. **地址门认的是"形状"而不是地址。** `^127\.\d+\.\d+\.\d+$` 这种正则会放行 `127.999.1.1`
+     这类**非法数字地址**; 而 `localhost` 被直接放行, 于是真正连到哪里由系统解析器决定 ——
+     检查对象与实际连接对象脱节。收紧成: 用 `ipaddress` 严格解析数字 IP 并看 `is_loopback`,
+     主机名一律无结论、**不做解析**。
+
+本支所有接收端都是**本轮自己起的回环端口(随机可用端口)**, 用自造 token, 不用真实 secret、
+不访问公网或生产。**完整查询格会核对连接目标属于本格登记的服务**; 地址门那一格只调地址解析
+函数, 不走网络。超时只用于回收故障夹具, 不作判据。
 """
 import http.server
 import json
@@ -90,18 +96,45 @@ def addr_of(srv):
 
 
 DRIVER = r'''
-import importlib.util, json, os, sys
+import importlib.util, json, os, socket, sys
+# 记账 + 拦截: 解析与连接都要留痕; 目标不在本格登记的白名单里就**在发包前**拒掉。
+# [["127.0.0.1", 41234], ...] -> {(host, port)}; json 给的是 list, 直接 set() 会 unhashable。
+ALLOW = {(a, int(b)) for a, b in json.loads(sys.argv[4])}
+STATS = {"getaddrinfo": 0, "connect": [], "blocked": []}
+FAKE = json.loads(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[5] else {}
+_gai = socket.getaddrinfo
+def gai(host, port, *a, **k):
+    STATS["getaddrinfo"] += 1
+    if host in FAKE:            # 模拟解析: 名字被解到一个**非回环**地址
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (FAKE[host], int(port)))]
+    return _gai(host, port, *a, **k)
+socket.getaddrinfo = gai
+_conn = socket.socket.connect
+def conn(self, addr):
+    try:
+        hp = (addr[0], int(addr[1]))
+    except Exception:
+        hp = (str(addr), -1)
+    STATS["connect"].append(list(hp))
+    if hp not in ALLOW:
+        STATS["blocked"].append(list(hp))
+        raise OSError("blocked-by-test: %s 不属于本格登记的回环服务" % (hp,))
+    return _conn(self, addr)
+socket.socket.connect = conn
 spec = importlib.util.spec_from_file_location("checks", sys.argv[1])
 c = importlib.util.module_from_spec(spec); spec.loader.exec_module(c)
 c.MIHOMO_CFG = sys.argv[2]; c.RS_META = sys.argv[3]; c.SB = sys.argv[2] + ".nosuch"
 base, why = c._clash_ctrl()
 r = c.check_rulesets()
-print(json.dumps({"base": base, "why": why, "res": list(r) if r else None}))
+print(json.dumps({"base": base, "why": why, "res": list(r) if r else None, "stats": STATS}))
 '''
 
 
-def query(controller, meta=META2, secret=TOKEN, env=None, providers_cfg=None):
-    """在**子进程**里跑一次真实查询(代理等环境变量只有新进程才确定生效)。"""
+def query(controller, meta=META2, secret=TOKEN, env=None, own=(), fake=None):
+    """在**子进程**里跑一次真实查询(代理等环境变量只有新进程才确定生效)。
+
+    `own` 是本格**自己起的**回环服务列表; 连接目标不在其中的, 在 socket.connect 里就被拦下并
+    记账 —— 测试绝不去碰不属于本轮的监听端口。"""
     cfg = os.path.join(WD, "mihomo.json")
     d = {}
     if controller is not None: d["external-controller"] = controller
@@ -113,18 +146,21 @@ def query(controller, meta=META2, secret=TOKEN, env=None, providers_cfg=None):
     for k in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "all_proxy", "no_proxy", "NO_PROXY"):
         e.pop(k, None)
     if env: e.update(env)
-    p = subprocess.run([sys.executable, "-c", DRIVER, str(ROOT / "deploy/bot/checks.py"), cfg, mp],
+    allow = json.dumps([[srv.server_address[0], srv.server_address[1]] for srv in own])
+    p = subprocess.run([sys.executable, "-c", DRIVER, str(ROOT / "deploy/bot/checks.py"), cfg, mp, allow,
+                        json.dumps(fake or {})],
                        capture_output=True, text=True, timeout=60, env=e)
     try:
         return json.loads(p.stdout.strip().splitlines()[-1])
     except Exception:
-        return {"base": None, "why": "驱动异常", "res": None, "err": (p.stdout + p.stderr)[:300]}
+        return {"base": None, "why": "驱动异常", "res": None, "stats": {"getaddrinfo": 0, "connect": [], "blocked": []},
+                "err": (p.stdout + p.stderr)[:300]}
 
 
 print("== A1. 管理面回 302: 不得请求 Location, 更不得把 Authorization 交给另一端 ==")
 other = serve(mode="ok")
 conf = serve(mode="redirect", location="http://%s/providers/rules" % addr_of(other))
-r = query(addr_of(conf))
+r = query(addr_of(conf), own=(conf, other))
 lvl = (r["res"] or [None])[0]
 auth_leaked = [h for h in other.hits if h["auth"]]
 if other.hits:
@@ -140,7 +176,7 @@ print("== A2. 环境里有代理: 仍须直连配置端, 代理接收次数必�
 proxy = serve(mode="ok", providers={"proxied": {"name": "proxied", "ruleCount": 1}})
 conf = serve(mode="ok")
 paddr = "http://%s" % addr_of(proxy)
-r = query(addr_of(conf), env={"http_proxy": paddr, "HTTP_PROXY": paddr, "all_proxy": paddr})
+r = query(addr_of(conf), env={"http_proxy": paddr, "HTTP_PROXY": paddr, "all_proxy": paddr}, own=(conf, proxy))
 lvl = (r["res"] or [None])[0]
 pauth = [h for h in proxy.hits if h["auth"]]
 if proxy.hits:
@@ -154,30 +190,78 @@ conf.shutdown(); proxy.shutdown()
 
 print("== A3. 凭据不得出现在文案里 ==")
 conf = serve(mode="ok")
-r = query(addr_of(conf))
+r = query(addr_of(conf), own=(conf,))
 txt = json.dumps(r, ensure_ascii=False)
 (ok if TOKEN not in txt else bad)("返回结构与文案里不含自造 token")
 got_auth = [h for h in conf.hits if h["auth"] == "Bearer " + TOKEN]
 (ok if got_auth else bad)("配置端确实收到了 Authorization(%d 次) —— 有鉴权路径仍能工作" % len(got_auth))
 conf.shutdown()
 
-print("== B. 地址忠实于配置: [::1] 不得被改写成 127.0.0.1 ==")
-r6 = query("[::1]:9090", secret="")
-base = r6["base"] or ""
-if "127.0.0.1" in base:
-    bad("配置 [::1]:9090 → 实际目标 %s, IPv6 回环被静默改成 IPv4(可能是另一个监听实例)" % base)
-elif "[::1]" in base:
-    ok("配置 [::1]:9090 → 目标保留为 %s" % base)
+print("== B. 地址门(只调地址解析函数, 零网络; 端口用不占用的高位号, 不连任何服务)==")
+CTRL = r'''
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("checks", sys.argv[1])
+c = importlib.util.module_from_spec(spec); spec.loader.exec_module(c)
+c.MIHOMO_CFG = sys.argv[2]
+print(json.dumps(list(c._clash_ctrl())))
+'''
+
+
+def ctrl(controller):
+    """只问地址门, 不跑 check_rulesets —— 这一格一个包都不发。"""
+    cfg = os.path.join(WD, "ctrl.json")
+    json.dump({} if controller is None else {"external-controller": controller},
+              open(cfg, "w", encoding="utf-8"))
+    p = subprocess.run([sys.executable, "-c", CTRL, str(ROOT / "deploy/bot/checks.py"), cfg],
+                       capture_output=True, text=True, timeout=30)
+    try:
+        return json.loads(p.stdout.strip().splitlines()[-1])
+    except Exception:
+        return [None, "驱动异常:" + (p.stdout + p.stderr)[:120]]
+
+
+GATE = [
+    ("127.0.0.1:45001", "http://127.0.0.1:45001", None),
+    ("[::1]:45002",     "http://[::1]:45002",     None),
+    ("127.0.0.53:45003","http://127.0.0.53:45003", None),
+    ("127.999.1.1:45004", None, "不是合法"),
+    ("localhost:45005",   None, "数字回环"),
+    ("10.0.0.5:45006",    None, "不在回环"),
+    (":45007",            None, "通配"),
+    ("127.0.0.1:abc",     None, "端口"),
+    ("127.0.0.1:0",       None, "端口"),
+]
+for raw, want_base, want_why in GATE:
+    base, why = ctrl(raw)
+    if want_base is not None:
+        (ok if base == want_base else bad)("%-20s → %s" % (raw, base if base == want_base else "实得 %r(期望 %s)" % (base, want_base)))
+    elif base is not None:
+        bad("%-20s → 被放行为 %s(应拒绝: %s)" % (raw, base, want_why))
+    elif want_why in (why or ""):
+        ok("%-20s → 拒绝, 理由含「%s」: %s" % (raw, want_why, (why or "")[:44]))
+    else:
+        bad("%-20s → 拒绝了但理由不对(期望含 %r): %s" % (raw, want_why, why))
+
+print("== B3. 名字不做解析: 模拟把 localhost 解到非回环地址, 解析与连接都必须为 0 次 ==")
+# 拦截器在 socket.connect **发包之前**记账并拒绝, 全程不产生任何真实非回环连接;
+# 也不改 hosts、不动系统 DNS。
+r = query("localhost:45111", secret="", own=(), fake={"localhost": "203.0.113.7"})
+st = r.get("stats") or {}
+gai_n = st.get("getaddrinfo", -1)
+conns = st.get("connect") or []
+nonloop = [c for c in conns if not str(c[0]).startswith("127.") and c[0] != "::1"]
+if gai_n == 0 and not conns:
+    ok("localhost 在地址门就被拒(理由: %s); 解析 0 次、连接尝试 0 次" % (r["why"] or "")[:44])
 else:
-    bad("配置 [::1]:9090 → 目标 %r, 既不是 IPv6 也没给出无结论理由(why=%s)" % (base, r6["why"]))
-r4 = query("127.0.0.1:9091", secret="")
-(ok if (r4["base"] or "").startswith("http://127.0.0.1:9091") else bad)(
-    "IPv4 配置仍忠实: %s" % r4["base"])
+    bad("localhost 未在地址门拦下: 解析 %d 次, 连接尝试 %s(其中非回环 %s) —— "
+        "检查对象与实际连接对象脱节" % (gai_n, conns, nonloop))
+(ok if not nonloop else bad)("全程没有对非回环地址发起过连接(拦截器记录 %d 条被拦: %s)"
+                             % (len(st.get("blocked") or []), (st.get("blocked") or [])[:2]))
 
 print("== B2. IPv6 实连(隔离环境; 不可用则明确记录, 不冒充通过)==")
 try:
     s6 = serve(family=socket.AF_INET6)
-    r = query(addr_of(s6), secret="")
+    r = query(addr_of(s6), secret="", own=(s6,))
     lvl = (r["res"] or [None])[0]
     if s6.hits and lvl == "ok":
         ok("[::1] 上的假管理面实收 %d 次, 判据给 ok —— IPv6 目标真的连通了" % len(s6.hits))
@@ -198,7 +282,7 @@ cases = [
 ]
 for label, provs, want in cases:
     srv = serve(mode="ok", providers=provs)
-    r = query(addr_of(srv), secret="")
+    r = query(addr_of(srv), secret="", own=(srv,))
     got = (r["res"] or [None])[0]
     msg = (r["res"] or ["", "", ""])[2]
     if got == want:

--- a/tests/test-ruleset-runtime-evidence.py
+++ b/tests/test-ruleset-runtime-evidence.py
@@ -24,6 +24,7 @@ v1.11.11 把这条判据从假绿改成 warn, 是对的 —— 它当时确实�
 import importlib.util
 import json
 import os
+import socket
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -43,6 +44,29 @@ def bad(m): FAIL[0] += 1; print("  ✗ %s" % m)
 
 WD = tmpguard.mkdtemp(prefix="pdg-rsrt.")
 
+# ── 连接所有权拦截器 ────────────────────────────────────────────────────────
+# 本支的接收端只能是**本进程自己起的回环假管理面**。加这层是因为负控要撤掉产品里的回环限制,
+# 撤掉之后被测代码会真的去连用例里写的那个非回环地址(10.0.0.5:9090) —— 那是一个不属于本轮、
+# 也不该被打扰的地址。拦截器在 socket.connect **发包之前**拒绝并记账, 于是负控照样有牙,
+# 却一个包也不会离开本机。记账在收尾统一核对。
+OWNED = set()
+BLOCKED = []
+_conn = socket.socket.connect
+
+
+def _guarded_connect(self, addr):
+    try:
+        hp = (addr[0], int(addr[1]))
+    except Exception:  # noqa: BLE001
+        hp = (str(addr), -1)
+    if hp not in OWNED:
+        BLOCKED.append(list(hp))
+        raise OSError("blocked-by-test: %s 不属于本轮登记的回环服务" % (hp,))
+    return _conn(self, addr)
+
+
+socket.socket.connect = _guarded_connect
+
 
 class Fake(BaseHTTPRequestHandler):
     """冒充 mihomo 管理面。只应答 /providers/rules; 行为由 server 上的属性决定。"""
@@ -60,6 +84,7 @@ class Fake(BaseHTTPRequestHandler):
 def serve(plan):
     srv = HTTPServer(("127.0.0.1", 0), Fake)
     srv.plan = plan
+    OWNED.add((srv.server_address[0], srv.server_address[1]))   # 登记: 只有它允许被连
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     return srv
 
@@ -186,6 +211,11 @@ if none2 is not None: probs.append("空元数据未返回 None")
 if lvl(broken) != "fail": probs.append("元数据损坏未判 fail(%s)" % lvl(broken))
 if probs: bad("既有契约回退: " + "; ".join(probs))
 else: ok(".srs→fail / 无元数据→None / 空→None / 损坏→fail 四条既有契约均未回退")
+
+print("== 8. 测试自身的访问范围: 全程只连本轮登记的回环服务 ==")
+(ok if not BLOCKED else bad)(
+    "拦截器记录的越界连接尝试 %d 条%s"
+    % (len(BLOCKED), "" if not BLOCKED else " —— 碰了不属于本轮的地址: %s" % BLOCKED[:4]))
 
 print()
 print("通过 %d, 失败 %d" % (PASS[0], FAIL[0]))


### PR DESCRIPTION
`check_rulesets` 在 v1.11.13 开始去读 mihomo 管理面取运行期证据。那一步方向是对的，但它把
**"往哪里发请求"和"谁收到请求"**这两件事交给了 urllib 的默认行为，又让一条"无结论"能盖住
已经成立的失败。这条分支把请求边界、地址判据和判定顺序各自钉死，并顺手收紧了测试自身的
连接范围。

整条分支 7 笔：6 文件、+628/−26。**生产改动只有 `deploy/bot/checks.py`（+87/−21）**；其余是
2 支正控（新增 1 支、扩充 1 支）、2 支负控与 `ci.yml` 的 3 行登记。

## 1. 请求专属 opener：不经代理、不跟重定向

`_clash_rule_providers` 以前走 `urllib.request.urlopen`，用的是**默认 opener**——它自带
`ProxyHandler`（读 `http_proxy` / `HTTP_PROXY` / `all_proxy`）与 `HTTPRedirectHandler`。
我们带着 `Authorization: Bearer <secret>` 去问管理面，于是两条路都能把**凭据交给另一个
接收端**：环境里有代理时整个请求交给代理；管理面回 302 时自动去请求 Location。

改成本次查询专属的 opener：`build_opener(ProxyHandler({}), _NoRedirect())`。3xx 由
`_NoRedirect` 变成错误，调用方判成"无结论"并明说不跟随。**不调 `install_opener`**——
只影响这一次查询，其它检查的网络行为一个字节都不变。

## 2. 只接受合法数字回环地址，地址族原样保留

`_clash_ctrl` 以前用 `^127\.\d+\.\d+\.\d+$` 比形状，并且解析出 host 之后一律返回
`http://127.0.0.1:<port>`。两处都不成立：

- **形状不等于地址**：`127.999.1.1` 能过这条正则，但它压根不是合法 IPv4；
- **地址族被静默改写**：配置写 `[::1]:9090` 会被打到 IPv4 回环——那可能是**另一个监听实例**。

现在把 host 交给 `ipaddress.ip_address()` 严格解析，再看 `is_loopback`；返回时按
`ip.version` 决定要不要加方括号，IPv4/IPv6 各自原样保留。端口从"是数字"收紧成
`0 < port < 65536`，理由写明是端口不合法而不是笼统的"形态不可解析"。通配监听（空 host）
仍判无结论：通配不等于回环。

## 3. localhost 不再主动查询 —— 明确的支持范围收紧

`localhost` 以前被直接当回环放行。但名字解析成什么地址由系统决定（hosts / nsswitch / DNS
都能改），于是**门检查的对象是字符串 `localhost`，实际连接的对象是解析器当时给出的任意
地址**，这条自检会带着 `Authorization` 去连它。

现在主机名一律无结论、**且不做解析**（零网络尝试）。**这是有意收紧的支持范围，不是"无行为
变化"**：此前写 `localhost:9090` 的配置能查到运行期证据，现在退成 WARN，理由写明只接受
数字回环地址。仓库自己的渲染器 `deploy/bot/sb2mihomo.py` 生成的是 `127.0.0.1:9090`，
默认路径不受影响。

## 4. 已成立的 FAIL 不被别人的"无结论"降级

判定顺序以前是 `incomplete` → `missing` → `empty`，于是"A 已确认在运行期缺失 + B 的
`ruleCount` 读不出"整体只报 WARN——**一个已经证实是死规则的 provider，被另一个 provider
的"无结论"盖掉了**。

改成 `missing` → `empty` → `incomplete`：确定性失败优先，`incomplete` 只作为附注跟在
文案后面。没有确定性失败时，字段缺失仍然是 WARN（与"读不到管理面"同级）。

## 5. 测试自身的连接所有权

上一轮的地址格用完整查询走了 `[::1]:9090`、`127.0.0.1:9091` 这些**不属于该轮**的端口。
开发机上那两个端口没有监听、调用也没带 secret，没有证据表明连上过或泄露过凭据；但
"测试可以去碰不属于自己的监听端口"本身就是错的边界。

两支正控各加一层记账拦截器，在 `socket.connect` **发包之前**核对目标：

- `tests/test-provider-query-boundary.py`：驱动子进程按本格登记的 ALLOW 集合拦截，主进程
  收尾统一核对（E 格）。**地址门那几格改走只调 `_clash_ctrl` 的驱动，一个包都不发。**
- `tests/test-ruleset-runtime-evidence.py`：`serve()` 建服务即登记，全局拦截器按登记表放行，
  第 8 格核对。这层是必需的——它的 ④ 号负控要撤掉产品的回环限制，撤掉之后被测代码会真的
  去连用例里的 `10.0.0.5:9090`；现在那次尝试在发包前被拦下并记账，负控照样有牙，却一个包
  也不离开本机。

假服务的收尾也补全了：`stop()` 做 shutdown + server_close + join 线程，并注册 `atexit`，
断言中断/抛异常时同样收干净。

## 6. 实际证据（接收次数来自隔离假管理面）

所有接收端都是**测试自己起的回环随机端口**，用自造 token。以下是 exact-head CI 日志原文：

```
✓ 302 → 目标端 0 次接收, 判据给 warn(不把重定向后的响应当运行期证据)
✓ 代理 0 次接收, 配置端实收 1 次, 判据正常给出 ok
✓ 返回结构与文案里不含自造 token
✓ 配置端确实收到了 Authorization(1 次) —— 有鉴权路径仍能工作
✓ 127.0.0.1:45001      → http://127.0.0.1:45001
✓ [::1]:45002          → http://[::1]:45002
✓ 127.0.0.53:45003     → http://127.0.0.53:45003
✓ 127.999.1.1:45004    → 拒绝, 理由含「非法数字地址」
✓ localhost:45005      → 拒绝, 理由含「数字回环」
✓ 10.0.0.5:45006       → 拒绝, 理由含「不在回环」
✓ :45007               → 拒绝, 理由含「通配」
✓ 127.0.0.1:abc / 127.0.0.1:0 → 拒绝, 理由含「端口」
✓ localhost 在地址门就被拒; 解析 0 次、连接尝试 0 次
✓ [::1] 上的假管理面实收 1 次, 判据给 ok —— IPv6 目标真的连通了
✓ A 缺失 + B 缺 ruleCount     → fail
✓ A 为 0 条 + B 缺 ruleCount  → fail
✓ 仅字段不完整                   → warn
✓ 仅缺失 / 仅 0 条                → fail
✓ 全部正常                     → ok
✓ 拦截器记录的越界连接尝试 0 条
```

**这些接收次数是隔离假管理面的记录，不是生产或真实 mihomo 现场的验证。**

## 7. 证据分档

**exact-head CI**（`workflow_dispatch` run
[34128336266](https://github.com/misaka-cpu/privdns-gateway/actions/runs/34128336266)，
attempt=1，head=`75e94bd2b1ab9b17a4fac73b453099f01bbfa364`）：

- **32/32 jobs、656/656 steps 全部 success**，GitHub step skipped 0；
- `tests/test-provider-query-boundary.py` → `通过 23, 失败 0`；
- `tests/test-ruleset-runtime-evidence.py` → `通过 8, 失败 0`；
- checkout 自身输出的 `git log -1 --format=%H` = 冻结 head。

相对基线（main run 34106393839，32 jobs / 655 steps）唯一差异：`lint` job 249 → 250 步，
新增的就是本 PR 登记的那一条正控。

**负控（本地手动证据，未在 CI 执行）**：

- `tests/negctl/provider-query-boundary-negative-controls.py` → 通过 10，失败 0。
  七格变异逐条转红：撤销禁重定向 / 撤销禁代理 / 撤销地址族保留 / 撤销 FAIL 优先级 /
  localhost 直接放行 / 换回只比形状的 `127.*` 正则 / **改坏测试自己**（地址格误走完整
  查询）；外加只加无关注释的反向对照 0 条新增。
- `tests/negctl/ruleset-runtime-evidence-negative-controls.py` → 通过 8，失败 0。

按本仓库惯例，`tests/negctl/` 下的负控是本地手动门，`ci.yml` 里对这两支的引用数为 0——
**它们不构成 CI 覆盖**。

## 8. 生产状态口径

本 PR **未读取生产配置**。只能确认：仓库渲染器 `sb2mihomo.py` 默认生成
`external-controller: 127.0.0.1:9090`，**默认路径兼容**；**不能据此断言 jp/jp2 上的实际
配置就是默认值**——部署前需逐机读取。

**没有生产凭据泄露的实证。** 已发现并修复的是请求边界与判定缺陷，不得写成"现网已泄露"。
本 PR 不涉及回滚、更换凭据、关闭管理面或重启服务。

另外：运行期能查到 provider 且 `ruleCount > 0`，**只说明规则集被内核加载了、条数不为零**，
不等于实际流量已经命中这些规则，也不等于所有分流都有效。

## Known boundaries

- **新正控 docstring 的 SyntaxWarning 尚未修复**：CI 会打出
  `tests/test-provider-query-boundary.py:2: SyntaxWarning: invalid escape sequence '\.'`
  （docstring 写了 `^127\.\d+…` 但不是 raw 字符串）。非阻塞，步骤仍 success。仓库另有 3 个
  测试文件是同类告警（`test-dot-render.py`、`test-firewall-template-sync.py`、
  `test-ratelimit-judgement.py`），属既有形态，一并留待后续处理。
- **既有环境 SKIP 不算已验收**：本 run 里脚本内部 SKIP 共 38 行（缺 nft、缺 CAP_SYS_ADMIN、
  无真 mihomo 等）。其中 `e2e-firewall-template-sync.sh` 打印 `[SKIP] 缺 nft` →
  `通过 0, 失败 0, 跳过 1`，步骤仍绿；该输出与基线**逐字相同**，是既有的、如实声明的证据
  缺口，不是本 PR 引入，也不能算作已验收。
- **localhost 支持范围变化**：见 §3。部署前必须逐机读取 `external-controller` 的实际写法。
- 本 PR **未发布、未部署**，也未处理其它清债项。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
