### PR TITLE
fix(bot): harden update-check lifecycle and message ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,6 +944,12 @@ jobs:
       - name: "管理面查询边界 (拒重定向/禁代理/地址族忠实; 确定性 FAIL 不被 WARN 遮住)"
         run: python3 tests/test-provider-query-boundary.py
 
+      # 用户反复遇到「检查更新中…」不结束。三个根因: 整段 git log 拼进一条消息超 Telegram
+      # 长度上限、异常只包到前半段、检查同步占住主 getUpdates 轮询。这一支把整条链路钉死。
+      # 隔离 git 仓库 + 假 Telegram 接收端, 不连真实 API、不用真实 token、不碰生产。
+      - name: "Bot 更新检查链路 (消息长度预算/全链路终态/后台与归属/有界等待与清理)"
+        run: python3 tests/test-bot-update-check.py
+
       # 弃用期内 runner 会把 node20 的 action 强行拉到 node24 上跑 —— 流程照常绿, 只是每个
       # job 都打一条 warning。那种"不红只是提醒"的形态最容易被放过, 直到某天 runner 不再兜底。
       - name: "action 运行时守卫 (没有 action 停在已弃用的 Node 20 上; 不认识的 action 判失败)"

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -60,16 +60,68 @@ del_sel: dict[int, set] = {}   # 删规则多选: chat -> 已勾选域名集合
 # 一条 HTTPS 连接不能被多线程并发复用(交错请求会串包), 故按线程隔离而非全局共享。
 _tls = threading.local()
 
-API_TIMEOUT = 70                 # 默认单次传输上限(主轮询 getUpdates 靠它)
+API_TIMEOUT = 70                 # socket **空闲**超时上限(主轮询 getUpdates 靠它)
+API_READ_CHUNK = 65536           # 按块读响应, 每块之间重新核对绝对期限
+
+
+class _ApiDeadline(Exception):
+    """这次调用的绝对期限到了。与 socket 空闲超时是两回事: 后者管"多久没收到字节",
+    前者管"这次操作总共可以花多久"。对端每 100ms 吐 4 个字节, 空闲超时永远不触发,
+    绝对期限照样必须触发。"""
+
+
+def _api_idle_timeout(deadline):
+    """这一次传输的 socket 空闲超时 = 默认上限与剩余绝对预算的较小者。"""
+    if deadline is None:
+        return API_TIMEOUT
+    return max(0.05, min(API_TIMEOUT, deadline - time.monotonic()))
+
+
+def _api_read(conn, resp, deadline):
+    """按绝对期限读完响应体。
+
+    只在请求前查一次期限是不够的: socket 超时管的是**单次空闲**, 对端持续小块发送时
+    每一次 recv 都不超时, 整个响应却可以远超期限, 最后还返回成功。
+
+    必须用 read1 而不是 read: read(n) 底层是 BufferedReader.read(n), 它会**读满 n 或读到
+    EOF 才返回** —— 于是"每块之间查期限"实际上要等整个响应读完才第一次执行, 等于没查。
+    read1(n) 只返回当下这一次底层读到的那一段, 期限检查才真的落在读取**过程**里。
+    """
+    buf = bytearray()
+    while True:
+        if deadline is not None:
+            if time.monotonic() >= deadline:
+                raise _ApiDeadline()
+            sk = conn.sock
+            if sk is not None:
+                sk.settimeout(_api_idle_timeout(deadline))
+        b = resp.read1(API_READ_CHUNK)
+        buf += b
+        # 读完就跳出, 不再多绕一圈查期限: 响应已经完整拿到了, 却因为"下一轮开始时刚好
+        # 超期"把它丢掉, 那是把成功判成失败。期限管的是还要不要**继续等**。
+        if not b or resp.length == 0 or resp.isclosed():
+            break
+    # read() 读满 Content-Length 会自己收尾, read1() **不会** —— 不补这一下, 连接就停在
+    # "Request-sent", 下一次调用撞 ResponseNotReady 后白白重连一次(keep-alive 名存实亡)。
+    resp.close()
+    return bytes(buf)
 
 
 def post(method, params, deadline=None):
     """调一次 Telegram API。
 
-    deadline(time.monotonic 的绝对时刻)给了就**真正约束**这一次调用: 每次传输的 socket
-    超时取"剩余时间"与默认值的较小者, 剩余为 0 就直接放弃, 重试也要重新看剩余。
-    以前这里恒用 70s 且必重连一次 —— 于是一次检查的两个 emit 各带两段回退, 合起来能发出
-    8 次传输、耗掉 560 秒, 远超整次检查的预算。调用方不传 deadline 时行为一个字不变。
+    deadline(time.monotonic 的绝对时刻)给了就**真正约束**这一次调用, 三个位置缺一不可:
+
+      · **建连**时 socket 空闲超时取剩余与默认值的较小者;
+      · **复用**连接时同样按本次剩余重设(conn.timeout 只在建连时生效, 已连上的还要
+        settimeout 到那条 socket 上) —— 否则 150s 预算跑掉 109s 之后, 最后一次传输
+        还在用建连时的 70s; 反过来, 上一次更新任务留下的短超时也不会被 deadline=None
+        的调用继承;
+      · **读响应**时每块之间重新核对(见 _api_read) —— socket 超时只管"多久没收到字节",
+        对端持续小块发送时它永远不触发, 整个响应却能远超期限、最后还返回成功。
+
+    剩余为 0 就直接放弃, 重试也要重新看剩余; 期限在读取中到达则关掉连接、不重试。
+    调用方不传 deadline 时上限就是 API_TIMEOUT, 行为与从前一致。
     """
     body = json.dumps(params).encode()
     path = "/bot" + TOKEN + "/" + method
@@ -80,14 +132,31 @@ def post(method, params, deadline=None):
             if left <= 0:
                 print("api", method, "deadline-exceeded"); return {}
         try:
+            _to = _api_idle_timeout(deadline)
             conn = getattr(_tls, "conn", None)
             if conn is None:
-                _to = API_TIMEOUT if deadline is None else max(0.1, min(API_TIMEOUT, left))
                 conn = http.client.HTTPSConnection("api.telegram.org", timeout=_to)
                 _tls.conn = conn
+            else:
+                # 复用的连接必须按**本次**的剩余预算重设 —— 否则 150s 预算里跑掉 109s 之后,
+                # 最后那次传输还在用建连时的 70s。反过来, 上一次更新任务留下的短超时也不能
+                # 被 deadline=None 的调用继承: 那会让一次本该有 70s 的调用在几秒后被误判超时。
+                conn.timeout = _to
+                if conn.sock is not None:
+                    conn.sock.settimeout(_to)
             conn.request("POST", path, body, hdr)
-            data = conn.getresponse().read()
+            data = _api_read(conn, conn.getresponse(), deadline)
             return json.loads(data) if data else {}
+        except _ApiDeadline:
+            # 期限到了: 本次实际网络工作到此为止 —— 关掉连接, 不留阻塞线程, 也不重试。
+            try:
+                c = getattr(_tls, "conn", None)
+                if c:
+                    c.close()
+            except Exception:  # noqa: BLE001
+                pass
+            _tls.conn = None
+            print("api", method, "deadline-exceeded-in-read"); return {}
         except Exception as e:  # noqa: BLE001
             try:
                 c = getattr(_tls, "conn", None)
@@ -2947,7 +3016,11 @@ _upd_jobs: dict = {}       # job -> (chat, mid)
 # 通知: 一个有界执行器 + 按消息合并的待发表 —— 连点多少次都只有一份在途工作。
 _upd_notify_exec = concurrent.futures.ThreadPoolExecutor(max_workers=2,
                                                          thread_name_prefix="pdg-updnote")
-_upd_notify_pending: dict = {}     # (chat, mid) -> (text, token, deadline)
+_upd_notify_pending: dict = {}     # (chat, mid) -> (text, token, deadline, job)
+# (chat, mid) 已有 go() 在跑 —— 排队中和投递在飞都算。待发表恒为它的子集:
+# 待发项只会为已在这个集合里的键写入, go() 摘掉待发项时才把键从这里去掉(同一把锁)。
+_upd_notify_live: set = set()
+UPD_NOTICE_MAX = 32                # **在跑的通知**的全局上限(不是只限执行线程数)
 
 UPD_CONFIRM_KB = {"inline_keyboard": [[{"text": "✅ 确认更新", "callback_data": "upd_apply"}],
                                       [{"text": "⬅️ 返回主菜单", "callback_data": "menu"}]]}
@@ -2956,7 +3029,14 @@ ACCEPT_OK, ACCEPT_BUSY, ACCEPT_FULL, ACCEPT_SUBMIT_FAIL = "ok", "busy", "full", 
 
 
 def _upd_new_sess(chat, mid, deadline, kind="check"):
-    """建一条会话。job = 稳定身份(清理按它匹配); token = 可被作废的写入权。"""
+    """建一条会话。job = 稳定身份(清理按它匹配); token = 可被作废的写入权。
+
+    同一条消息上换新会话时, 旧身份要一并从 _upd_jobs 里摘掉 —— 否则每换一次就漏一条,
+    表随点击次数单调增长。_upd_inflight 不在这里动: 旧任务自己的 finally 会按身份释放,
+    在这里抢着释放会把它还占着的名额提前让出去。"""
+    old = _upd_sess.get((chat, mid))
+    if old is not None:
+        _upd_jobs.pop(old.get("job"), None)
     job = uuid.uuid4().hex
     _upd_sess[(chat, mid)] = {"job": job, "token": job, "phase": 0, "inflight": None,
                               "deadline": deadline, "send": threading.Lock(),
@@ -2995,6 +3075,10 @@ def _upd_emit(chat, mid, token, phase, text, kb):
     """这条消息的**唯一**写入口。阶段序管准入, per-message 投递锁管落地顺序,
     deadline 管每一次传输与重试。"""
     want = UPD_PHASE[phase]
+    if token is None:
+        # 空 token 不是写入权, 是"写入权已被撤销"。以前 None == None 让被导航作废的任务
+        # 重新拿到写回权, 把旧结果盖到用户当前页面上。
+        return False, "superseded"
     with _upd_lock:
         sess = _upd_sess.get((chat, mid))
         if not sess or sess.get("token") != token:
@@ -3003,8 +3087,8 @@ def _upd_emit(chat, mid, token, phase, text, kb):
     with send_lock:
         with _upd_lock:
             sess = _upd_sess.get((chat, mid))
-            if not sess or sess.get("token") != token:
-                return False, "superseded"
+            if not sess or sess.get("token") is None or sess.get("token") != token:
+                return False, "superseded"       # 等锁期间被撤销的也算撤销
             if sess.get("phase", 0) >= want:
                 return False, "stale-phase"
             sess["phase"] = want
@@ -3047,28 +3131,81 @@ def _upd_repaint(chat, mid, deadline):
     print("upd repaint give up: attempts", flush=True)
 
 
-def _upd_notify(chat, mid, text, token, deadline):
-    """有界通知: 同一条消息只保留一份待发工作, 重复点击合并成一次, 不新开线程。"""
-    with _upd_lock:
-        had = (chat, mid) in _upd_notify_pending
-        _upd_notify_pending[(chat, mid)] = (text, token, deadline)
-    if had:
+def _upd_notice_release(chat, mid, job):
+    """结束一条**通知**自己的状态。必须在 _upd_lock 内调用。
+
+    只认自己的稳定身份, 且**只碰 kind="notice"**: 忙提示传进来的就是正在跑的那次检查的
+    身份(它复用检查会话把提示写到同一条消息上), 照着收就等于把在跑的检查一起干掉。
+    同一条消息上后来新建的会话 job 不同, 也不会被误删。"""
+    if job is None:
         return
+    cur = _upd_sess.get((chat, mid))
+    if cur is not None and cur.get("job") == job:
+        if cur.get("kind") == "notice":
+            _upd_drop_sess(chat, mid, job)
+        return                       # 是检查会话的身份(忙提示复用的就是它) —— 不碰
+    if _upd_jobs.get(job) == (chat, mid):
+        _upd_jobs.pop(job, None)     # 会话已经换掉了, 只剩一条孤儿身份
+
+
+def _upd_notify(chat, mid, text, token, deadline, job=None):
+    """有界通知。
+
+    三件事以前没做对:
+      · **合并只覆盖排队阶段**。go() 把待发项 pop 走之后, 同一条消息再来一次通知会看到
+        "没有待发", 于是又提交一份 go() —— 两份同时往同一条消息写。现在用 _upd_notify_live
+        标记"这条消息已经有 go() 在跑", 排队中和投递在飞都算, 合并覆盖两个阶段。
+      · **只限执行线程, 不限队列**。两个 worker 只是同时投递的上限; 不同 message_id 可以
+        无界排进来(实测 300 次点击排出 298 条待发)。现在**在跑的通知**(排队中 + 在飞,
+        待发表恒为它的子集)有全局上限, 满载就**拒绝**并把自己的会话收掉 ——
+        不为了说一句"已满"再无界排一条新通知。
+      · **投递完只清 pending, 会话和身份留在表里**。现在成功 / 失败 / 过期 / 被撤销
+        都走同一个收尾: 按稳定身份精确释放自己那一份, 且只碰 kind="notice" 的会话 ——
+        忙提示复用的是**检查**会话的身份, 收掉它等于把正在跑的检查一起干掉。
+    """
+    key = (chat, mid)
+    with _upd_lock:
+        if key in _upd_notify_pending or key in _upd_notify_live:
+            _upd_notify_pending[key] = (text, token, deadline, job)   # 合并, 不新排
+            return True
+        if len(_upd_notify_live) >= UPD_NOTICE_MAX:
+            _upd_notice_release(chat, mid, job)
+            print("upd notify rejected: full", flush=True)
+            return False
+        _upd_notify_pending[key] = (text, token, deadline, job)
+        _upd_notify_live.add(key)
+
     def go():
-        while True:
+        try:
+            while True:
+                with _upd_lock:
+                    item = _upd_notify_pending.pop(key, None)
+                    if item is None:
+                        _upd_notify_live.discard(key)   # 与 pop 同一把锁: 不留提交窗口
+                        return
+                txt, tok, dl, jb = item
+                try:
+                    if time.monotonic() < dl:
+                        _upd_emit(chat, mid, tok, "notice", txt, BACK)
+                finally:
+                    with _upd_lock:
+                        _upd_notice_release(chat, mid, jb)
+        except BaseException:               # noqa: BLE001
             with _upd_lock:
-                item = _upd_notify_pending.pop((chat, mid), None)
-            if item is None:
-                return
-            txt, tok, dl = item
-            if time.monotonic() >= dl:
-                continue
-            _upd_emit(chat, mid, tok, "notice", txt, BACK)
+                _upd_notify_pending.pop(key, None)
+                _upd_notify_live.discard(key)
+            raise
+
     try:
         _upd_notify_exec.submit(go)
+        return True
     except Exception:  # noqa: BLE001
         with _upd_lock:
-            _upd_notify_pending.pop((chat, mid), None)
+            item = _upd_notify_pending.pop(key, None)
+            _upd_notify_live.discard(key)
+            if item is not None:
+                _upd_notice_release(chat, mid, item[3])
+        return False
 
 
 def _upd_reap():
@@ -3086,18 +3223,26 @@ def _upd_reap():
                     continue
                 if now >= sess["deadline"] - UPD_DELIVER_BUDGET:
                     sess["cancelled"] = True
-                    fut = sess.get("fut")
-                    expired.append((c, m, sess["job"], sess.get("token"), sess["deadline"], fut))
-        for c, m, job, tok, dl, fut in expired:
+                    expired.append((c, m, sess["job"], sess.get("fut"),
+                                    sess.get("token") is None))
+        for c, m, job, fut, revoked in expired:
             if fut is not None:
                 fut.cancel()
+            ntok = njob = None
             with _upd_lock:
+                # 快照到动作之间可能已经换了任务: 动作前按**稳定身份**重新核对, 只清自己的,
+                # 绝不覆盖或清掉后来建立的新会话。
+                cur = _upd_sess.get((c, m))
+                mine = cur is not None and cur.get("job") == job
                 _upd_drop_sess(c, m, job)
-                _upd_new_sess(c, m, now + UPD_NOTICE_BUDGET, kind="notice")
-                ntok = _upd_sess[(c, m)]["token"]
-            print("upd check expired in queue", flush=True)
-            _upd_notify(c, m, "❌ 检查更新排队过久, 本次未执行(未发起任何 git)。稍后重试。",
-                        ntok, now + UPD_NOTICE_BUDGET)
+                if mine and not revoked:
+                    # 撤销过的任务不在这里"恢复权限": 用户已经翻到别处, 过期提示不该盖回去。
+                    njob = _upd_new_sess(c, m, now + UPD_NOTICE_BUDGET, kind="notice")
+                    ntok = _upd_sess[(c, m)]["token"]
+            print("upd check expired in queue revoked=%s mine=%s" % (revoked, mine), flush=True)
+            if ntok is not None:
+                _upd_notify(c, m, "❌ 检查更新排队过久, 本次未执行(未发起任何 git)。稍后重试。",
+                            ntok, now + UPD_NOTICE_BUDGET, njob)
 
 
 _upd_reaper = threading.Thread(target=_upd_reap, daemon=True, name="pdg-updreap")
@@ -3129,6 +3274,12 @@ def _upd_check_async(chat, mid):
                 sess = _upd_sess.get((chat, mid))
                 if not sess or sess.get("job") != job or sess.get("cancelled"):
                     return                          # 已被收割: 不跑 git, 不发进度
+                if sess.get("token") is None:
+                    # 排在队里的时候用户已经翻走了。写回权是**撤销**了, 不是"变成空的":
+                    # 空 token 曾经能和已撤销的空 token 相等, 于是这个任务重新拿到写回权,
+                    # 跑完 git 再把结果盖到用户当前页面上。撤销就是撤销 —— 直接收尾。
+                    print("upd check revoked before start", flush=True)
+                    return
                 sess["started"] = True
                 dl, tok = sess["deadline"], sess.get("token")
             left = dl - time.monotonic()
@@ -5103,7 +5254,10 @@ def _handle_cb_inner(chat, mid, data, uid=None):
             _msg = ("❌ 后台执行器不可用, 本次<b>未受理</b>(没有任务在跑)。稍后再试; "
                     "也可以到服务器上跑 <code>sudo pdg update</code>。")
         if _msg and _tok:
-            _upd_notify(chat, mid, _msg, _tok, time.monotonic() + UPD_NOTICE_BUDGET)
+            # 身份照实传进去, 由 _upd_notice_release 自己判归属: FULL / SUBMIT_FAIL 拿到的
+            # 是它**自己**那条 notice 会话, 该收; BUSY 拿到的是正在跑的那次**检查**的身份,
+            # 收它等于把在跑的检查一起干掉 —— 那一处按 kind 拒绝, 不指望每个调用方都记得。
+            _upd_notify(chat, mid, _msg, _tok, time.monotonic() + UPD_NOTICE_BUDGET, _tok)
         return
     if data == "upd_apply":
         ok = start_update()

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -11,7 +11,7 @@ UI 原地编辑消息(editMessageText), 不刷屏。改 sing-box 前备份, chec
 注: 模块可被 import (供定时任务调用 refresh_rulesets), 此时无需 token。
 """
 from __future__ import annotations
-import base64, contextlib, fcntl, hashlib, html, http.client, io, json, os, re, shutil, socket, subprocess, sys, tarfile, tempfile, threading, time, uuid
+import base64, contextlib, fcntl, hashlib, html, http.client, io, json, os, re, shutil, signal, socket, subprocess, sys, tarfile, tempfile, threading, time, uuid
 import concurrent.futures
 import urllib.parse, urllib.request, urllib.error
 from collections import Counter
@@ -2641,49 +2641,281 @@ PDG_REPO = "/opt/privdns-gateway"
 def _esc(s):
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-def _git(*args, t=60):
-    return subprocess.run(["git", "-C", PDG_REPO, *args], capture_output=True, text=True, timeout=t)
+# 一次检查的**总时限**。以前每个 git 步骤各自拿一份完整超时(fetch 120 + unshallow 180 +
+# 后面若干个 60), 最坏情况能把一次"检查更新"拖到十分钟以上, 而用户只看到"检查更新中…"。
+# 现在全链路共用一个截止时间, 后续步骤只拿**剩余**预算。
+UPD_CHECK_BUDGET = 150.0
+# fetch 是唯一可能真的很慢的一步, 给它一个上限, 免得它把后面几步的预算吃光而"卡在最后一格"。
+UPD_FETCH_CAP = 90.0
+# 整条消息的字符预算。Telegram 文本上限是 4096, 这里留出余量: 键盘、实体、以及极端情况下
+# HTML 转义把 1 个字符变成 6 个(&quot;)。**预算覆盖整条消息**, 不是只覆盖提交列表那一段。
+UPD_TG_LIMIT = 4096
+UPD_MSG_BUDGET = 3500
+# 单条提交标题的展示上限(按码点截, 截完再转义 —— 绝不切开 HTML 实体或标签)。
+UPD_LINE_MAX = 110
 
-def _fetch_release_tags():
-    r = _git("fetch", "-q", "--tags", "origin", "main", t=120)
+
+class _UpdCheckTimeout(Exception):
+    """整次检查超出总时限。单独成类, 好和"某一步 git 超时"区分开。"""
+
+
+def _upd_left(deadline, cap=None):
+    """还剩多少秒。已经超了就抛 —— 后续步骤不再重新获得完整等待时长。"""
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise _UpdCheckTimeout()
+    return min(left, cap) if cap else left
+
+
+def _git(*args, t=60):
+    """跑一条 git; 超时按**本次自己创建的进程组**收干净。
+
+    为什么不能只 kill 父进程: `git fetch` 会派生 git-remote-https 这类助手, 父进程被杀之后
+    助手还连着网络、还攥着我们这一端的管道 —— 于是 communicate() 继续等, "超时"并没有真正结束。
+    start_new_session=True 让这一次调用独占一个进程组, killpg 打到的**只可能是本次启动的进程**;
+    不按进程名做宽匹配, 不会碰到别的检查、真实升级或用户自己的 git。
+    """
+    p = subprocess.Popen(["git", "-C", PDG_REPO, *args],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True, start_new_session=True)
+    try:
+        out, err = p.communicate(timeout=t)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            p.kill()
+        try:
+            out, err = p.communicate(timeout=10)     # 收尸并把管道读干净, 不留 FD
+        except subprocess.TimeoutExpired:            # 连尸体都收不掉: 如实抛, 不假装收干净了
+            out, err = "", ""
+        raise subprocess.TimeoutExpired(cmd=["git", *args], timeout=t, output=out, stderr=err)
+    return subprocess.CompletedProcess(p.args, p.returncode, out, err)
+
+
+def _fetch_release_tags(deadline=None):
+    """拉发布 tag。deadline 给了就按**剩余预算**分配, 不再每步重新计时。"""
+    def _t(cap):
+        return cap if deadline is None else _upd_left(deadline, cap)
+    r = _git("fetch", "-q", "--tags", "origin", "main", t=_t(UPD_FETCH_CAP))
     if r.returncode != 0:
         return False, (r.stderr or r.stdout or "git fetch 失败").strip()
-    shallow = _git("rev-parse", "--is-shallow-repository")
+    shallow = _git("rev-parse", "--is-shallow-repository", t=_t(20))
     if shallow.stdout.strip() == "true":
-        r = _git("fetch", "-q", "--unshallow", "--tags", "origin", "main", t=180)
+        r = _git("fetch", "-q", "--unshallow", "--tags", "origin", "main", t=_t(UPD_FETCH_CAP))
         if r.returncode != 0:
             return False, (r.stderr or r.stdout or "git fetch --unshallow 失败").strip()
     return True, ""
 
-def update_check():
-    """检查是否有更新的发布 tag(只跟 tag, 不拉 main 中间提交)。返回 (有更新?, 文本)。"""
+
+def _upd_repo_slug():
+    """从 origin 推出 owner/repo, 只接受 github.com, 并**丢掉任何 userinfo**。
+
+    远端 URL 里可能带 token(https://x-access-token:***@github.com/…), 那东西一个字都不能进
+    用户消息。推不出来就不给链接 —— 少一个链接可以, 泄凭据不行。"""
     try:
-        ok, err = _fetch_release_tags()
+        u = _git("config", "--get", "remote.origin.url", t=5).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return None
+    m = re.match(r"^(?:https://|ssh://git@|git@)(?:[^@/]*@)?github\.com[:/]"
+                 r"([A-Za-z0-9._-]{1,64})/([A-Za-z0-9._-]{1,64}?)(?:\.git)?$", u)
+    return "%s/%s" % (m.group(1), m.group(2)) if m else None
+
+
+def _upd_clip(line):
+    """把一条提交标题裁到展示上限。**先裁明文再转义** —— 于是永远不会切出半个 HTML 实体。
+    按码点裁: 中文/emoji 都算一个, 不会把一个字符劈成半个字节。"""
+    line = line.replace("\r", "").strip()
+    return line if len(line) <= UPD_LINE_MAX else line[:UPD_LINE_MAX - 1] + "…"
+
+
+def _upd_render(cur, tgt, lines, slug):
+    """在**整条消息**的字符预算内渲染。总数独立于展示条数: 截断的是展示, 不是计数。"""
+    total = len(lines)
+    head = ("🔄 有新发布 <b>%s</b>(当前 <code>%s</code>,共 <b>%d</b> 个提交):\n"
+            % (_esc(tgt), _esc(cur), total))
+    links = ""
+    if slug:
+        links = ('\n📄 <a href="https://github.com/%s/releases/tag/%s">%s 发布说明</a>'
+                 ' · <a href="https://github.com/%s/compare/%s...%s">完整提交比较</a>\n'
+                 % (slug, urllib.parse.quote(tgt, safe=""), _esc(tgt),
+                    slug, urllib.parse.quote(cur, safe=""), urllib.parse.quote(tgt, safe="")))
+    tail = ("确认后后台执行 pdg update → 更新到 %s(约 30-60 秒, bot 自动重启回来)。\n"
+            "更新会同时安装该 PrivDNS Gateway 发布版指定并校验过的内核版本。" % _esc(tgt))
+
+    def assemble(shown, omitted):
+        body = ""
+        if shown:
+            note = ("\n… 另有 <b>%d</b> 条未在此显示(见上面的完整提交比较)" % omitted) if omitted else ""
+            body = "<pre>%s</pre>%s\n" % ("\n".join(shown), note)
+        return head + body + links + tail
+
+    esc = [_esc(_upd_clip(x)) for x in lines]
+    shown = []
+    for i, e in enumerate(esc):
+        cand = shown + [e]
+        if len(assemble(cand, total - len(cand))) > UPD_MSG_BUDGET:
+            break
+        shown = cand
+    msg = assemble(shown, total - len(shown))
+    if len(msg) > UPD_MSG_BUDGET:            # 连零条提交都放不下(极端长的 tag/版本串)
+        msg = head + links + tail
+    return msg
+
+
+def update_check(budget=None):
+    """检查是否有更新的发布 tag(只跟 tag, 不拉 main 中间提交)。返回 (有更新?, 文本)。
+
+    三条契约, 都是这一版补的:
+      · **整条链路**都在 try 里 —— 以前只包到 `tag -l`, 后面的 rev-parse / merge-base / log
+        一旦超时就把异常抛给调用方, 回调拿不到终态, 页面永远停在"检查更新中…";
+      · **判不出来就说判不出来**。任何一步非零返回、输出为空、或超时, 一律 ❌, 不退回 🟢;
+      · **不回显可能含凭据的东西**: git 的 stderr 里可能有远端 URL(带 token), 所以只报
+        "第几步失败 + 返回码/异常类名", 不带命令行、不带环境、不带异常正文。
+    """
+    deadline = time.monotonic() + (UPD_CHECK_BUDGET if budget is None else budget)
+
+    def g(*args, cap=30):
+        return _git(*args, t=_upd_left(deadline, cap))
+
+    try:
+        ok, err = _fetch_release_tags(deadline)
         if not ok:
-            return False, f"检查更新失败: {err}"
-        cur = _git("describe", "--tags", "--always").stdout.strip()
-        tags = _git("tag", "-l", "v*", "--sort=-v:refname").stdout.split()
-    except Exception as e:  # noqa: BLE001
-        return False, f"检查更新失败: {e}"
-    if not tags:
-        return False, "🟢 仓库还没有发布 tag。"
-    tgt = tags[0]
-    head = _git("rev-parse", "HEAD").stdout.strip()
-    tcommit = _git("rev-parse", tgt + "^{commit}").stdout.strip()
-    if head == tcommit:
-        return False, f"🟢 已是最新发布 <b>{tgt}</b>。"
-    mb = _git("merge-base", "--is-ancestor", "HEAD", tgt)
-    if mb.returncode == 0:
-        pass
-    elif mb.returncode == 1:
-        return False, f"🟢 已是最新(当前 <code>{cur}</code> 不落后于最新发布 {tgt})。"
-    else:
-        return False, f"检查更新失败: merge-base 判断失败: {(mb.stderr or mb.stdout).strip()}"
-    log = _git("log", "--oneline", "HEAD.." + tgt).stdout.strip()
-    n = len(log.splitlines())
-    return True, (f"🔄 有新发布 <b>{tgt}</b>(当前 <code>{cur}</code>,含 {n} 个提交):\n"
-                  f"<pre>{_esc(log)}</pre>\n确认后后台执行 pdg update → 更新到 {tgt}(约 30-60 秒, bot 自动重启回来)。\n"
-                  "更新会同时安装该 PrivDNS Gateway 发布版指定并校验过的内核版本。")
+            # err 来自 git stderr, 可能含远端 URL → 只说哪一步坏了, 不带正文
+            print("upd check fetch failed", (err or "")[:0], flush=True)
+            return False, "❌ 检查更新失败: 拉取发布 tag 没成功(网络或仓库状态)。稍后重试。"
+
+        r = g("describe", "--tags", "--always")
+        cur = r.stdout.strip()
+        if r.returncode != 0 or not cur:
+            return False, "❌ 检查更新失败: 读不出当前版本(git describe 返回 %d)。" % r.returncode
+
+        r = g("tag", "-l", "v*", "--sort=-v:refname")
+        if r.returncode != 0:
+            return False, "❌ 检查更新失败: 读不出发布 tag 列表(git tag 返回 %d)。" % r.returncode
+        tags = r.stdout.split()
+        if not tags:
+            # 一条发布 tag 都没读到 —— 那就**判不出**最新是哪一版。以前这里报 🟢, 但绿色
+            # 读起来就是"你已经最新了", 而实际情况是我们根本不知道最新是什么。
+            return False, "❌ 检查更新失败: 没有读到任何发布 tag(v*), 本次判不出是否有新版本。"
+        tgt = tags[0]
+
+        r = g("rev-parse", "HEAD")
+        head = r.stdout.strip()
+        if r.returncode != 0 or not head:
+            return False, "❌ 检查更新失败: 读不出当前提交(git rev-parse 返回 %d)。" % r.returncode
+
+        r = g("rev-parse", tgt + "^{commit}")
+        tcommit = r.stdout.strip()
+        if r.returncode != 0 or not tcommit:
+            return False, ("❌ 检查更新失败: 解析不出 %s 指向的提交(git rev-parse 返回 %d)。"
+                           % (_esc(tgt), r.returncode))
+        if head == tcommit:
+            return False, "🟢 已是最新发布 <b>%s</b>。" % _esc(tgt)
+
+        # merge-base --is-ancestor 是**三态**: 0=HEAD 是 tgt 的祖先(确实有更新)、
+        # 1=不是祖先(已是最新)、其它=git 自己出错。三者必须分开 —— 把"出错"并进"已是最新"
+        # 就是拿故障冒充绿色。这三个分支有 tests/test-release-flow.sh 的静态守卫盯着。
+        mb = g("merge-base", "--is-ancestor", "HEAD", tgt)
+        if mb.returncode == 0:
+            pass
+        elif mb.returncode == 1:
+            return False, ("🟢 已是最新(当前 <code>%s</code> 不落后于最新发布 %s)。"
+                           % (_esc(cur), _esc(tgt)))
+        else:
+            return False, ("❌ 检查更新失败: merge-base 判断失败(返回 %d), 本次无结论。"
+                           % mb.returncode)
+
+        r = g("log", "--oneline", "HEAD.." + tgt, cap=60)
+        if r.returncode != 0:
+            return False, "❌ 检查更新失败: 取不到提交列表(git log 返回 %d)。" % r.returncode
+        lines = [x for x in r.stdout.splitlines() if x.strip()]
+        if not lines:
+            # 前面已判定 HEAD 落后于 tgt, 这里却一条提交都没有 —— 自相矛盾, 不猜
+            return False, "❌ 检查更新失败: 版本关系与提交列表对不上, 本次无结论。"
+        return True, _upd_render(cur, tgt, lines, _upd_repo_slug())
+    except _UpdCheckTimeout:
+        return False, ("❌ 检查更新超时(超过 %d 秒仍未完成), 本次无结论。稍后重试。"
+                       % int(UPD_CHECK_BUDGET if budget is None else budget))
+    except subprocess.TimeoutExpired:
+        return False, "❌ 检查更新失败: git 操作超时, 本次无结论。稍后重试。"
+    except Exception as e:  # noqa: BLE001   # 不带异常正文(可能含远端 URL/凭据)
+        return False, "❌ 检查更新失败(%s), 本次无结论。稍后重试。" % type(e).__name__
+
+# ── 检查更新的后台执行与消息归属 ────────────────────────────────────────────
+# 为什么必须后台: 检查里有 git fetch, 线上要走网络。以前它**同步跑在主 getUpdates 循环里**,
+# 这段时间整个 bot 不响应任何菜单。
+# 为什么不用 run_bg: run_bg 会占住 per-chat BUSY, 于是"检查更新"期间用户连自检、状态都点不了 ——
+# 而检查本身不改任何配置, 没有互斥的必要。这里只给**这一个入口**一个 per-chat 在飞上限。
+# 归属沿用本文件里 WLOC 监听那套最小写法: (chat, message_id) → token。用户在这条消息上做任何
+# 新动作(返回菜单、开始更新、再点一次检查)都会换掉 token, 旧检查的结果就不再往回写 ——
+# 不用补发把用户已经翻过去的页面刷回来。
+_upd_lock = threading.Lock()
+_upd_token: dict[tuple, str] = {}     # (chat, mid) -> token; 只有持有当前 token 的任务能写回
+_upd_inflight: dict = {}              # chat -> (mid, token); 同一会话同时只允许一次检查
+
+UPD_CONFIRM_KB = {"inline_keyboard": [[{"text": "✅ 确认更新", "callback_data": "upd_apply"}],
+                                      [{"text": "⬅️ 返回主菜单", "callback_data": "menu"}]]}
+
+
+def _upd_invalidate(chat, mid):
+    """这条消息被任何新回调接管 → 作废还在飞的检查结果。"""
+    with _upd_lock:
+        _upd_token.pop((chat, mid), None)
+
+
+def _upd_check_async(chat, mid):
+    """把一次检查放进后台执行器。返回 True=已受理, False=忙/提交失败(调用方给明确反馈)。"""
+    with _upd_lock:
+        cur = _upd_inflight.get(chat)
+        if cur is not None:
+            # 同一条消息上的重复点击: handle_cb 入口刚把归属作废掉了, 这里**还回去** ——
+            # 否则在飞的那次检查出了结果也不敢写回, 页面就永久停在"还在跑"上, 等于把旧的
+            # "检查更新中…"换成了一个新的卡死态。
+            if cur[0] == mid:
+                _upd_token[(chat, mid)] = cur[1]
+            return False
+        token = uuid.uuid4().hex
+        _upd_inflight[chat] = (mid, token)
+        _upd_token[(chat, mid)] = token
+
+    def _release():
+        with _upd_lock:
+            if _upd_inflight.get(chat) == (mid, token):
+                _upd_inflight.pop(chat, None)
+            if _upd_token.get((chat, mid)) == token:
+                _upd_token.pop((chat, mid), None)
+
+    def superseded():
+        with _upd_lock:
+            return _upd_token.get((chat, mid)) != token
+
+    def go():
+        try:
+            try:
+                has, txt = update_check()
+            except BaseException as e:      # noqa: BLE001  兜底: 任何逃逸都要变成终态
+                has, txt = False, ("❌ 检查更新失败(%s), 本次无结论。稍后重试。"
+                                   % type(e).__name__)
+            if superseded():
+                # 用户已经翻到别的页面了。**不补发** —— 补发等于把他刚离开的界面又刷回来。
+                print("upd check superseded", flush=True)
+                return
+            # edit_only: 只原地改, 编辑不成就安静结束(消息可能已被删)。它最多两次 API 调用,
+            # 每次 post() 自带 70s 超时 + 一次重连 —— 投递路径是有界的, 不会把任务吊在这里。
+            delivered = edit_only(chat, mid, txt, UPD_CONFIRM_KB if has else BACK)
+            # 服务端任务已结束 ≠ 用户已收到。两件事分开记, 不用前者冒充后者。
+            print("upd check finished has=%s delivered=%s" % (bool(has), bool(delivered)), flush=True)
+        finally:
+            _release()
+
+    try:
+        _EXEC.submit(go)
+        return True
+    except Exception:  # noqa: BLE001       # 执行器满/已关 → 立刻释放, 不静默泄漏占用
+        _release()
+        return False
+
 
 def start_update():
     """在独立的 systemd 瞬时单元里跑 pdg update, 不受 pdg-bot 自身重启影响。"""
@@ -4467,6 +4699,9 @@ def _adblock_pending(chat, uid, kind):
 
 
 def handle_cb(chat, mid, data, uid=None):
+    # 这条消息被新回调接管了 → 作废还在飞的"检查更新"结果。用户已经返回菜单、开始更新、
+    # 或者又点了一次检查, 旧结果再写回去就是覆盖他正在看的页面。
+    _upd_invalidate(chat, mid)
     # ── 去广告(闭集 callback, 不接受任意动作名)────────────────────────────────
     if data.startswith("adblock:"):
         act = data.split(":", 1)[1]
@@ -4595,11 +4830,12 @@ def handle_cb(chat, mid, data, uid=None):
     if data == "doctor":
         edit(chat, mid, "🩺 自检中(几秒)…", BACK); edit(chat, mid, doctor_text(), BACK); return
     if data == "upd_check":
-        edit(chat, mid, "🔄 检查更新中…", BACK)
-        has, txt = update_check()
-        kb = ({"inline_keyboard": [[{"text": "✅ 确认更新", "callback_data": "upd_apply"}],
-                                   [{"text": "⬅️ 返回主菜单", "callback_data": "menu"}]]} if has else BACK)
-        edit(chat, mid, txt, kb); return
+        # 检查里有 git fetch(走网络) —— 绝不能在主 getUpdates 循环里同步等它, 否则整个
+        # bot 在这段时间不响应任何菜单。这里只把消息改成"检查中", 剩下的交给后台执行器。
+        if not _upd_check_async(chat, mid):
+            edit(chat, mid, "⏳ 上一次「检查更新」还在跑, 结果会更新到发起它的那条消息。"
+                            "等它出结果再点。", BACK); return
+        edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", BACK); return
     if data == "upd_apply":
         ok = start_update()
         edit(chat, mid, ("🚀 已开始后台更新, 约 30-60 秒后 bot 自动回来(期间可能短暂无响应)。\n"

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -77,24 +77,72 @@ def _api_idle_timeout(deadline):
     return max(0.05, min(API_TIMEOUT, deadline - time.monotonic()))
 
 
-def _api_read(conn, resp, deadline):
+class _ApiGuard:
+    """到点就把这条 socket 的收发关掉, 让**任何**阶段正在阻塞的读立刻结束。
+
+    为什么非要它: 一次响应的阻塞点不止"响应体"这一处 —— 沿 http.client 的调用栈数,
+    至少有状态行(_read_status → fp.readline)、响应头(begin → parse_headers 的多次 readline)、
+    分块头与尾部(_read_next_chunk_size / _read_and_discard_trailer 的 readline)、响应体
+    (read1 → fp.read1)。前两处发生在 getresponse() **里面**, 中间两处发生在 read1()
+    **里面** —— 调用方在循环里查期限, 一次也查不到它们。
+
+    socket 超时也顶不上: 它管的是"多久没收到字节"(空闲), 每收到一个字节就重新计时。
+    对端逐字节慢吐时它永远不触发, 整个响应可以远超绝对期限 —— 实测状态行慢吐让
+    1.00s 预算的调用跑到 4.26s。
+
+    还有一个更隐蔽的: `Connection: close` 时 getresponse() 会把 conn.sock 置空, 而响应流
+    照样能继续读。此时"每轮 settimeout 到 conn.sock 上"这一手一次都不会执行。
+
+    所以按**绝对时刻**在这条 socket 上 shutdown: 不是让外层返回了事, 是真的把本次网络
+    工作结束掉, 不留后台线程继续读。用 shutdown 而不是 close —— 关掉别的线程正阻塞着的
+    fd 是未定义行为, shutdown 则会让阻塞中的读立刻拿到 EOF/错误。
+    """
+
+    __slots__ = ("sock", "timer", "fired")
+
+    def __init__(self, sock, deadline):
+        self.sock, self.timer, self.fired = sock, None, False
+        if sock is None or deadline is None:
+            return
+        self.timer = threading.Timer(max(0.0, deadline - time.monotonic()), self._fire)
+        self.timer.daemon = True
+        self.timer.start()
+
+    def _fire(self):
+        self.fired = True
+        try:
+            self.sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+
+    def cancel(self):
+        if self.timer is not None:
+            self.timer.cancel()
+
+
+def _api_read(sock, resp, deadline):
     """按绝对期限读完响应体。
 
-    只在请求前查一次期限是不够的: socket 超时管的是**单次空闲**, 对端持续小块发送时
-    每一次 recv 都不超时, 整个响应却可以远超期限, 最后还返回成功。
+    sock 是**请求发出时抓住的那条** socket, 不是 conn.sock: `Connection: close` 之后
+    conn.sock 已经是 None, 而响应流还能继续读 —— 依赖 conn.sock 就等于这一路完全没有约束。
 
     必须用 read1 而不是 read: read(n) 底层是 BufferedReader.read(n), 它会**读满 n 或读到
     EOF 才返回** —— 于是"每块之间查期限"实际上要等整个响应读完才第一次执行, 等于没查。
     read1(n) 只返回当下这一次底层读到的那一段, 期限检查才真的落在读取**过程**里。
+
+    这里的逐轮检查只是细粒度的第一道; 单次 read1 内部还可能有多个阻塞 readline(分块头、
+    尾部), 那一层由 _ApiGuard 按绝对时刻兜底。
     """
     buf = bytearray()
     while True:
         if deadline is not None:
             if time.monotonic() >= deadline:
                 raise _ApiDeadline()
-            sk = conn.sock
-            if sk is not None:
-                sk.settimeout(_api_idle_timeout(deadline))
+            if sock is not None:
+                try:
+                    sock.settimeout(_api_idle_timeout(deadline))
+                except OSError:
+                    pass                 # 已被 guard 关掉 —— 下面的读会立刻结束
         b = resp.read1(API_READ_CHUNK)
         buf += b
         # 读完就跳出, 不再多绕一圈查期限: 响应已经完整拿到了, 却因为"下一轮开始时刚好
@@ -117,11 +165,22 @@ def post(method, params, deadline=None):
         settimeout 到那条 socket 上) —— 否则 150s 预算跑掉 109s 之后, 最后一次传输
         还在用建连时的 70s; 反过来, 上一次更新任务留下的短超时也不会被 deadline=None
         的调用继承;
-      · **读响应**时每块之间重新核对(见 _api_read) —— socket 超时只管"多久没收到字节",
-        对端持续小块发送时它永远不触发, 整个响应却能远超期限、最后还返回成功。
+      · **整个响应**都在期限之内, 不只是"普通响应体":
+          - 逐轮核对(见 _api_read)管响应体这一层;
+          - 状态行、响应头在 getresponse() 里面, 分块头与尾部在 read1() 里面 —— 调用方
+            的循环一次也查不到它们, 由 _ApiGuard 按绝对时刻 shutdown 那条 socket 兜底;
+          - 读完之后再判一次: 逐轮检查通过、之后才到齐的完整 JSON, 内容是完整的, 但它是
+            期限**之后**才到的 —— 按时到达和内容完整是两件事。
 
-    剩余为 0 就直接放弃, 重试也要重新看剩余; 期限在读取中到达则关掉连接、不重试。
-    调用方不传 deadline 时上限就是 API_TIMEOUT, 行为与从前一致。
+    剩余为 0 就直接放弃, 重试也要重新看剩余; 期限在响应途中到达则结束这次网络工作
+    (shutdown + 关连接)、不重试, 不留后台线程继续读。
+    调用方不传 deadline 时上限就是 API_TIMEOUT(只有空闲超时, 没有绝对期限), 行为与从前一致。
+
+    **覆盖边界(不要读成"所有网络阶段都有硬上界")**: _ApiGuard 要先拿到 socket 才能武装,
+    而 socket 是 conn.request() 之后才有的 —— 所以**建连(TCP connect + TLS 握手)与发送请求**
+    这几段不在 guard 之内, 它们目前只受 socket 超时 _to = min(API_TIMEOUT, 剩余) 约束:
+    单次阻塞不会越过期限, 但握手里的多次往返理论上仍可能累计超出。这一段尚未复现、
+    也未验证, 按已登记的独立问题处理, 不在这里顺手改。
     """
     body = json.dumps(params).encode()
     path = "/bot" + TOKEN + "/" + method
@@ -145,7 +204,21 @@ def post(method, params, deadline=None):
                 if conn.sock is not None:
                     conn.sock.settimeout(_to)
             conn.request("POST", path, body, hdr)
-            data = _api_read(conn, conn.getresponse(), deadline)
+            # 必须在 getresponse() **之前**抓住这条 socket: Connection: close 会在
+            # getresponse() 里把 conn.sock 置空, 之后就再也拿不到正在读的那个资源了。
+            sk = conn.sock
+            guard = _ApiGuard(sk, deadline)
+            try:
+                resp = conn.getresponse()          # 状态行 + 响应头也在期限之内
+                data = _api_read(sk, resp, deadline)
+            finally:
+                guard.cancel()
+            if guard.fired:
+                raise _ApiDeadline()
+            if deadline is not None and time.monotonic() >= deadline:
+                # 逐轮检查通过之后才读完的那一次: 内容是完整的, 但它是期限**之后**才到齐的。
+                # 按时到达和内容完整是两件事, 不能拿后者冒充前者。
+                raise _ApiDeadline()
             return json.loads(data) if data else {}
         except _ApiDeadline:
             # 期限到了: 本次实际网络工作到此为止 —— 关掉连接, 不留阻塞线程, 也不重试。
@@ -3223,20 +3296,21 @@ def _upd_reap():
                     continue
                 if now >= sess["deadline"] - UPD_DELIVER_BUDGET:
                     sess["cancelled"] = True
-                    expired.append((c, m, sess["job"], sess.get("fut"),
-                                    sess.get("token") is None))
-        for c, m, job, fut, revoked in expired:
+                    expired.append((c, m, sess["job"], sess.get("fut")))
+        for c, m, job, fut in expired:
             if fut is not None:
-                fut.cancel()
+                fut.cancel()                    # 锁外 —— 这一段就是下面说的"窗口"
             ntok = njob = None
             with _upd_lock:
-                # 快照到动作之间可能已经换了任务: 动作前按**稳定身份**重新核对, 只清自己的,
-                # 绝不覆盖或清掉后来建立的新会话。
+                # 快照与动作之间隔着一段没有锁的窗口(fut.cancel() 那一下)。用户可能正好在
+                # 这段时间里返回菜单 —— 拿快照时的 revoked 裁决, 就会给一个**已经被撤销**的
+                # 任务新建 notice/token, 等于把撤销掉的写回权又发回去, 过期提示盖掉菜单。
+                # 所以身份和写回权都在锁内**重新读当前值**再裁决, 快照只用来找对象。
                 cur = _upd_sess.get((c, m))
                 mine = cur is not None and cur.get("job") == job
+                revoked = mine and cur.get("token") is None
                 _upd_drop_sess(c, m, job)
                 if mine and not revoked:
-                    # 撤销过的任务不在这里"恢复权限": 用户已经翻到别处, 过期提示不该盖回去。
                     njob = _upd_new_sess(c, m, now + UPD_NOTICE_BUDGET, kind="notice")
                     ntok = _upd_sess[(c, m)]["token"]
             print("upd check expired in queue revoked=%s mine=%s" % (revoked, mine), flush=True)

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -325,14 +325,37 @@ def send_tracked(chat, text, kb=None):
         r = post("sendMessage", p)
     return (r.get("result") or {}).get("message_id") if r.get("ok") else None
 
+# 每条消息最后一次**成功**写入的页面。只写不读地记一份, 供"后台任务抢在导航之后落地"时把
+# 用户真正要看的那一页补回来(见 _upd_emit)。有界: 超过上限丢最旧的, 不让它无限长。
+_last_page: dict = {}
+_last_page_lock = threading.Lock()
+_LAST_PAGE_MAX = 256
+
+
+def _remember_page(chat, mid, text, kb):
+    """记最近**两**条: 后台任务抢在导航之后落地时, 要靠上一条把用户真正要看的那页补回去。"""
+    if mid is None:
+        return
+    with _last_page_lock:
+        hist = _last_page.get((chat, mid)) or []
+        _last_page[(chat, mid)] = ([(text, kb)] + hist)[:2]
+        while len(_last_page) > _LAST_PAGE_MAX:
+            _last_page.pop(next(iter(_last_page)))
+
+
+def _recall_pages(chat, mid):
+    with _last_page_lock:
+        return list(_last_page.get((chat, mid)) or [])
+
+
 def edit(chat, mid, text, kb=None):
     p = {"chat_id": chat, "message_id": mid, "text": text, "parse_mode": "HTML",
          "reply_markup": kb or MENU, "disable_web_page_preview": True}
     if post("editMessageText", p).get("ok"):
-        return
+        _remember_page(chat, mid, text, kb); return
     p.pop("parse_mode", None)        # 先退回纯文本重试编辑(原地保留键盘)
     if post("editMessageText", p).get("ok"):
-        return
+        _remember_page(chat, mid, text, kb); return
     send(chat, text, kb)             # 仍不行(如消息已删)再发新消息
 
 def edit_only(chat, mid, text, kb=None):
@@ -345,12 +368,12 @@ def edit_only(chat, mid, text, kb=None):
          "reply_markup": kb or MENU, "disable_web_page_preview": True}
     r = post("editMessageText", p)
     if r.get("ok"):
-        return True
+        _remember_page(chat, mid, text, kb); return True
     p.pop("parse_mode", None)        # HTML 解析失败(文本含 < & 等)→ 退回纯文本再试一次
     r = post("editMessageText", p)
     if r.get("ok"):
-        return True
-    print("wloc watch edit skipped", (r or {}).get("error_code"), flush=True)
+        _remember_page(chat, mid, text, kb); return True
+    print("edit_only skipped", (r or {}).get("error_code"), flush=True)
     return False
 
 def delete_message(chat, mid):
@@ -2700,21 +2723,34 @@ def _fetch_release_tags(deadline=None):
     r = _git("fetch", "-q", "--tags", "origin", "main", t=_t(UPD_FETCH_CAP))
     if r.returncode != 0:
         return False, (r.stderr or r.stdout or "git fetch 失败").strip()
+    # 这一步以前只看 stdout 是不是 "true": 非零返回、空输出、乱码一律被当成"非浅仓库"
+    # 继续往下走, 于是浅仓库上 tag 不全, 却照样能报 🟢。按它自己的契约判: rc 必须为 0,
+    # 输出必须恰好是 true/false, 否则判不出来 —— 判不出来就说判不出来。
     shallow = _git("rev-parse", "--is-shallow-repository", t=_t(20))
-    if shallow.stdout.strip() == "true":
+    _sv = shallow.stdout.strip()
+    if shallow.returncode != 0 or _sv not in ("true", "false"):
+        return False, "无法判定仓库是否为浅克隆(git rev-parse 返回 %d)" % shallow.returncode
+    if _sv == "true":
         r = _git("fetch", "-q", "--unshallow", "--tags", "origin", "main", t=_t(UPD_FETCH_CAP))
         if r.returncode != 0:
             return False, (r.stderr or r.stdout or "git fetch --unshallow 失败").strip()
     return True, ""
 
 
-def _upd_repo_slug():
+def _upd_repo_slug(deadline=None):
     """从 origin 推出 owner/repo, 只接受 github.com, 并**丢掉任何 userinfo**。
 
     远端 URL 里可能带 token(https://x-access-token:***@github.com/…), 那东西一个字都不能进
-    用户消息。推不出来就不给链接 —— 少一个链接可以, 泄凭据不行。"""
+    用户消息。推不出来就不给链接 —— 少一个链接可以, 泄凭据不行。
+
+    这是**可选信息**: 只花剩余预算里的一小段(不另拿一份独立超时), 拿不到就不给链接,
+    绝不为了补一个链接把整次检查拖过期限。
+    """
     try:
-        u = _git("config", "--get", "remote.origin.url", t=5).stdout.strip()
+        cap = 5 if deadline is None else min(5, max(0.0, deadline - time.monotonic()))
+        if cap <= 0:
+            return None
+        u = _git("config", "--get", "remote.origin.url", t=cap).stdout.strip()
     except Exception:  # noqa: BLE001
         return None
     m = re.match(r"^(?:https://|ssh://git@|git@)(?:[^@/]*@)?github\.com[:/]"
@@ -2833,7 +2869,7 @@ def update_check(budget=None):
         if not lines:
             # 前面已判定 HEAD 落后于 tgt, 这里却一条提交都没有 —— 自相矛盾, 不猜
             return False, "❌ 检查更新失败: 版本关系与提交列表对不上, 本次无结论。"
-        return True, _upd_render(cur, tgt, lines, _upd_repo_slug())
+        return True, _upd_render(cur, tgt, lines, _upd_repo_slug(deadline))
     except _UpdCheckTimeout:
         return False, ("❌ 检查更新超时(超过 %d 秒仍未完成), 本次无结论。稍后重试。"
                        % int(UPD_CHECK_BUDGET if budget is None else budget))
@@ -2842,79 +2878,179 @@ def update_check(budget=None):
     except Exception as e:  # noqa: BLE001   # 不带异常正文(可能含远端 URL/凭据)
         return False, "❌ 检查更新失败(%s), 本次无结论。稍后重试。" % type(e).__name__
 
-# ── 检查更新的后台执行与消息归属 ────────────────────────────────────────────
-# 为什么必须后台: 检查里有 git fetch, 线上要走网络。以前它**同步跑在主 getUpdates 循环里**,
-# 这段时间整个 bot 不响应任何菜单。
-# 为什么不用 run_bg: run_bg 会占住 per-chat BUSY, 于是"检查更新"期间用户连自检、状态都点不了 ——
-# 而检查本身不改任何配置, 没有互斥的必要。这里只给**这一个入口**一个 per-chat 在飞上限。
-# 归属沿用本文件里 WLOC 监听那套最小写法: (chat, message_id) → token。用户在这条消息上做任何
-# 新动作(返回菜单、开始更新、再点一次检查)都会换掉 token, 旧检查的结果就不再往回写 ——
-# 不用补发把用户已经翻过去的页面刷回来。
+# ── 检查更新: 受理 → 排队 → 执行 → 投递, 全程有界且写入有序 ──────────────────
+# 上一版把检查挪到后台就以为完事了, 留下六个洞(每一个都在 tests/ 里有确定性复现):
+#   · 结果比"检查中"先落地 → 终态被进度覆盖(倒退);
+#   · "还在跑"先出发后落地 → 终态被它覆盖;
+#   · 初始 edit 失败会 send 一条新消息 → 孤立进度消息, 任务只认原 mid, 永不更新它;
+#   · 过了 token 检查、正在投递时用户返回菜单 → 新页面被旧结果取代;
+#   · 提交失败被说成"上一次还在跑";
+#   · 初始提示/忙反馈在主轮询里同步发 → 网络慢就把 getUpdates 卡住。
+#
+# 收口办法是**一条通道**: 这条消息上的每一次写入都走 _upd_emit, 它按阶段序(进度 < 忙 < 终态)
+# 单调推进 —— 低阶段永远盖不了已经落地的高阶段。归属仍是 (chat, message_id) → token。
+# 三种写入(进度/忙/终态)一律在后台线程发出, 主轮询一次网络都不做。
+UPD_PHASE = {"progress": 1, "busy": 2, "final": 3}
+# 全局准入上限: 线程数有限**不等于**队列有界 —— ThreadPoolExecutor 的队列是无限的,
+# 4 个 worker 被占满时 20 个会话照样全被受理, 然后一起排队等到超时。
+UPD_MAX_INFLIGHT = 8
+# 排队太久就别做了: worker 真正开跑时若剩余预算不足这个数, 直接给终态, 不再发起 git。
+UPD_MIN_RUN_BUDGET = 20.0
+# 投递(含重试)与子进程收尾的固定收尾预算, 计入端到端上界。
+UPD_DELIVER_BUDGET = 40.0
+
 _upd_lock = threading.Lock()
-_upd_token: dict[tuple, str] = {}     # (chat, mid) -> token; 只有持有当前 token 的任务能写回
-_upd_inflight: dict = {}              # chat -> (mid, token); 同一会话同时只允许一次检查
+_upd_sess: dict = {}       # (chat, mid) -> {"token", "phase", "inflight", "deadline"}
+_upd_inflight: dict = {}   # chat -> (mid, token)
 
 UPD_CONFIRM_KB = {"inline_keyboard": [[{"text": "✅ 确认更新", "callback_data": "upd_apply"}],
                                       [{"text": "⬅️ 返回主菜单", "callback_data": "menu"}]]}
 
+ACCEPT_OK, ACCEPT_BUSY, ACCEPT_FULL, ACCEPT_SUBMIT_FAIL = "ok", "busy", "full", "submit_fail"
+
 
 def _upd_invalidate(chat, mid):
-    """这条消息被任何新回调接管 → 作废还在飞的检查结果。"""
+    """这条消息被新回调接管 → 作废在飞检查的写入权。
+
+    返回 True 表示**此刻正有一次投递在网上飞**: 已经发出的请求收不回来(这一点不假装能做到),
+    所以由那个写入方在收到响应后, 把用户真正要看的那一页补回去(见 _upd_emit 的 repaint)。
+    """
     with _upd_lock:
-        _upd_token.pop((chat, mid), None)
+        sess = _upd_sess.get((chat, mid))
+        if not sess:
+            return False
+        sess["token"] = None            # 之后任何 emit 都会被拒
+        if sess.get("inflight"):
+            sess["repaint"] = True      # 有一次投递正在网上飞 —— 落地后要把新页面补回去
+            return True
+        return False
+
+
+def _upd_emit(chat, mid, token, phase, text, kb):
+    """这条消息的**唯一**写入口。阶段序单调: 低阶段盖不了已经落地的高阶段。
+
+    锁只用来占位与记账, **网络调用在锁外**做 —— 主轮询和导航都不会因为它而等网络。
+    """
+    want = UPD_PHASE[phase]
+    with _upd_lock:
+        sess = _upd_sess.get((chat, mid))
+        if not sess or sess.get("token") != token:
+            return False, "superseded"
+        send_lock = sess["send"]
+    # **按消息串行化投递**。阶段序只管准入: 两次写入可以按序被放行, 却因为网络快慢而乱序
+    # 落地(上一版就栽在这里 —— "还在跑"先出发、后落地, 把已经到达的终态盖了回去)。
+    # 这把锁只在后台线程里持有, 主轮询和导航都不取它, 不会因此等网络。
+    with send_lock:
+        with _upd_lock:
+            sess = _upd_sess.get((chat, mid))
+            if not sess or sess.get("token") != token:
+                return False, "superseded"
+            if sess.get("phase", 0) >= want:
+                return False, "stale-phase"
+            sess["phase"] = want
+            sess["inflight"] = want
+            sess["mine"].add(text)
+        try:
+            delivered = edit_only(chat, mid, text, kb)
+        finally:
+            with _upd_lock:
+                sess = _upd_sess.get((chat, mid))
+                if sess is not None and sess.get("inflight") == want:
+                    sess["inflight"] = None
+                need_repaint = bool(sess and sess.get("repaint"))
+                mine = set(sess["mine"]) if sess else set()
+        if need_repaint and delivered:
+            # 我们在"用户已经翻页"之后才落地。已经发出的请求收不回来 —— 这里做的是**收敛**:
+            # 把用户真正要看的那一页补回去。上一条页面若还是我们自己写的, 说明导航那次编辑
+            # 没落地(或失败了), 那就不补 —— 补了会把终态倒退成进度。
+            hist = _recall_pages(chat, mid)
+            if len(hist) > 1 and hist[0][0] == text and hist[1][0] not in mine:
+                edit_only(chat, mid, hist[1][0], hist[1][1])
+                return False, "repainted"
+    return delivered, ("ok" if delivered else "undelivered")
 
 
 def _upd_check_async(chat, mid):
-    """把一次检查放进后台执行器。返回 True=已受理, False=忙/提交失败(调用方给明确反馈)。"""
+    """受理一次检查。返回 ACCEPT_* —— 忙 / 全局满 / 提交失败必须分开, 不能互相冒充。
+
+    **等待从受理这一刻开始计时**(accepted_at), 不是等 worker 跑起来才开始 —— 排队时间
+    也算在用户的等待里。
+    """
+    accepted_at = time.monotonic()
     with _upd_lock:
         cur = _upd_inflight.get(chat)
         if cur is not None:
-            # 同一条消息上的重复点击: handle_cb 入口刚把归属作废掉了, 这里**还回去** ——
-            # 否则在飞的那次检查出了结果也不敢写回, 页面就永久停在"还在跑"上, 等于把旧的
-            # "检查更新中…"换成了一个新的卡死态。
-            if cur[0] == mid:
-                _upd_token[(chat, mid)] = cur[1]
-            return False
+            if cur[0] == mid:                       # 同一条消息上的重复点击: 归属还回去
+                sess = _upd_sess.get((chat, mid))
+                if sess is not None:
+                    sess["token"] = cur[1]
+            # 把在飞任务的 token 一并交出去: "还在跑"这条反馈必须走**同一条通道**,
+            # 否则任务一旦已经收尾把会话记录清掉, 这条反馈就会绕过阶段序、把终态盖回去。
+            return ACCEPT_BUSY, cur[1]
+        if len(_upd_inflight) >= UPD_MAX_INFLIGHT:
+            return ACCEPT_FULL, None
         token = uuid.uuid4().hex
         _upd_inflight[chat] = (mid, token)
-        _upd_token[(chat, mid)] = token
+        _upd_sess[(chat, mid)] = {"token": token, "phase": 0, "inflight": None,
+                                  "deadline": accepted_at + UPD_CHECK_BUDGET,
+                                  "send": threading.Lock(), "repaint": False, "mine": set()}
 
     def _release():
         with _upd_lock:
             if _upd_inflight.get(chat) == (mid, token):
                 _upd_inflight.pop(chat, None)
-            if _upd_token.get((chat, mid)) == token:
-                _upd_token.pop((chat, mid), None)
-
-    def superseded():
-        with _upd_lock:
-            return _upd_token.get((chat, mid)) != token
+            sess = _upd_sess.get((chat, mid))
+            if sess is not None and sess.get("token") == token:
+                _upd_sess.pop((chat, mid), None)
 
     def go():
         try:
+            _upd_emit(chat, mid, token, "progress",
+                      "🔄 检查更新中…(结果会更新到这条消息)", BACK)
+            left = _upd_sess.get((chat, mid), {}).get("deadline", 0) - time.monotonic()
+            if left < UPD_MIN_RUN_BUDGET:
+                # 排队排掉了预算: 直接给终态, 不再发起任何 git。
+                _upd_emit(chat, mid, token, "final",
+                          "❌ 检查更新排队过久, 本次未执行。稍后重试。", BACK)
+                return
             try:
-                has, txt = update_check()
-            except BaseException as e:      # noqa: BLE001  兜底: 任何逃逸都要变成终态
+                has, txt = update_check(budget=max(0.0, left - UPD_DELIVER_BUDGET))
+            except BaseException as e:      # noqa: BLE001
                 has, txt = False, ("❌ 检查更新失败(%s), 本次无结论。稍后重试。"
                                    % type(e).__name__)
-            if superseded():
-                # 用户已经翻到别的页面了。**不补发** —— 补发等于把他刚离开的界面又刷回来。
-                print("upd check superseded", flush=True)
-                return
-            # edit_only: 只原地改, 编辑不成就安静结束(消息可能已被删)。它最多两次 API 调用,
-            # 每次 post() 自带 70s 超时 + 一次重连 —— 投递路径是有界的, 不会把任务吊在这里。
-            delivered = edit_only(chat, mid, txt, UPD_CONFIRM_KB if has else BACK)
-            # 服务端任务已结束 ≠ 用户已收到。两件事分开记, 不用前者冒充后者。
-            print("upd check finished has=%s delivered=%s" % (bool(has), bool(delivered)), flush=True)
+            delivered, why = _upd_emit(chat, mid, token, "final", txt,
+                                       UPD_CONFIRM_KB if has else BACK)
+            # 任务结束 ≠ 用户收到。两件事分开记。
+            print("upd check finished has=%s delivered=%s why=%s"
+                  % (bool(has), bool(delivered), why), flush=True)
         finally:
             _release()
 
     try:
         _EXEC.submit(go)
-        return True
-    except Exception:  # noqa: BLE001       # 执行器满/已关 → 立刻释放, 不静默泄漏占用
+        return ACCEPT_OK, token
+    except Exception:  # noqa: BLE001
         _release()
-        return False
+        return ACCEPT_SUBMIT_FAIL, None
+
+
+def _upd_notify_async(chat, mid, text, token=None):
+    """把"忙 / 队列满 / 提交失败"这类反馈也放后台发 —— 主轮询不做网络调用。
+
+    token 非空(=有任务在飞)时走**同一条通道**, 阶段序 busy(2) < final(3): 终态已经落地就
+    直接拒掉, 不会把结果盖回去; 任务已经收尾、会话记录被清掉时, emit 同样判 superseded 而
+    不写 —— 这正是上一版的洞: 那时它退化成裸 edit_only, 把终态覆盖成了"还在跑"。
+    token 为空(队列满 / 提交失败)时这条消息上本来就没有在飞的检查, 直接写。
+    """
+    def go():
+        if token:
+            _upd_emit(chat, mid, token, "busy", text, BACK)
+        else:
+            edit_only(chat, mid, text, BACK)
+    try:
+        threading.Thread(target=go, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def start_update():
@@ -4830,12 +4966,20 @@ def handle_cb(chat, mid, data, uid=None):
     if data == "doctor":
         edit(chat, mid, "🩺 自检中(几秒)…", BACK); edit(chat, mid, doctor_text(), BACK); return
     if data == "upd_check":
-        # 检查里有 git fetch(走网络) —— 绝不能在主 getUpdates 循环里同步等它, 否则整个
-        # bot 在这段时间不响应任何菜单。这里只把消息改成"检查中", 剩下的交给后台执行器。
-        if not _upd_check_async(chat, mid):
-            edit(chat, mid, "⏳ 上一次「检查更新」还在跑, 结果会更新到发起它的那条消息。"
-                            "等它出结果再点。", BACK); return
-        edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", BACK); return
+        # 主轮询在这里**一次网络调用都不做**: 受理只动内存表, 连"检查更新中…"这条进度
+        # 也由后台任务自己发 —— 否则它既会阻塞 getUpdates, 又可能后于终态落地把结果盖掉。
+        # 三种受理结果必须分开说: 忙 / 全局排满 / 提交失败, 互相冒充会把用户引到错的动作上。
+        _acc, _tok = _upd_check_async(chat, mid)
+        if _acc == ACCEPT_BUSY:
+            _upd_notify_async(chat, mid, "⏳ 上一次「检查更新」还在跑, 结果会更新到发起它的"
+                                         "那条消息。等它出结果再点。", _tok)
+        elif _acc == ACCEPT_FULL:
+            _upd_notify_async(chat, mid, "⏳ 正在检查更新的会话太多, 本次<b>未受理</b>。"
+                                         "稍后再点一次。")
+        elif _acc == ACCEPT_SUBMIT_FAIL:
+            _upd_notify_async(chat, mid, "❌ 后台执行器不可用, 本次<b>未受理</b>(没有任务在跑)。"
+                                         "稍后再试; 也可以到服务器上跑 <code>sudo pdg update</code>。")
+        return
     if data == "upd_apply":
         ok = start_update()
         edit(chat, mid, ("🚀 已开始后台更新, 约 30-60 秒后 bot 自动回来(期间可能短暂无响应)。\n"

--- a/deploy/bot/pdg-bot.py
+++ b/deploy/bot/pdg-bot.py
@@ -60,15 +60,30 @@ del_sel: dict[int, set] = {}   # 删规则多选: chat -> 已勾选域名集合
 # 一条 HTTPS 连接不能被多线程并发复用(交错请求会串包), 故按线程隔离而非全局共享。
 _tls = threading.local()
 
-def post(method, params):
+API_TIMEOUT = 70                 # 默认单次传输上限(主轮询 getUpdates 靠它)
+
+
+def post(method, params, deadline=None):
+    """调一次 Telegram API。
+
+    deadline(time.monotonic 的绝对时刻)给了就**真正约束**这一次调用: 每次传输的 socket
+    超时取"剩余时间"与默认值的较小者, 剩余为 0 就直接放弃, 重试也要重新看剩余。
+    以前这里恒用 70s 且必重连一次 —— 于是一次检查的两个 emit 各带两段回退, 合起来能发出
+    8 次传输、耗掉 560 秒, 远超整次检查的预算。调用方不传 deadline 时行为一个字不变。
+    """
     body = json.dumps(params).encode()
     path = "/bot" + TOKEN + "/" + method
     hdr = {"Content-Type": "application/json", "Connection": "keep-alive"}
     for attempt in (0, 1):                       # 连接断了就重连重试一次
+        if deadline is not None:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                print("api", method, "deadline-exceeded"); return {}
         try:
             conn = getattr(_tls, "conn", None)
             if conn is None:
-                conn = http.client.HTTPSConnection("api.telegram.org", timeout=70)
+                _to = API_TIMEOUT if deadline is None else max(0.1, min(API_TIMEOUT, left))
+                conn = http.client.HTTPSConnection("api.telegram.org", timeout=_to)
                 _tls.conn = conn
             conn.request("POST", path, body, hdr)
             data = conn.getresponse().read()
@@ -330,22 +345,42 @@ def send_tracked(chat, text, kb=None):
 _last_page: dict = {}
 _last_page_lock = threading.Lock()
 _LAST_PAGE_MAX = 256
+# 用户**意图版本**: 每次回调进来 +1。只有主轮询线程(handle_cb 里)写的页面才算"用户想看的",
+# 后台任务/补绘写的不算 —— 靠一个 thread-local 区分, 不用改 137 处调用方。
+_intent: dict = {}                 # (chat, mid) -> (ver, text, kb)
+_intent_ver: dict = {}             # (chat, mid) -> ver
+_last_write: dict = {}             # (chat, mid) -> 最近一次**成功**写入的文本
+_intent_tls = threading.local()
+
+
+def _bump_intent(chat, mid):
+    with _last_page_lock:
+        v = _intent_ver.get((chat, mid), 0) + 1
+        _intent_ver[(chat, mid)] = v
+        while len(_intent_ver) > _LAST_PAGE_MAX:
+            _intent_ver.pop(next(iter(_intent_ver)))
+        return v
+
+
+def _intent_now(chat, mid):
+    with _last_page_lock:
+        return _intent_ver.get((chat, mid), 0), _intent.get((chat, mid)), _last_write.get((chat, mid))
 
 
 def _remember_page(chat, mid, text, kb):
-    """记最近**两**条: 后台任务抢在导航之后落地时, 要靠上一条把用户真正要看的那页补回去。"""
+    """记一次成功写入。**带上写它的那一刻的用户意图版本** —— 只有主轮询线程有版本号,
+    后台写入没有, 于是"用户想看哪一页"不会被后台的迟到写入冒名顶替。"""
     if mid is None:
         return
+    ver = getattr(_intent_tls, "ver", None)
     with _last_page_lock:
-        hist = _last_page.get((chat, mid)) or []
-        _last_page[(chat, mid)] = ([(text, kb)] + hist)[:2]
-        while len(_last_page) > _LAST_PAGE_MAX:
-            _last_page.pop(next(iter(_last_page)))
-
-
-def _recall_pages(chat, mid):
-    with _last_page_lock:
-        return list(_last_page.get((chat, mid)) or [])
+        _last_write[(chat, mid)] = text
+        if ver is not None:
+            _intent[(chat, mid)] = (ver, text, kb)
+        while len(_last_write) > _LAST_PAGE_MAX:
+            _last_write.pop(next(iter(_last_write)))
+        while len(_intent) > _LAST_PAGE_MAX:
+            _intent.pop(next(iter(_intent)))
 
 
 def edit(chat, mid, text, kb=None):
@@ -358,7 +393,7 @@ def edit(chat, mid, text, kb=None):
         _remember_page(chat, mid, text, kb); return
     send(chat, text, kb)             # 仍不行(如消息已删)再发新消息
 
-def edit_only(chat, mid, text, kb=None):
+def edit_only(chat, mid, text, kb=None, deadline=None):
     """只尝试原地编辑, **绝不退化成发新消息**。成功 True, 失败 False。
 
     给后台监听这类"事后回报"用: 用户可能早就把那条消息删了, 这时普通 edit() 的 fallback
@@ -366,11 +401,17 @@ def edit_only(chat, mid, text, kb=None):
     只在日志里留一行(不含正文)。"""
     p = {"chat_id": chat, "message_id": mid, "text": text, "parse_mode": "HTML",
          "reply_markup": kb or MENU, "disable_web_page_preview": True}
-    r = post("editMessageText", p)
+    # 兼容: 没有期限时**按原样两参调用** —— 既有调用方(以及它们的测试替身)一个字都不用改。
+    def _post(pp):
+        return post("editMessageText", pp) if deadline is None else post("editMessageText", pp, deadline)
+
+    r = _post(p)
     if r.get("ok"):
         _remember_page(chat, mid, text, kb); return True
+    if deadline is not None and time.monotonic() >= deadline:
+        print("edit_only give up: deadline"); return False   # 期限到了就不再回退重试
     p.pop("parse_mode", None)        # HTML 解析失败(文本含 < & 等)→ 退回纯文本再试一次
-    r = post("editMessageText", p)
+    r = _post(p)
     if r.get("ok"):
         _remember_page(chat, mid, text, kb); return True
     print("edit_only skipped", (r or {}).get("error_code"), flush=True)
@@ -2878,30 +2919,35 @@ def update_check(budget=None):
     except Exception as e:  # noqa: BLE001   # 不带异常正文(可能含远端 URL/凭据)
         return False, "❌ 检查更新失败(%s), 本次无结论。稍后重试。" % type(e).__name__
 
-# ── 检查更新: 受理 → 排队 → 执行 → 投递, 全程有界且写入有序 ──────────────────
-# 上一版把检查挪到后台就以为完事了, 留下六个洞(每一个都在 tests/ 里有确定性复现):
-#   · 结果比"检查中"先落地 → 终态被进度覆盖(倒退);
-#   · "还在跑"先出发后落地 → 终态被它覆盖;
-#   · 初始 edit 失败会 send 一条新消息 → 孤立进度消息, 任务只认原 mid, 永不更新它;
-#   · 过了 token 检查、正在投递时用户返回菜单 → 新页面被旧结果取代;
-#   · 提交失败被说成"上一次还在跑";
-#   · 初始提示/忙反馈在主轮询里同步发 → 网络慢就把 getUpdates 卡住。
-#
-# 收口办法是**一条通道**: 这条消息上的每一次写入都走 _upd_emit, 它按阶段序(进度 < 忙 < 终态)
-# 单调推进 —— 低阶段永远盖不了已经落地的高阶段。归属仍是 (chat, message_id) → token。
-# 三种写入(进度/忙/终态)一律在后台线程发出, 主轮询一次网络都不做。
-UPD_PHASE = {"progress": 1, "busy": 2, "final": 3}
-# 全局准入上限: 线程数有限**不等于**队列有界 —— ThreadPoolExecutor 的队列是无限的,
-# 4 个 worker 被占满时 20 个会话照样全被受理, 然后一起排队等到超时。
-UPD_MAX_INFLIGHT = 8
-# 排队太久就别做了: worker 真正开跑时若剩余预算不足这个数, 直接给终态, 不再发起 git。
-UPD_MIN_RUN_BUDGET = 20.0
-# 投递(含重试)与子进程收尾的固定收尾预算, 计入端到端上界。
-UPD_DELIVER_BUDGET = 40.0
+# ── 检查更新: 受理 → 排队 → 执行 → 投递, 全程有界、写入有序、归属可作废 ────────
+# 六条来之不易的性质(每条都有确定性复现与撤销负控):
+#   1. **投递也在期限内**。post/edit_only 接受 deadline: 每次传输的 socket 超时取剩余,
+#      期限到了就不再回退重试。以前恒用 70s 且必重连一次 —— 两个 emit 能发 8 次传输、560 秒。
+#   2. **排队过期不等空闲 worker**。一个共用的收割线程按期限裁决, 取消待执行的 Future、
+#      释放名额; 迟到才启动的旧任务看到 cancelled 就直接返回, 不跑 git、不发进度。
+#   3. **身份与写入权分开**。job 是稳定身份(清理按它匹配), write token 可被导航作废 ——
+#      作废写入权不等于丢掉清理自己的资格。
+#   4. **拒绝通知同样有归属与期限**: FULL / SUBMIT_FAIL 也建一条 notice 会话, 能被作废。
+#   5. **反馈不新开线程**: 一个有界的通知执行器 + 按消息合并的待发表, 连点 20 次也只有
+#      一份在途工作。主轮询不等网络、不等投递锁。
+#   6. **补绘服从最新意图**: 用用户意图版本(只有主轮询线程的写入才算意图), 不再靠"最近两条
+#      成功写入"猜; 补绘自己也受版本、归属与期限约束, 尝试次数有界。
+UPD_PHASE = {"progress": 1, "busy": 2, "notice": 2, "final": 3, "repaint": 4}
+UPD_MAX_INFLIGHT = 8               # 全局准入上限(独立于线程数)
+UPD_MIN_RUN_BUDGET = 20.0          # worker 开跑时剩余不足这个数就直接给终态
+UPD_DELIVER_BUDGET = 40.0          # 投递 + 补绘 + 收尾的固定预算
+UPD_NOTICE_BUDGET = 20.0           # 拒绝/忙 通知自己的期限
+UPD_REPAINT_MAX = 3                # 补绘尝试次数上限
+UPD_REAP_TICK = 1.0                # 收割线程的轮询间隔
 
 _upd_lock = threading.Lock()
-_upd_sess: dict = {}       # (chat, mid) -> {"token", "phase", "inflight", "deadline"}
-_upd_inflight: dict = {}   # chat -> (mid, token)
+_upd_sess: dict = {}       # (chat, mid) -> 会话
+_upd_inflight: dict = {}   # chat -> job(稳定身份)
+_upd_jobs: dict = {}       # job -> (chat, mid)
+# 通知: 一个有界执行器 + 按消息合并的待发表 —— 连点多少次都只有一份在途工作。
+_upd_notify_exec = concurrent.futures.ThreadPoolExecutor(max_workers=2,
+                                                         thread_name_prefix="pdg-updnote")
+_upd_notify_pending: dict = {}     # (chat, mid) -> (text, token, deadline)
 
 UPD_CONFIRM_KB = {"inline_keyboard": [[{"text": "✅ 确认更新", "callback_data": "upd_apply"}],
                                       [{"text": "⬅️ 返回主菜单", "callback_data": "menu"}]]}
@@ -2909,37 +2955,51 @@ UPD_CONFIRM_KB = {"inline_keyboard": [[{"text": "✅ 确认更新", "callback_da
 ACCEPT_OK, ACCEPT_BUSY, ACCEPT_FULL, ACCEPT_SUBMIT_FAIL = "ok", "busy", "full", "submit_fail"
 
 
-def _upd_invalidate(chat, mid):
-    """这条消息被新回调接管 → 作废在飞检查的写入权。
+def _upd_new_sess(chat, mid, deadline, kind="check"):
+    """建一条会话。job = 稳定身份(清理按它匹配); token = 可被作废的写入权。"""
+    job = uuid.uuid4().hex
+    _upd_sess[(chat, mid)] = {"job": job, "token": job, "phase": 0, "inflight": None,
+                              "deadline": deadline, "send": threading.Lock(),
+                              "kind": kind, "cancelled": False, "fut": None,
+                              "started": False, "repaint": False, "mine": set()}
+    _upd_jobs[job] = (chat, mid)
+    return job
 
-    返回 True 表示**此刻正有一次投递在网上飞**: 已经发出的请求收不回来(这一点不假装能做到),
-    所以由那个写入方在收到响应后, 把用户真正要看的那一页补回去(见 _upd_emit 的 repaint)。
-    """
+
+def _upd_drop_sess(chat, mid, job):
+    """按**稳定身份**清理自己的记录 —— 写入权被作废也照样能清; 同一条消息上后来新建的
+    会话 job 不同, 不会被误删。"""
+    sess = _upd_sess.get((chat, mid))
+    if sess is not None and sess.get("job") == job:
+        _upd_sess.pop((chat, mid), None)
+    _upd_jobs.pop(job, None)
+    for c, j in list(_upd_inflight.items()):
+        if j == job:
+            _upd_inflight.pop(c, None)
+
+
+def _upd_invalidate(chat, mid):
+    """这条消息被新回调接管 → 作废写入权(身份不动, 清理资格保留)。"""
     with _upd_lock:
         sess = _upd_sess.get((chat, mid))
         if not sess:
             return False
-        sess["token"] = None            # 之后任何 emit 都会被拒
+        sess["token"] = None
         if sess.get("inflight"):
-            sess["repaint"] = True      # 有一次投递正在网上飞 —— 落地后要把新页面补回去
+            sess["repaint"] = True
             return True
         return False
 
 
 def _upd_emit(chat, mid, token, phase, text, kb):
-    """这条消息的**唯一**写入口。阶段序单调: 低阶段盖不了已经落地的高阶段。
-
-    锁只用来占位与记账, **网络调用在锁外**做 —— 主轮询和导航都不会因为它而等网络。
-    """
+    """这条消息的**唯一**写入口。阶段序管准入, per-message 投递锁管落地顺序,
+    deadline 管每一次传输与重试。"""
     want = UPD_PHASE[phase]
     with _upd_lock:
         sess = _upd_sess.get((chat, mid))
         if not sess or sess.get("token") != token:
             return False, "superseded"
-        send_lock = sess["send"]
-    # **按消息串行化投递**。阶段序只管准入: 两次写入可以按序被放行, 却因为网络快慢而乱序
-    # 落地(上一版就栽在这里 —— "还在跑"先出发、后落地, 把已经到达的终态盖了回去)。
-    # 这把锁只在后台线程里持有, 主轮询和导航都不取它, 不会因此等网络。
+        send_lock, dl, job = sess["send"], sess["deadline"], sess["job"]
     with send_lock:
         with _upd_lock:
             sess = _upd_sess.get((chat, mid))
@@ -2951,106 +3011,158 @@ def _upd_emit(chat, mid, token, phase, text, kb):
             sess["inflight"] = want
             sess["mine"].add(text)
         try:
-            delivered = edit_only(chat, mid, text, kb)
+            delivered = edit_only(chat, mid, text, kb, deadline=dl)
         finally:
             with _upd_lock:
                 sess = _upd_sess.get((chat, mid))
-                if sess is not None and sess.get("inflight") == want:
-                    sess["inflight"] = None
+                if sess is not None and sess.get("job") == job:
+                    if sess.get("inflight") == want:
+                        sess["inflight"] = None
                 need_repaint = bool(sess and sess.get("repaint"))
-                mine = set(sess["mine"]) if sess else set()
         if need_repaint and delivered:
-            # 我们在"用户已经翻页"之后才落地。已经发出的请求收不回来 —— 这里做的是**收敛**:
-            # 把用户真正要看的那一页补回去。上一条页面若还是我们自己写的, 说明导航那次编辑
-            # 没落地(或失败了), 那就不补 —— 补了会把终态倒退成进度。
-            hist = _recall_pages(chat, mid)
-            if len(hist) > 1 and hist[0][0] == text and hist[1][0] not in mine:
-                edit_only(chat, mid, hist[1][0], hist[1][1])
-                return False, "repainted"
+            _upd_repaint(chat, mid, dl)
+            return False, "repainted"
     return delivered, ("ok" if delivered else "undelivered")
 
 
-def _upd_check_async(chat, mid):
-    """受理一次检查。返回 ACCEPT_* —— 忙 / 全局满 / 提交失败必须分开, 不能互相冒充。
+def _upd_repaint(chat, mid, deadline):
+    """把用户**当前**想看的那一页补回去。
 
-    **等待从受理这一刻开始计时**(accepted_at), 不是等 worker 跑起来才开始 —— 排队时间
-    也算在用户的等待里。
+    不靠"最近两条成功写入"猜: 用意图版本。每写一次就重看一次版本, 版本又变了就照最新的再写,
+    次数与期限双重有界。已经发出去的请求收不回来 —— 这里做的是收敛, 不是撤回。
     """
-    accepted_at = time.monotonic()
+    for _ in range(UPD_REPAINT_MAX):
+        if time.monotonic() >= deadline:
+            print("upd repaint give up: deadline", flush=True)
+            return
+        ver, intent, last = _intent_now(chat, mid)
+        if not intent or intent[0] != ver:
+            return                      # 当前版本还没有对应的页面, 不猜
+        if last == intent[1]:
+            return                      # 屏幕上已经是用户要看的那页
+        edit_only(chat, mid, intent[1], intent[2], deadline=deadline)
+        ver2, _i2, _l2 = _intent_now(chat, mid)
+        if ver2 == ver:
+            return                      # 期间没有新动作 —— 收敛完成
+    print("upd repaint give up: attempts", flush=True)
+
+
+def _upd_notify(chat, mid, text, token, deadline):
+    """有界通知: 同一条消息只保留一份待发工作, 重复点击合并成一次, 不新开线程。"""
     with _upd_lock:
-        cur = _upd_inflight.get(chat)
-        if cur is not None:
-            if cur[0] == mid:                       # 同一条消息上的重复点击: 归属还回去
+        had = (chat, mid) in _upd_notify_pending
+        _upd_notify_pending[(chat, mid)] = (text, token, deadline)
+    if had:
+        return
+    def go():
+        while True:
+            with _upd_lock:
+                item = _upd_notify_pending.pop((chat, mid), None)
+            if item is None:
+                return
+            txt, tok, dl = item
+            if time.monotonic() >= dl:
+                continue
+            _upd_emit(chat, mid, tok, "notice", txt, BACK)
+    try:
+        _upd_notify_exec.submit(go)
+    except Exception:  # noqa: BLE001
+        with _upd_lock:
+            _upd_notify_pending.pop((chat, mid), None)
+
+
+def _upd_reap():
+    """收割线程: 按期限裁决排队过久的检查 —— **不等空闲 worker**。
+
+    取消还没开跑的 Future、置 cancelled、释放名额, 并把终态通知交给有界通知器。
+    """
+    while True:
+        time.sleep(UPD_REAP_TICK)
+        now = time.monotonic()
+        expired = []
+        with _upd_lock:
+            for (c, m), sess in list(_upd_sess.items()):
+                if sess.get("kind") != "check" or sess.get("started") or sess.get("cancelled"):
+                    continue
+                if now >= sess["deadline"] - UPD_DELIVER_BUDGET:
+                    sess["cancelled"] = True
+                    fut = sess.get("fut")
+                    expired.append((c, m, sess["job"], sess.get("token"), sess["deadline"], fut))
+        for c, m, job, tok, dl, fut in expired:
+            if fut is not None:
+                fut.cancel()
+            with _upd_lock:
+                _upd_drop_sess(c, m, job)
+                _upd_new_sess(c, m, now + UPD_NOTICE_BUDGET, kind="notice")
+                ntok = _upd_sess[(c, m)]["token"]
+            print("upd check expired in queue", flush=True)
+            _upd_notify(c, m, "❌ 检查更新排队过久, 本次未执行(未发起任何 git)。稍后重试。",
+                        ntok, now + UPD_NOTICE_BUDGET)
+
+
+_upd_reaper = threading.Thread(target=_upd_reap, daemon=True, name="pdg-updreap")
+_upd_reaper.start()
+
+
+def _upd_check_async(chat, mid):
+    """受理一次检查。等待从**受理**这一刻计时。返回 (ACCEPT_*, token)。"""
+    now = time.monotonic()
+    with _upd_lock:
+        if chat in _upd_inflight:
+            job = _upd_inflight[chat]
+            c_m = _upd_jobs.get(job)
+            if c_m == (chat, mid):                  # 同一条消息重复点击: 写入权还回去
                 sess = _upd_sess.get((chat, mid))
                 if sess is not None:
-                    sess["token"] = cur[1]
-            # 把在飞任务的 token 一并交出去: "还在跑"这条反馈必须走**同一条通道**,
-            # 否则任务一旦已经收尾把会话记录清掉, 这条反馈就会绕过阶段序、把终态盖回去。
-            return ACCEPT_BUSY, cur[1]
+                    sess["token"] = sess["job"]
+                    return ACCEPT_BUSY, sess["job"]
+            return ACCEPT_BUSY, None
         if len(_upd_inflight) >= UPD_MAX_INFLIGHT:
-            return ACCEPT_FULL, None
-        token = uuid.uuid4().hex
-        _upd_inflight[chat] = (mid, token)
-        _upd_sess[(chat, mid)] = {"token": token, "phase": 0, "inflight": None,
-                                  "deadline": accepted_at + UPD_CHECK_BUDGET,
-                                  "send": threading.Lock(), "repaint": False, "mine": set()}
-
-    def _release():
-        with _upd_lock:
-            if _upd_inflight.get(chat) == (mid, token):
-                _upd_inflight.pop(chat, None)
-            sess = _upd_sess.get((chat, mid))
-            if sess is not None and sess.get("token") == token:
-                _upd_sess.pop((chat, mid), None)
+            job = _upd_new_sess(chat, mid, now + UPD_NOTICE_BUDGET, kind="notice")
+            return ACCEPT_FULL, job
+        job = _upd_new_sess(chat, mid, now + UPD_CHECK_BUDGET)
+        _upd_inflight[chat] = job
 
     def go():
         try:
-            _upd_emit(chat, mid, token, "progress",
-                      "🔄 检查更新中…(结果会更新到这条消息)", BACK)
-            left = _upd_sess.get((chat, mid), {}).get("deadline", 0) - time.monotonic()
+            with _upd_lock:
+                sess = _upd_sess.get((chat, mid))
+                if not sess or sess.get("job") != job or sess.get("cancelled"):
+                    return                          # 已被收割: 不跑 git, 不发进度
+                sess["started"] = True
+                dl, tok = sess["deadline"], sess.get("token")
+            left = dl - time.monotonic()
             if left < UPD_MIN_RUN_BUDGET:
-                # 排队排掉了预算: 直接给终态, 不再发起任何 git。
-                _upd_emit(chat, mid, token, "final",
-                          "❌ 检查更新排队过久, 本次未执行。稍后重试。", BACK)
+                _upd_emit(chat, mid, tok, "final",
+                          "❌ 检查更新排队过久, 本次未执行(未发起任何 git)。稍后重试。", BACK)
                 return
+            _upd_emit(chat, mid, tok, "progress",
+                      "🔄 检查更新中…(结果会更新到这条消息)", BACK)
             try:
-                has, txt = update_check(budget=max(0.0, left - UPD_DELIVER_BUDGET))
+                has, txt = update_check(budget=max(0.0, dl - time.monotonic() - UPD_DELIVER_BUDGET))
             except BaseException as e:      # noqa: BLE001
                 has, txt = False, ("❌ 检查更新失败(%s), 本次无结论。稍后重试。"
                                    % type(e).__name__)
-            delivered, why = _upd_emit(chat, mid, token, "final", txt,
+            delivered, why = _upd_emit(chat, mid, tok, "final", txt,
                                        UPD_CONFIRM_KB if has else BACK)
-            # 任务结束 ≠ 用户收到。两件事分开记。
             print("upd check finished has=%s delivered=%s why=%s"
                   % (bool(has), bool(delivered), why), flush=True)
         finally:
-            _release()
+            with _upd_lock:
+                _upd_drop_sess(chat, mid, job)      # 按稳定身份清理, 与写入权无关
 
     try:
-        _EXEC.submit(go)
-        return ACCEPT_OK, token
+        fut = _EXEC.submit(go)
+        with _upd_lock:
+            sess = _upd_sess.get((chat, mid))
+            if sess is not None and sess.get("job") == job:
+                sess["fut"] = fut
+        return ACCEPT_OK, job
     except Exception:  # noqa: BLE001
-        _release()
-        return ACCEPT_SUBMIT_FAIL, None
-
-
-def _upd_notify_async(chat, mid, text, token=None):
-    """把"忙 / 队列满 / 提交失败"这类反馈也放后台发 —— 主轮询不做网络调用。
-
-    token 非空(=有任务在飞)时走**同一条通道**, 阶段序 busy(2) < final(3): 终态已经落地就
-    直接拒掉, 不会把结果盖回去; 任务已经收尾、会话记录被清掉时, emit 同样判 superseded 而
-    不写 —— 这正是上一版的洞: 那时它退化成裸 edit_only, 把终态覆盖成了"还在跑"。
-    token 为空(队列满 / 提交失败)时这条消息上本来就没有在飞的检查, 直接写。
-    """
-    def go():
-        if token:
-            _upd_emit(chat, mid, token, "busy", text, BACK)
-        else:
-            edit_only(chat, mid, text, BACK)
-    try:
-        threading.Thread(target=go, daemon=True).start()
-    except Exception:  # noqa: BLE001
-        pass
+        with _upd_lock:
+            _upd_drop_sess(chat, mid, job)
+            njob = _upd_new_sess(chat, mid, now + UPD_NOTICE_BUDGET, kind="notice")
+        return ACCEPT_SUBMIT_FAIL, njob
 
 
 def start_update():
@@ -4835,9 +4947,18 @@ def _adblock_pending(chat, uid, kind):
 
 
 def handle_cb(chat, mid, data, uid=None):
-    # 这条消息被新回调接管了 → 作废还在飞的"检查更新"结果。用户已经返回菜单、开始更新、
-    # 或者又点了一次检查, 旧结果再写回去就是覆盖他正在看的页面。
+    # 每次回调都推进这条消息的**用户意图版本**, 并作废还在飞的"检查更新"写入权。
+    # thread-local 的版本号让 _remember_page 分得清"用户想看的页"与"后台迟到的写入" ——
+    # 补绘据此收敛到最新意图, 而不是靠猜最近两条写入。
+    _intent_tls.ver = _bump_intent(chat, mid)
     _upd_invalidate(chat, mid)
+    try:
+        return _handle_cb_inner(chat, mid, data, uid)
+    finally:
+        _intent_tls.ver = None
+
+
+def _handle_cb_inner(chat, mid, data, uid=None):
     # ── 去广告(闭集 callback, 不接受任意动作名)────────────────────────────────
     if data.startswith("adblock:"):
         act = data.split(":", 1)[1]
@@ -4969,16 +5090,20 @@ def handle_cb(chat, mid, data, uid=None):
         # 主轮询在这里**一次网络调用都不做**: 受理只动内存表, 连"检查更新中…"这条进度
         # 也由后台任务自己发 —— 否则它既会阻塞 getUpdates, 又可能后于终态落地把结果盖掉。
         # 三种受理结果必须分开说: 忙 / 全局排满 / 提交失败, 互相冒充会把用户引到错的动作上。
+        # 主轮询在这里**一次网络调用都不做, 也不等任何投递锁**: 受理只动内存表,
+        # 反馈交给有界通知器。三种受理结果分开说 —— 忙 / 全局排满 / 提交失败互不冒充。
         _acc, _tok = _upd_check_async(chat, mid)
+        _msg = None
         if _acc == ACCEPT_BUSY:
-            _upd_notify_async(chat, mid, "⏳ 上一次「检查更新」还在跑, 结果会更新到发起它的"
-                                         "那条消息。等它出结果再点。", _tok)
+            _msg = ("⏳ 上一次「检查更新」还在跑, 结果会更新到发起它的那条消息。"
+                    "等它出结果再点。")
         elif _acc == ACCEPT_FULL:
-            _upd_notify_async(chat, mid, "⏳ 正在检查更新的会话太多, 本次<b>未受理</b>。"
-                                         "稍后再点一次。")
+            _msg = "⏳ 正在检查更新的会话太多, 本次<b>未受理</b>。稍后再点一次。"
         elif _acc == ACCEPT_SUBMIT_FAIL:
-            _upd_notify_async(chat, mid, "❌ 后台执行器不可用, 本次<b>未受理</b>(没有任务在跑)。"
-                                         "稍后再试; 也可以到服务器上跑 <code>sudo pdg update</code>。")
+            _msg = ("❌ 后台执行器不可用, 本次<b>未受理</b>(没有任务在跑)。稍后再试; "
+                    "也可以到服务器上跑 <code>sudo pdg update</code>。")
+        if _msg and _tok:
+            _upd_notify(chat, mid, _msg, _tok, time.monotonic() + UPD_NOTICE_BUDGET)
         return
     if data == "upd_apply":
         ok = start_update()

--- a/tests/negctl/bot-update-check-negative-controls.py
+++ b/tests/negctl/bot-update-check-negative-controls.py
@@ -60,12 +60,23 @@ INVAL = lift(r'^    _upd_invalidate\(chat, mid\)$')
 CLIP = lift(r'^    return line if len\(line\) <= UPD_LINE_MAX else line\[:UPD_LINE_MAX - 1\] \+ "…"$')
 # ── 本轮新增的六条承重性质 ────────────────────────────────────────────────────
 SENDLOCK = lift(r'^    with send_lock:$')
+# ── 本轮六项 ──────────────────────────────────────────────────────────────────
+POSTDL = lift(r'^        if deadline is not None:\n            left = deadline - time\.monotonic\(\)\n            if left <= 0:\n                print\("api", method, "deadline-exceeded"\); return \{\}$')
+EDITDL = lift(r'^    if deadline is not None and time\.monotonic\(\) >= deadline:$')
+REAPER = lift(r'^                if now >= sess\["deadline"\] - UPD_DELIVER_BUDGET:$')
+CANCEL = lift(r'^                if not sess or sess\.get\("job"\) != job or sess\.get\("cancelled"\):$')
+DROPJOB = lift(r'^    if sess is not None and sess\.get\("job"\) == job:\n        _upd_sess\.pop\(\(chat, mid\), None\)$')
+NOTICE = lift(r'^            job = _upd_new_sess\(chat, mid, now \+ UPD_NOTICE_BUDGET, kind="notice"\)\n            return ACCEPT_FULL, job$')
+NOTEMERGE = lift(r'^    if had:\n        return$')
+INTENTVER = lift(r'^        ver, intent, last = _intent_now\(chat, mid\)$')
 PHASE = lift(r'^            if sess\.get\("phase", 0\) >= want:\n                return False, "stale-phase"$')
-NOTIFY_TOK = lift(r'^        if token:\n            _upd_emit\(chat, mid, token, "busy", text, BACK\)\n        else:\n            edit_only\(chat, mid, text, BACK\)$')
-ADMIT = lift(r'^        if len\(_upd_inflight\) >= UPD_MAX_INFLIGHT:\n            return ACCEPT_FULL, None$')
+# 忙/拒绝反馈现在一律经通道(notice 阶段), 锚点跟着挪。
+NOTIFY_TOK = lift(r'^            _upd_emit\(chat, mid, tok, "notice", txt, BACK\)$')
+ADMIT = lift(r'^        if len\(_upd_inflight\) >= UPD_MAX_INFLIGHT:$')
 SHALLOW = lift(r'^    if shallow\.returncode != 0 or _sv not in \("true", "false"\):\n.*?shallow\.returncode$')
 SLUGCAP = lift(r'^        cap = 5 if deadline is None else min\(5, max\(0\.0, deadline - time\.monotonic\(\)\)\)$')
-REPAINT = lift(r'^            if len\(hist\) > 1 and hist\[0\]\[0\] == text and hist\[1\]\[0\] not in mine:$')
+# 补绘已改成按用户意图版本收敛, 锚点指到它的调用点。
+REPAINT = lift(r'^        if need_repaint and delivered:\n            _upd_repaint\(chat, mid, dl\)$')
 KILLPG = lift(r'^        try:\n            os\.killpg\(os\.getpgid\(p\.pid\), signal\.SIGKILL\)\n.*?p\.kill\(\)$')
 
 MUT = [
@@ -97,16 +108,33 @@ MUT = [
     ("⑧ 取消阶段序(低阶段可以盖掉已落地的高阶段)",
      [(PHASE, '            if False:\n                return False, "stale-phase"', 1)]),
     ("⑨ 忙反馈绕过通道(退化成裸 edit_only)",
-     [(NOTIFY_TOK, '        edit_only(chat, mid, text, BACK)', 1)]),
+     [(NOTIFY_TOK, '            edit_only(chat, mid, txt, BACK)', 1)]),
     ("⑩ 取消全局准入上限(线程有限≠队列有界)",
-     [(ADMIT, '        if False:\n            return ACCEPT_FULL, None', 1)]),
+     [(ADMIT, '        if False:', 1)]),
     ("⑪ shallow 探测不校验退出码/取值",
      [(SHALLOW, '    if False:\n        return False, "x" % shallow.returncode', 1)]),
     ("⑫ origin 查询另拿独立预算",
      [(SLUGCAP, '        cap = 5', 1)]),
     ("⑬ 取消导航抢写后的收敛修复",
-     [(REPAINT, '            if False:', 1)]),
-    ("⑭ 只加无关注释(反向对照)",
+     [(REPAINT, '        if False:\n            _upd_repaint(chat, mid, dl)', 1)]),
+    ("⑮ post 忽略 deadline(投递回到恒定 70s + 必重连)",
+     [(POSTDL, '        if False:\n            left = 0\n            if left <= 0:\n'
+               '                print("x"); return {}', 1)]),
+    ("⑯ edit_only 期限到了仍然回退重试",
+     [(EDITDL, '    if False:', 1)]),
+    ("⑰ 取消收割线程的排队裁决(回到等空闲 worker)",
+     [(REAPER, '                if False:', 1)]),
+    ("⑱ 迟到启动的旧任务仍然执行(不看 cancelled)",
+     [(CANCEL, '                if not sess or sess.get("job") != job:\n                    return', 1)]),
+    ("⑲ 清理按写入权而不是稳定身份(作废后漏清理)",
+     [(DROPJOB, '    if sess is not None and sess.get("token") == job:\n        _upd_sess.pop((chat, mid), None)', 1)]),
+    ("⑳ 拒绝通知不再建归属(裸通知, 不可作废)",
+     [(NOTICE, '            return ACCEPT_FULL, None', 1)]),
+    ("㉑ 通知不合并(每次点击都排一份新工作)",
+     [(NOTEMERGE, '    if False:\n        return', 1)]),
+    ("㉒ 补绘回到猜「最近一次写入」而非最新意图",
+     [(INTENTVER, '        ver, intent, last = (0, None, None)', 1)]),
+    ("㉓ 只加无关注释(反向对照)",
      [(INVAL, '    # (负控的空转对照)\n' + INVAL, 1)]),
 ]
 
@@ -188,7 +216,7 @@ try:
             bad("%s → 正控没有正常运行(%s), 这一格既不算有牙也不算无牙" % (tag, kind))
             continue
         new = got - base
-        if tag.startswith("⑭"):
+        if tag.startswith("㉓"):
             (ok if not new else bad)("%s → %d 条新增(应为 0)" % (tag, len(new)))
             continue
         if new:

--- a/tests/negctl/bot-update-check-negative-controls.py
+++ b/tests/negctl/bot-update-check-negative-controls.py
@@ -62,7 +62,8 @@ CLIP = lift(r'^    return line if len\(line\) <= UPD_LINE_MAX else line\[:UPD_LI
 SENDLOCK = lift(r'^    with send_lock:$')
 # ── 本轮六项 ──────────────────────────────────────────────────────────────────
 POSTDL = lift(r'^        if deadline is not None:\n            left = deadline - time\.monotonic\(\)\n            if left <= 0:\n                print\("api", method, "deadline-exceeded"\); return \{\}$')
-EDITDL = lift(r'^    if deadline is not None and time\.monotonic\(\) >= deadline:$')
+EDITDL = lift(r'^    if deadline is not None and time\.monotonic\(\) >= deadline:\n'
+              r'        print\("edit_only give up: deadline"\); return False.*?$')
 REAPER = lift(r'^                if now >= sess\["deadline"\] - UPD_DELIVER_BUDGET:$')
 CANCEL = lift(r'^                if not sess or sess\.get\("job"\) != job or sess\.get\("cancelled"\):$')
 DROPJOB = lift(r'^    if sess is not None and sess\.get\("job"\) == job:\n        _upd_sess\.pop\(\(chat, mid\), None\)$')
@@ -83,9 +84,6 @@ REPAINT = lift(r'^        if need_repaint and delivered:\n            _upd_repai
 REUSETO = lift(r'^                conn\.timeout = _to\n'
                r'                if conn\.sock is not None:\n'
                r'                    conn\.sock\.settimeout\(_to\)$')
-READDL = lift(r'^        if deadline is not None:\n'
-              r'            if time\.monotonic\(\) >= deadline:\n'
-              r'                raise _ApiDeadline\(\)$')
 # 空 token 有两道拦截(入口快速判 + 取到投递锁后复查)。单撤一道另一道仍拦得住 ——
 # 要撤就两道一起撤, 否则这一格没牙。
 EMITNULL = lift(r'^    if token is None:$')
@@ -101,6 +99,23 @@ NOTICEKIND = lift(r'^        if cur\.get\("kind"\) == "notice":\n'
                   r'            _upd_drop_sess\(chat, mid, job\)$')
 NOTICECAP = lift(r'^        if len\(_upd_notify_live\) >= UPD_NOTICE_MAX:$')
 READCLOSE = lift(r'^    resp\.close\(\)\n    return bytes\(buf\)$')
+
+# ── 本轮(完整响应期限 / 回收器撤销窗口)的锚点 ─────────────────────────────────
+# _api_read 里的逐轮期限检查、逐轮 settimeout, 以及用 read1 而不是 read —— 这三处**没有**
+# 对应的变异格。加了 _ApiGuard 之后它们被完全包住: 实测单撤 ㉕、合并撤 ㉕+㊵、以及 read1
+# 换回 read, 都是 0 条转红。它们是同线程的第一道(不依赖定时器线程被调度), 保留在实现里,
+# 但按纪律不计入"已验证" —— 一格永远不会红的对照等于没有对照。
+# 若将来去掉 guard, 必须把这几格补回来。
+GUARDARM = lift(r'^            sk = conn\.sock\n            guard = _ApiGuard\(sk, deadline\)$')
+GUARDFIRE = lift(r'^    def _fire\(self\):\n'
+                 r'        self\.fired = True\n'
+                 r'        try:\n'
+                 r'            self\.sock\.shutdown\(socket\.SHUT_RDWR\)$')
+GUARDCHK = lift(r'^            if guard\.fired:\n                raise _ApiDeadline\(\)$')
+LATECHK = lift(r'^            if deadline is not None and time\.monotonic\(\) >= deadline:\n'
+               r'                # 逐轮检查通过之后才读完的那一次.*?\n.*?\n'
+               r'                raise _ApiDeadline\(\)$', max_lines=6)
+REAPRECHK = lift(r'^                revoked = mine and cur\.get\("token"\) is None$')
 SESSOLD = lift(r'^    old = _upd_sess\.get\(\(chat, mid\)\)\n'
                r'    if old is not None:\n'
                r'        _upd_jobs\.pop\(old\.get\("job"\), None\)$')
@@ -148,7 +163,7 @@ MUT = [
      [(POSTDL, '        if False:\n            left = 0\n            if left <= 0:\n'
                '                print("x"); return {}', 1)]),
     ("⑯ edit_only 期限到了仍然回退重试",
-     [(EDITDL, '    if False:', 1)]),
+     [(EDITDL, '    if False:\n        print("x"); return False', 1)]),
     ("⑰ 取消收割线程的排队裁决(回到等空闲 worker)",
      [(REAPER, '                if False:', 1)]),
     ("⑱ 迟到启动的旧任务仍然执行(不看 cancelled)",
@@ -164,11 +179,19 @@ MUT = [
     # ── A: 绝对期限贯穿真实请求 ──
     ("㉔ 复用的连接不按剩余预算重设超时(缓存超时)",
      [(REUSETO, '                pass', 1)]),
-    ("㉕ 读响应不再核对绝对期限(只在请求前查一次)",
-     [(READDL, '        if False:\n            if False:\n                raise _ApiDeadline()', 1)]),
     ("㉟ 按块读之后不收尾(keep-alive 名存实亡, 每次都白重连一次)",
      [(READCLOSE, '    return bytes(buf)', 1)]),
+    ("㊱ 期限不覆盖状态行/响应头(守卫不武装, getresponse 裸奔)",
+     [(GUARDARM, '            sk = conn.sock\n            guard = _ApiGuard(sk, None)', 1)]),
+    ("㊲ 守卫到点不结束实际网络工作(只置标志, 不 shutdown)",
+     [(GUARDFIRE, '    def _fire(self):\n        self.fired = True\n        try:\n'
+                  '            pass', 1)]),
+    ("㊳ 超期不再判失败(守卫开火与读完后两处判定一起撤)",
+     [(GUARDCHK, '            if False:\n                raise _ApiDeadline()', 1),
+      (LATECHK, '            if False:\n                raise _ApiDeadline()', 1)]),
     # ── B: 撤销即撤销 ──
+    ("㊶ 回收器动作前不重读撤销状态(用快照时的 revoked 裁决)",
+     [(REAPRECHK, '                revoked = False', 1)]),
     ("㉖ 空 token 重新被当成写回权(两道拦截一起撤: None == None 放行)",
      [(EMITNULL, '    if False:', 1),
       (EMITNULL2, '            if not sess or sess.get("token") != token:', 1)]),
@@ -210,6 +233,19 @@ try:
                         ignore=shutil.ignore_patterns("__pycache__", ".bin"))
     pristine = (Path(wd) / BOT).read_text(encoding="utf-8")
 
+    _crash = {"out": None}
+
+    def _stash(out):
+        """把这一次"没跑正常"的完整输出留住 —— 只报个形态, 排查时等于什么都没说。"""
+        _crash["out"] = out
+
+    def _crash_excerpt():
+        out = _crash["out"] or ""
+        i = out.find("Traceback (most recent call last)")
+        if i < 0:
+            return [l for l in out.splitlines() if l.strip()][-6:]
+        return out[i:].splitlines()[:14]
+
     def run_pos():
         """跑一次正控, 返回 (具名失败集合, 形态)。形态用来把「没牙」和「压根没跑起来」分开。"""
         try:
@@ -221,12 +257,16 @@ try:
         n_ok = len(re.findall(r"^\[OK\]", out, re.M))
         n_fail = len(re.findall(r"^\[FAIL\]", out, re.M))
         if "Traceback (most recent call last)" in out:
+            _stash(out)
             return set(), "崩溃(Traceback)"
         if "ModuleNotFoundError" in out or "ImportError" in out:
+            _stash(out)
             return set(), "导入失败"
         if n_ok + n_fail == 0:
+            _stash(out)
             return set(), "零有效断言"
         if "通过 " not in out:
+            _stash(out)
             return set(), "没有汇总行"
         fails = {re.sub(r"\s+", " ", l.strip())[:150]
                  for l in out.splitlines() if l.startswith("[FAIL]")}
@@ -269,6 +309,8 @@ try:
         (Path(wd) / BOT).write_text(pristine, encoding="utf-8")
         if kind != "正常":
             bad("%s → 正控没有正常运行(%s), 这一格既不算有牙也不算无牙" % (tag, kind))
+            for _l in _crash_excerpt():
+                print("       | " + _l[:150])
             continue
         new = got - base
         if tag.startswith("㉓"):

--- a/tests/negctl/bot-update-check-negative-controls.py
+++ b/tests/negctl/bot-update-check-negative-controls.py
@@ -52,11 +52,20 @@ def lift(pattern, max_lines=24, flags=re.M | re.S):
     return g
 
 
-RENDER = lift(r'^        return True, _upd_render\(cur, tgt, lines, _upd_repo_slug\(\)\)$')
+RENDER = lift(r'^        return True, _upd_render\(cur, tgt, lines, _upd_repo_slug\(deadline\)\)$')
 TRY = lift(r'^    except _UpdCheckTimeout:\n.*?稍后重试。" % type\(e\)\.__name__$')
-ASYNC = lift(r'^        if not _upd_check_async\(chat, mid\):\n.*?结果会更新到这条消息\)", BACK\); return$')
+# 回调这一段在本轮重写过(受理返回三态 + 反馈全走后台), 锚点跟着挪。
+ASYNC = lift(r'^        _acc, _tok = _upd_check_async\(chat, mid\)\n.*?^        return$', max_lines=14)
 INVAL = lift(r'^    _upd_invalidate\(chat, mid\)$')
 CLIP = lift(r'^    return line if len\(line\) <= UPD_LINE_MAX else line\[:UPD_LINE_MAX - 1\] \+ "…"$')
+# ── 本轮新增的六条承重性质 ────────────────────────────────────────────────────
+SENDLOCK = lift(r'^    with send_lock:$')
+PHASE = lift(r'^            if sess\.get\("phase", 0\) >= want:\n                return False, "stale-phase"$')
+NOTIFY_TOK = lift(r'^        if token:\n            _upd_emit\(chat, mid, token, "busy", text, BACK\)\n        else:\n            edit_only\(chat, mid, text, BACK\)$')
+ADMIT = lift(r'^        if len\(_upd_inflight\) >= UPD_MAX_INFLIGHT:\n            return ACCEPT_FULL, None$')
+SHALLOW = lift(r'^    if shallow\.returncode != 0 or _sv not in \("true", "false"\):\n.*?shallow\.returncode$')
+SLUGCAP = lift(r'^        cap = 5 if deadline is None else min\(5, max\(0\.0, deadline - time\.monotonic\(\)\)\)$')
+REPAINT = lift(r'^            if len\(hist\) > 1 and hist\[0\]\[0\] == text and hist\[1\]\[0\] not in mine:$')
 KILLPG = lift(r'^        try:\n            os\.killpg\(os\.getpgid\(p\.pid\), signal\.SIGKILL\)\n.*?p\.kill\(\)$')
 
 MUT = [
@@ -73,16 +82,31 @@ MUT = [
        '        raise', 1)]),
     ("③ 回调恢复同步调用(占住主轮询)",
      [(ASYNC,
-       '        edit(chat, mid, "🔄 检查更新中…", BACK)\n'
+       '        edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", BACK)\n'
        '        has, txt = update_check()\n'
-       '        edit(chat, mid, txt, UPD_CONFIRM_KB if has else BACK); return', 1)]),
+       '        edit(chat, mid, txt, UPD_CONFIRM_KB if has else BACK)\n'
+       '        return', 1)]),
     ("④ 取消归属作废(旧结果会覆盖新页面)",
      [(INVAL, '    pass  # 变异: 不再作废在飞的检查', 1)]),
     ("⑤ 单条标题不再裁剪(超长标题撑爆消息)",
      [(CLIP, '    return line', 1)]),
     ("⑥ 超时只杀父进程(留下 git 派生的助手)",
      [(KILLPG, '        try:\n            p.kill()\n        except Exception:  # noqa: BLE001\n            p.kill()', 1)]),
-    ("⑦ 只加无关注释(反向对照)",
+    ("⑦ 取消按消息串行化投递(阶段序只管准入, 落地会乱序)",
+     [(SENDLOCK, '    if True:', 1)]),
+    ("⑧ 取消阶段序(低阶段可以盖掉已落地的高阶段)",
+     [(PHASE, '            if False:\n                return False, "stale-phase"', 1)]),
+    ("⑨ 忙反馈绕过通道(退化成裸 edit_only)",
+     [(NOTIFY_TOK, '        edit_only(chat, mid, text, BACK)', 1)]),
+    ("⑩ 取消全局准入上限(线程有限≠队列有界)",
+     [(ADMIT, '        if False:\n            return ACCEPT_FULL, None', 1)]),
+    ("⑪ shallow 探测不校验退出码/取值",
+     [(SHALLOW, '    if False:\n        return False, "x" % shallow.returncode', 1)]),
+    ("⑫ origin 查询另拿独立预算",
+     [(SLUGCAP, '        cap = 5', 1)]),
+    ("⑬ 取消导航抢写后的收敛修复",
+     [(REPAINT, '            if False:', 1)]),
+    ("⑭ 只加无关注释(反向对照)",
      [(INVAL, '    # (负控的空转对照)\n' + INVAL, 1)]),
 ]
 
@@ -164,7 +188,7 @@ try:
             bad("%s → 正控没有正常运行(%s), 这一格既不算有牙也不算无牙" % (tag, kind))
             continue
         new = got - base
-        if tag.startswith("⑦"):
+        if tag.startswith("⑭"):
             (ok if not new else bad)("%s → %d 条新增(应为 0)" % (tag, len(new)))
             continue
         if new:

--- a/tests/negctl/bot-update-check-negative-controls.py
+++ b/tests/negctl/bot-update-check-negative-controls.py
@@ -55,7 +55,7 @@ def lift(pattern, max_lines=24, flags=re.M | re.S):
 RENDER = lift(r'^        return True, _upd_render\(cur, tgt, lines, _upd_repo_slug\(deadline\)\)$')
 TRY = lift(r'^    except _UpdCheckTimeout:\n.*?稍后重试。" % type\(e\)\.__name__$')
 # 回调这一段在本轮重写过(受理返回三态 + 反馈全走后台), 锚点跟着挪。
-ASYNC = lift(r'^        _acc, _tok = _upd_check_async\(chat, mid\)\n.*?^        return$', max_lines=14)
+ASYNC = lift(r'^        _acc, _tok = _upd_check_async\(chat, mid\)\n.*?^        return$', max_lines=18)
 INVAL = lift(r'^    _upd_invalidate\(chat, mid\)$')
 CLIP = lift(r'^    return line if len\(line\) <= UPD_LINE_MAX else line\[:UPD_LINE_MAX - 1\] \+ "…"$')
 # ── 本轮新增的六条承重性质 ────────────────────────────────────────────────────
@@ -67,16 +67,43 @@ REAPER = lift(r'^                if now >= sess\["deadline"\] - UPD_DELIVER_BUDG
 CANCEL = lift(r'^                if not sess or sess\.get\("job"\) != job or sess\.get\("cancelled"\):$')
 DROPJOB = lift(r'^    if sess is not None and sess\.get\("job"\) == job:\n        _upd_sess\.pop\(\(chat, mid\), None\)$')
 NOTICE = lift(r'^            job = _upd_new_sess\(chat, mid, now \+ UPD_NOTICE_BUDGET, kind="notice"\)\n            return ACCEPT_FULL, job$')
-NOTEMERGE = lift(r'^    if had:\n        return$')
+# 合并点本轮从"只看待发"改成"待发或在飞", 锚点跟着挪。
+NOTEMERGE = lift(r'^        if key in _upd_notify_pending or key in _upd_notify_live:$')
 INTENTVER = lift(r'^        ver, intent, last = _intent_now\(chat, mid\)$')
 PHASE = lift(r'^            if sess\.get\("phase", 0\) >= want:\n                return False, "stale-phase"$')
 # 忙/拒绝反馈现在一律经通道(notice 阶段), 锚点跟着挪。
-NOTIFY_TOK = lift(r'^            _upd_emit\(chat, mid, tok, "notice", txt, BACK\)$')
+NOTIFY_TOK = lift(r'^                        _upd_emit\(chat, mid, tok, "notice", txt, BACK\)$')
 ADMIT = lift(r'^        if len\(_upd_inflight\) >= UPD_MAX_INFLIGHT:$')
 SHALLOW = lift(r'^    if shallow\.returncode != 0 or _sv not in \("true", "false"\):\n.*?shallow\.returncode$')
 SLUGCAP = lift(r'^        cap = 5 if deadline is None else min\(5, max\(0\.0, deadline - time\.monotonic\(\)\)\)$')
 # 补绘已改成按用户意图版本收敛, 锚点指到它的调用点。
 REPAINT = lift(r'^        if need_repaint and delivered:\n            _upd_repaint\(chat, mid, dl\)$')
+
+# ── 本轮(绝对期限 / 撤销权限 / 通知生命周期)的锚点 ─────────────────────────────
+REUSETO = lift(r'^                conn\.timeout = _to\n'
+               r'                if conn\.sock is not None:\n'
+               r'                    conn\.sock\.settimeout\(_to\)$')
+READDL = lift(r'^        if deadline is not None:\n'
+              r'            if time\.monotonic\(\) >= deadline:\n'
+              r'                raise _ApiDeadline\(\)$')
+# 空 token 有两道拦截(入口快速判 + 取到投递锁后复查)。单撤一道另一道仍拦得住 ——
+# 要撤就两道一起撤, 否则这一格没牙。
+EMITNULL = lift(r'^    if token is None:$')
+EMITNULL2 = lift(r'^            if not sess or sess\.get\("token"\) is None or sess\.get\("token"\) != token:$')
+REVOKED = lift(r'^                if sess\.get\("token"\) is None:$')
+REAPMINE = lift(r'^                mine = cur is not None and cur\.get\("job"\) == job$')
+REAPREVOKE = lift(r'^                if mine and not revoked:$')
+NOTICEREL = lift(r'^    cur = _upd_sess\.get\(\(chat, mid\)\)\n'
+                 r'    if cur is not None and cur\.get\("job"\) == job:\n'
+                 r'        if cur\.get\("kind"\) == "notice":\n'
+                 r'            _upd_drop_sess\(chat, mid, job\)$')
+NOTICEKIND = lift(r'^        if cur\.get\("kind"\) == "notice":\n'
+                  r'            _upd_drop_sess\(chat, mid, job\)$')
+NOTICECAP = lift(r'^        if len\(_upd_notify_live\) >= UPD_NOTICE_MAX:$')
+READCLOSE = lift(r'^    resp\.close\(\)\n    return bytes\(buf\)$')
+SESSOLD = lift(r'^    old = _upd_sess\.get\(\(chat, mid\)\)\n'
+               r'    if old is not None:\n'
+               r'        _upd_jobs\.pop\(old\.get\("job"\), None\)$')
 KILLPG = lift(r'^        try:\n            os\.killpg\(os\.getpgid\(p\.pid\), signal\.SIGKILL\)\n.*?p\.kill\(\)$')
 
 MUT = [
@@ -108,7 +135,7 @@ MUT = [
     ("⑧ 取消阶段序(低阶段可以盖掉已落地的高阶段)",
      [(PHASE, '            if False:\n                return False, "stale-phase"', 1)]),
     ("⑨ 忙反馈绕过通道(退化成裸 edit_only)",
-     [(NOTIFY_TOK, '            edit_only(chat, mid, txt, BACK)', 1)]),
+     [(NOTIFY_TOK, '                        edit_only(chat, mid, txt, BACK)', 1)]),
     ("⑩ 取消全局准入上限(线程有限≠队列有界)",
      [(ADMIT, '        if False:', 1)]),
     ("⑪ shallow 探测不校验退出码/取值",
@@ -131,9 +158,37 @@ MUT = [
     ("⑳ 拒绝通知不再建归属(裸通知, 不可作废)",
      [(NOTICE, '            return ACCEPT_FULL, None', 1)]),
     ("㉑ 通知不合并(每次点击都排一份新工作)",
-     [(NOTEMERGE, '    if False:\n        return', 1)]),
+     [(NOTEMERGE, '        if False:', 1)]),
     ("㉒ 补绘回到猜「最近一次写入」而非最新意图",
      [(INTENTVER, '        ver, intent, last = (0, None, None)', 1)]),
+    # ── A: 绝对期限贯穿真实请求 ──
+    ("㉔ 复用的连接不按剩余预算重设超时(缓存超时)",
+     [(REUSETO, '                pass', 1)]),
+    ("㉕ 读响应不再核对绝对期限(只在请求前查一次)",
+     [(READDL, '        if False:\n            if False:\n                raise _ApiDeadline()', 1)]),
+    ("㉟ 按块读之后不收尾(keep-alive 名存实亡, 每次都白重连一次)",
+     [(READCLOSE, '    return bytes(buf)', 1)]),
+    # ── B: 撤销即撤销 ──
+    ("㉖ 空 token 重新被当成写回权(两道拦截一起撤: None == None 放行)",
+     [(EMITNULL, '    if False:', 1),
+      (EMITNULL2, '            if not sess or sess.get("token") != token:', 1)]),
+    ("㉗ 排队期间被撤销的任务照样执行",
+     [(REVOKED, '                if False:', 1)]),
+    ("㉘ 过期处理靠新建通知恢复写回权(不看撤销事实)",
+     [(REAPREVOKE, '                if mine:', 1)]),
+    ("㉙ 收割器动作前不重新核对身份(会覆盖后来的新任务)",
+     [(REAPMINE, '                mine = True', 1)]),
+    # ── C: 通知生命周期与全局准入 ──
+    ("㉚ 通知投递完不释放自己的记录",
+     [(NOTICEREL, '    cur = None\n    if cur is not None and cur.get("job") == job:\n'
+                  '        if cur.get("kind") == "notice":\n'
+                  '            _upd_drop_sess(chat, mid, job)', 1)]),
+    ("㉛ 通知收尾不看 kind(忙提示把在跑的检查会话一起收掉)",
+     [(NOTICEKIND, '        if True:\n            _upd_drop_sess(chat, mid, job)', 1)]),
+    ("㉜ 通知排队没有全局上限(只限执行线程数)",
+     [(NOTICECAP, '        if False:', 1)]),
+    ("㉝ 替换会话不摘旧身份(_upd_jobs 单调增长)",
+     [(SESSOLD, '    old = None', 1)]),
     ("㉓ 只加无关注释(反向对照)",
      [(INVAL, '    # (负控的空转对照)\n' + INVAL, 1)]),
 ]

--- a/tests/negctl/bot-update-check-negative-controls.py
+++ b/tests/negctl/bot-update-check-negative-controls.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""负控: Bot 更新检查这几条判据有没有牙。
+
+正控在 tests/test-bot-update-check.py。这里逐项把修复撤回去, 看正控会不会红。
+撤回的都是**用户实际遇到过的那三个形态**: 整段 log 拼进消息、异常只包前半段、同步占主轮询。
+
+夹具崩溃 / 导入失败 / 零断言 / 正控被超时强杀, 一律**不算检出** —— 那和"判据没牙"长得一样,
+必须分开。
+"""
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tmpguard          # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+BOT = "deploy/bot/pdg-bot.py"
+POS = "tests/test-bot-update-check.py"
+TOUCHED = [ROOT / BOT, ROOT / POS]
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+def sha(p):
+    return hashlib.sha256(Path(p).read_bytes()).hexdigest()
+
+
+SRC = (ROOT / BOT).read_text(encoding="utf-8")
+
+
+def lift(pattern, max_lines=24, flags=re.M | re.S):
+    m = re.search(pattern, SRC, flags)
+    assert m, pattern
+    g = m.group(0)
+    assert SRC.count(g) == 1, pattern
+    n = g.count("\n") + 1
+    assert n <= max_lines, "锚点跨度 %d 行 > %d: %s" % (n, max_lines, pattern)
+    return g
+
+
+RENDER = lift(r'^        return True, _upd_render\(cur, tgt, lines, _upd_repo_slug\(\)\)$')
+TRY = lift(r'^    except _UpdCheckTimeout:\n.*?稍后重试。" % type\(e\)\.__name__$')
+ASYNC = lift(r'^        if not _upd_check_async\(chat, mid\):\n.*?结果会更新到这条消息\)", BACK\); return$')
+INVAL = lift(r'^    _upd_invalidate\(chat, mid\)$')
+CLIP = lift(r'^    return line if len\(line\) <= UPD_LINE_MAX else line\[:UPD_LINE_MAX - 1\] \+ "…"$')
+KILLPG = lift(r'^        try:\n            os\.killpg\(os\.getpgid\(p\.pid\), signal\.SIGKILL\)\n.*?p\.kill\(\)$')
+
+MUT = [
+    ("① 整段 log 拼回一条消息(不做长度预算)",
+     [(RENDER,
+       '        return True, ("🔄 有新发布 <b>%s</b>(当前 <code>%s</code>,含 %d 个提交):\\n"\n'
+       '                      "<pre>%s</pre>\\n确认后后台执行 pdg update。"\n'
+       '                      % (_esc(tgt), _esc(cur), len(lines), _esc("\\n".join(lines))))', 1)]),
+    ("② 后半段异常不再兜底(恢复只包前半段)",
+     [(TRY,
+       '    except _UpdCheckTimeout:\n'
+       '        raise\n'
+       '    except subprocess.TimeoutExpired:\n'
+       '        raise', 1)]),
+    ("③ 回调恢复同步调用(占住主轮询)",
+     [(ASYNC,
+       '        edit(chat, mid, "🔄 检查更新中…", BACK)\n'
+       '        has, txt = update_check()\n'
+       '        edit(chat, mid, txt, UPD_CONFIRM_KB if has else BACK); return', 1)]),
+    ("④ 取消归属作废(旧结果会覆盖新页面)",
+     [(INVAL, '    pass  # 变异: 不再作废在飞的检查', 1)]),
+    ("⑤ 单条标题不再裁剪(超长标题撑爆消息)",
+     [(CLIP, '    return line', 1)]),
+    ("⑥ 超时只杀父进程(留下 git 派生的助手)",
+     [(KILLPG, '        try:\n            p.kill()\n        except Exception:  # noqa: BLE001\n            p.kill()', 1)]),
+    ("⑦ 只加无关注释(反向对照)",
+     [(INVAL, '    # (负控的空转对照)\n' + INVAL, 1)]),
+]
+
+before = {p: sha(p) for p in TOUCHED}
+modes = {p: os.stat(p).st_mode for p in TOUCHED}
+wd = tmpguard.mkdtemp(prefix="pdg-updcheck-negctl.")
+shutil.rmtree(wd)          # git clone 要目标不存在
+try:
+    # 沙箱要有**真实的 git 历史与 tag**(正控要按 v1.11.3/v1.11.10 回放), 所以先 clone 一份 ——
+    # worktree 里的 .git 是文件不是目录, 直接 copytree 会炸。clone 之后再把**当前工作树**的
+    # tests/ deploy/ lib/ 覆盖上去, 于是历史是真的、被测代码是现在这一版。
+    # 只读本地对象, 不写共享 refs/tag/remote。
+    subprocess.run(["git", "clone", "-q", "--no-hardlinks", str(ROOT), wd], check=True,
+                   env={**os.environ, "GIT_TERMINAL_PROMPT": "0"})
+    subprocess.run(["git", "-C", wd, "fetch", "-q", "--tags", "origin"], check=False)
+    for sub in ("tests", "deploy", "lib"):
+        shutil.copytree(ROOT / sub, Path(wd) / sub, dirs_exist_ok=True, symlinks=True,
+                        ignore=shutil.ignore_patterns("__pycache__", ".bin"))
+    pristine = (Path(wd) / BOT).read_text(encoding="utf-8")
+
+    def run_pos():
+        """跑一次正控, 返回 (具名失败集合, 形态)。形态用来把「没牙」和「压根没跑起来」分开。"""
+        try:
+            r = subprocess.run([sys.executable, POS], cwd=wd, capture_output=True,
+                               text=True, timeout=900, errors="replace")
+        except subprocess.TimeoutExpired:
+            return set(), "正控被超时强杀"
+        out = r.stdout + r.stderr
+        n_ok = len(re.findall(r"^\[OK\]", out, re.M))
+        n_fail = len(re.findall(r"^\[FAIL\]", out, re.M))
+        if "Traceback (most recent call last)" in out:
+            return set(), "崩溃(Traceback)"
+        if "ModuleNotFoundError" in out or "ImportError" in out:
+            return set(), "导入失败"
+        if n_ok + n_fail == 0:
+            return set(), "零有效断言"
+        if "通过 " not in out:
+            return set(), "没有汇总行"
+        fails = {re.sub(r"\s+", " ", l.strip())[:150]
+                 for l in out.splitlines() if l.startswith("[FAIL]")}
+        return fails, "正常"
+
+    base, kind = run_pos()
+    if kind != "正常":
+        bad("基线正控没有正常运行(%s) —— 后面每一格都算不出「新增」" % kind)
+        raise SystemExit(1)
+    if base:
+        bad("基线正控不绿(%d 条)" % len(base))
+        for f in sorted(base)[:4]:
+            print("       " + f[:140])
+        raise SystemExit(1)
+    ok("基线绿: 正控在未改坏的副本上 0 条具名失败")
+
+    for tag, edits in MUT:
+        text, good = pristine, True
+        for anchor, repl, want in edits:
+            hits = text.count(anchor)
+            if hits != want:
+                bad("%s → 锚点命中 %d 次, 期望 %d" % (tag, hits, want))
+                good = False
+                break
+            after = text.replace(anchor, repl, want)
+            if after == text:
+                bad("%s → 改坏器空转" % tag)
+                good = False
+                break
+            text = after
+        if not good:
+            continue
+        (Path(wd) / BOT).write_text(text, encoding="utf-8")
+        if subprocess.run([sys.executable, "-m", "py_compile", str(Path(wd) / BOT)],
+                          capture_output=True).returncode != 0:
+            bad("%s → 改坏后语法不合法" % tag)
+            (Path(wd) / BOT).write_text(pristine, encoding="utf-8")
+            continue
+        got, kind = run_pos()
+        (Path(wd) / BOT).write_text(pristine, encoding="utf-8")
+        if kind != "正常":
+            bad("%s → 正控没有正常运行(%s), 这一格既不算有牙也不算无牙" % (tag, kind))
+            continue
+        new = got - base
+        if tag.startswith("⑦"):
+            (ok if not new else bad)("%s → %d 条新增(应为 0)" % (tag, len(new)))
+            continue
+        if new:
+            ok("%s → 新增具名失败 %d 条" % (tag, len(new)))
+            for f in sorted(new)[:2]:
+                print("       " + f[:135])
+        else:
+            bad("%s → 正控正常运行但 0 条转红, 这一格无效" % tag)
+finally:
+    shutil.rmtree(wd, ignore_errors=True)
+
+clean = all(sha(p) == before[p] and os.stat(p).st_mode == modes[p] for p in TOUCHED)
+(ok if clean else bad)("正式树未被污染: pdg-bot.py 与正控 sha256/mode 均一致"
+                       if clean else "正式树被改动了!")
+print("-" * 62)
+print("bot-update-check-negative-controls.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-bot-nav.py
+++ b/tests/test-bot-nav.py
@@ -63,16 +63,25 @@ assert_near('if data == "test":', 'edit(chat, mid, "测试中…", BACK)', (
 assert 'edit(chat, mid, "测试中…", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
-# 检查改成后台执行之后, 这条"进行中"文案多了一句"结果会更新到这条消息" —— 结果是异步回填的,
-# 得告诉用户去哪儿看。断言的性质一个字没松: 仍然要求它挂 BACK 而不是整排一级菜单。
-assert_near('if data == "upd_check":',
-            'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", BACK)', (
+# 进度消息现在由后台任务经 _upd_emit 发出(回调里一次网络调用都不做), 所以断言指到它**现在
+# 的产生点**。要守的性质一个字没松: 仍然要求它挂 BACK 而不是整排一级菜单; 忙/未受理这类
+# 反馈同样如此。
+assert_near('def _upd_check_async(chat, mid):',
+            '_upd_emit(chat, mid, token, "progress",\n'
+            '                      "🔄 检查更新中…(结果会更新到这条消息)", BACK)', (
                 "update-check progress message should show only a back button, "
                 "not the full first-level menu"
-            ))
+            ), window=2600)
 assert 'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
+assert_near('def _upd_notify_async(', '_upd_emit(chat, mid, token, "busy", text, BACK)', (
+    "update-check busy/rejection feedback should also show only a back button"
+), window=1400)
+assert_near('if data == "upd_check":', "_upd_notify_async(chat, mid,", (
+    "update-check callback must route its feedback through the async notifier, "
+    "not edit inline on the polling thread"
+), window=1400)
 none_progress_edits = re.findall(r"edit\(chat, mid, [^\n]+, None\)", bot)
 assert not none_progress_edits, (
     "progress/result edits must pass an explicit keyboard; None falls back to the full first-level MENU: "

--- a/tests/test-bot-nav.py
+++ b/tests/test-bot-nav.py
@@ -67,7 +67,7 @@ assert 'edit(chat, mid, "测试中…", None)' not in bot, (
 # 的产生点**。要守的性质一个字没松: 仍然要求它挂 BACK 而不是整排一级菜单; 忙/未受理这类
 # 反馈同样如此。
 assert_near('def _upd_check_async(chat, mid):',
-            '_upd_emit(chat, mid, token, "progress",\n'
+            '_upd_emit(chat, mid, tok, "progress",\n'
             '                      "🔄 检查更新中…(结果会更新到这条消息)", BACK)', (
                 "update-check progress message should show only a back button, "
                 "not the full first-level menu"
@@ -75,10 +75,10 @@ assert_near('def _upd_check_async(chat, mid):',
 assert 'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
-assert_near('def _upd_notify_async(', '_upd_emit(chat, mid, token, "busy", text, BACK)', (
+assert_near('def _upd_notify(', '_upd_emit(chat, mid, tok, "notice", txt, BACK)', (
     "update-check busy/rejection feedback should also show only a back button"
 ), window=1400)
-assert_near('if data == "upd_check":', "_upd_notify_async(chat, mid,", (
+assert_near('if data == "upd_check":', "_upd_notify(chat, mid, _msg, _tok,", (
     "update-check callback must route its feedback through the async notifier, "
     "not edit inline on the polling thread"
 ), window=1400)

--- a/tests/test-bot-nav.py
+++ b/tests/test-bot-nav.py
@@ -63,10 +63,14 @@ assert_near('if data == "test":', 'edit(chat, mid, "测试中…", BACK)', (
 assert 'edit(chat, mid, "测试中…", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
-assert_near('if data == "upd_check":', 'edit(chat, mid, "🔄 检查更新中…", BACK)', (
-    "update-check progress message should show only a back button, not the full first-level menu"
-))
-assert 'edit(chat, mid, "🔄 检查更新中…", None)' not in bot, (
+# 检查改成后台执行之后, 这条"进行中"文案多了一句"结果会更新到这条消息" —— 结果是异步回填的,
+# 得告诉用户去哪儿看。断言的性质一个字没松: 仍然要求它挂 BACK 而不是整排一级菜单。
+assert_near('if data == "upd_check":',
+            'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", BACK)', (
+                "update-check progress message should show only a back button, "
+                "not the full first-level menu"
+            ))
+assert 'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
 none_progress_edits = re.findall(r"edit\(chat, mid, [^\n]+, None\)", bot)

--- a/tests/test-bot-nav.py
+++ b/tests/test-bot-nav.py
@@ -75,9 +75,11 @@ assert_near('def _upd_check_async(chat, mid):',
 assert 'edit(chat, mid, "🔄 检查更新中…(结果会更新到这条消息)", None)' not in bot, (
     "passing None to edit() falls back to the full first-level MENU"
 )
+# 窗口只跟着 _upd_notify 的文档串变长而放宽; 断言的性质一字未动 ——
+# 反馈仍必须经 _upd_emit 且挂 BACK, 不是整排一级菜单。
 assert_near('def _upd_notify(', '_upd_emit(chat, mid, tok, "notice", txt, BACK)', (
     "update-check busy/rejection feedback should also show only a back button"
-), window=1400)
+), window=2600)
 assert_near('if data == "upd_check":', "_upd_notify(chat, mid, _msg, _tok,", (
     "update-check callback must route its feedback through the async notifier, "
     "not edit inline on the polling thread"

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -54,6 +54,7 @@ bot.PDG_REPO = REPO
 _REAL_GIT = bot._git
 _REAL_UPDATE_CHECK = bot.update_check      # 后面几节会拿桩替换它, 用完要还回来
 _REAL_FETCH_TAGS = bot._fetch_release_tags
+_REAL_POST = bot.post                      # §14 要用**真实** post(带重连), 不能是假件
 
 
 def at(rev):
@@ -75,7 +76,7 @@ class Tg:
         self.unreachable = False    # 完全不可达
         self.delay = 0.0
 
-    def post(self, method, params):
+    def post(self, method, params, deadline=None):
         if self.delay:
             time.sleep(self.delay)
         with self.lock:
@@ -272,6 +273,8 @@ gate2.set(); time.sleep(0.6)
 (ok if not any(m == "sendMessage" and "旧结果 B" in p.get("text", "")
                for m, p in tg.calls) else bad)("也不补发新消息把旧结果推回来")
 (ok if 303 not in bot._upd_inflight else bad)("作废后占用仍被释放")
+(ok if (303, 33) not in bot._upd_sess else
+ bad)("作废写入权后**仍有清理资格**: 会话记录也被清掉(残留 %r)" % (list(bot._upd_sess),))
 
 print()
 print("══ 6. 消息编辑失败 / 发送失败 / API 不可达: 回退有界, 占用能释放 ══")
@@ -452,8 +455,8 @@ tg = Tg(); with_tg(tg)
 _real_submit = bot._EXEC.submit
 bot._EXEC.submit = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("closed"))
 _v, _tk = bot._upd_check_async(910, 91)
-(ok if _v == bot.ACCEPT_SUBMIT_FAIL and _tk is None else
- bad)("提交失败返回 SUBMIT_FAIL 而不是 BUSY(实得 %r)" % (_v,))
+(ok if _v == bot.ACCEPT_SUBMIT_FAIL and _tk else
+ bad)("提交失败返回 SUBMIT_FAIL(且带可作废的通知归属; 实得 %r/%s)" % (_v, bool(_tk)))
 (ok if 910 not in bot._upd_inflight else bad)("提交失败后占用不残留")
 bot.handle_cb(910, 91, "upd_check")     # 仍在"提交必失败"状态下走真实回调
 time.sleep(0.5)
@@ -513,7 +516,7 @@ class GateTg:
         self.gates = {}
         self.waiters = {}          # 哪一条已经**进到网络调用里**被闸挡住了
 
-    def post(self, method, params):
+    def post(self, method, params, deadline=None):
         txt = params.get("text") or ""
         for k, g in list(self.gates.items()):
             if k in txt:
@@ -648,6 +651,276 @@ _s = gt.seq()
  bad)("13c 导航抢写后收敛回新页面(实得 %r)" % (_s,))
 (ok if any("旧结果C" in x for x in _s) else
  bad)("13c 如实记录: 旧结果那一次请求确实到达过, 收敛不是撤回(实得 %r)" % (_s,))
+
+print()
+print("══ 14. 投递时限: 在**连接层**注入故障, 保留真实 post 重连与 edit_only 回退 ══")
+# 这一节**不替换 post** —— 替换掉它就等于没验投递路径。故障注入在 HTTPSConnection 上,
+# 于是 post 的重连、edit_only 的两段回退、以及新加的 deadline 全都真的跑到。
+# 用受控时钟量"模拟时间", 与墙钟分开记。
+
+
+class _Clock:
+    def __init__(self):
+        self.t = 10000.0
+        self.lock = threading.Lock()
+
+    def mono(self):
+        with self.lock:
+            return self.t
+
+    def advance(self, d):
+        with self.lock:
+            self.t += d
+
+
+class _DeadConn:
+    """每次 request 都走满 socket timeout 再失败 —— 模拟不可达。"""
+    tries = []
+
+    def __init__(self, host, timeout=None):
+        self.timeout = timeout
+
+    def request(self, *a, **k):
+        _DeadConn.tries.append(self.timeout)
+        _CK.advance(self.timeout or 0)
+        raise OSError("unreachable")
+
+    def getresponse(self):
+        raise OSError("unreachable")
+
+    def close(self):
+        pass
+
+
+_CK = _Clock()
+_real_conn_cls = bot.http.client.HTTPSConnection
+_real_mono = time.monotonic
+_post_calls = [0]
+
+
+def _counting_post(method, params, deadline=None):
+    """**包装**真实 post(不替换它): 数调用次数, 内部仍走真实重连与 deadline 逻辑。"""
+    _post_calls[0] += 1
+    return _REAL_POST(method, params, deadline)
+
+
+bot.post = _counting_post                  # 关键: 内部仍是真实 post, 只在连接层注入故障
+bot.http.client.HTTPSConnection = _DeadConn
+bot.time.monotonic = _CK.mono
+_DeadConn.tries = []
+bot._tls.conn = None
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear()
+_emits = [0]
+_real_emit = bot._upd_emit
+
+
+def _counting_emit(chat, mid, token, phase, text, kb):
+    _emits[0] += 1
+    return _real_emit(chat, mid, token, phase, text, kb)
+
+
+bot._upd_emit = _counting_emit
+bot.update_check = lambda budget=None: (True, "🔄 终态14")
+_sim0 = _CK.mono()
+_wall0 = _real_mono()
+bot.handle_cb(1401, 141, "upd_check")
+while 1401 in bot._upd_inflight and _real_mono() - _wall0 < 60:
+    time.sleep(0.02)
+bot._upd_emit = _real_emit
+_sim = _CK.mono() - _sim0
+_wall = _real_mono() - _wall0
+bot.http.client.HTTPSConnection = _real_conn_cls
+bot.time.monotonic = _real_mono
+bot._tls.conn = None
+(ok if bot.post is _counting_post else bad)("14 走的是包装后的真实 post(未被假件替换)")
+bot.post = _REAL_POST
+(ok if _post_calls[0] < 2 * max(1, _emits[0]) else
+ bad)("14 期限到了 edit_only 不再回退重试: post 调用 %d 次 < emit %d × 2"
+      % (_post_calls[0], _emits[0]))
+print("       post 调用 %d 次" % _post_calls[0])
+print("       emit %d 次 / 传输尝试 %d 次 / 模拟耗时 %.0fs / 实测墙钟 %.2fs"
+      % (_emits[0], len(_DeadConn.tries), _sim, _wall))
+(ok if _sim <= bot.UPD_CHECK_BUDGET else
+ bad)("投递受期限约束: 模拟耗时 %.0fs ≤ 总预算 %.0fs" % (_sim, bot.UPD_CHECK_BUDGET))
+(ok if len(_DeadConn.tries) < 2 * max(1, _emits[0]) else
+ bad)("期限到了就不再回退重试: 传输 %d 次 < emit %d × 2(否则说明 edit_only 仍走满回退)"
+      % (len(_DeadConn.tries), _emits[0]))
+(ok if any(t is not None and t < bot.API_TIMEOUT for t in _DeadConn.tries) else
+ bad)("至少一次传输的 socket 超时被期限压小(实得 %r)" % (_DeadConn.tries,))
+(ok if 1401 not in bot._upd_inflight and (1401, 141) not in bot._upd_sess else
+ bad)("不可达之后两张表都清理")
+
+print()
+print("══ 15. 排队过期: 先占满 worker, 再受理, 推进时间, 核对裁决 ══")
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear()
+tg = Tg(); with_tg(tg)
+_hold = threading.Event()
+for _ in range(bot._EXEC._max_workers):
+    bot._EXEC.submit(lambda: _hold.wait(40))
+time.sleep(0.4)
+(ok if all(w for w in [True]) else bad)("worker 已被占满(提交了 %d 个阻塞任务)" % bot._EXEC._max_workers)
+_gitcalls = []
+bot.update_check = lambda budget=None: (_gitcalls.append(1), (True, "x"))[1]
+_CK2 = _Clock()
+bot.time.monotonic = _CK2.mono
+_v, _t = bot._upd_check_async(1501, 151)
+(ok if _v == bot.ACCEPT_OK and 1501 in bot._upd_inflight else
+ bad)("worker 满时仍先受理并占名额(实得 %r)" % (_v,))
+_CK2.advance(bot.UPD_CHECK_BUDGET - bot.UPD_DELIVER_BUDGET + 1)
+time.sleep(bot.UPD_REAP_TICK * 3)
+(ok if 1501 not in bot._upd_inflight else
+ bad)("排队过期被裁决并释放名额(不等空闲 worker; 在飞 %r)" % (list(bot._upd_inflight),))
+_hold.set()
+time.sleep(1.2)
+(ok if not _gitcalls else
+ bad)("迟到启动的旧任务不再执行检查/Git(实得 %d 次)" % len(_gitcalls))
+_texts = tg.texts("editMessageText")
+(ok if any("排队过久" in t for t in _texts) else
+ bad)("排队过期有终态说明(实得 %r)" % (_texts[-2:],))
+bot.time.monotonic = _real_mono
+
+print()
+print("══ 16. 补绘期间第二次导航: 最后页面必须对应最新动作 ══")
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear()
+gt = GateTg(); bot.post = gt.post
+_rel = threading.Event()
+bot.update_check = lambda budget=None: (_rel.wait(15), (True, "🔄 旧结果F"))[1]
+bot.handle_cb(1601, 161, "upd_check"); time.sleep(0.3)
+gt.gates["旧结果F"] = threading.Event()
+_rel.set()
+(ok if _wait_gate(gt, "旧结果F") else bad)("16 旧结果已进入网络调用(窗口成立)")
+_rs = bot.status_text
+bot.status_text = lambda: "（菜单A）"
+try:
+    bot.handle_cb(1601, 161, "menu")
+finally:
+    bot.status_text = _rs
+gt.gates["菜单A"] = threading.Event()      # 卡住补绘 A
+gt.gates["旧结果F"].set()
+_wait_gate(gt, "菜单A")
+bot.status_text = lambda: "（菜单B）"       # 用户又翻到 B
+try:
+    bot.handle_cb(1601, 161, "menu")
+finally:
+    bot.status_text = _rs
+time.sleep(0.2)
+gt.gates["菜单A"].set()
+_settle(1601); _quiesce(gt, limit=12)
+_s = gt.seq()
+(ok if _s and "菜单B" in _s[-1] else
+ bad)("16 补绘服从最新意图, 最后页面是 B(实得 %r)" % (_s,))
+
+print()
+print("══ 17. 取消资格 / 拒绝通知归属 / 通知合并 ══")
+# 17a 被标记 cancelled 的排队任务, 即使 worker 后来空出来也不得执行检查
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear()
+tg = Tg(); with_tg(tg)
+_hold = threading.Event()
+for _ in range(bot._EXEC._max_workers):
+    bot._EXEC.submit(lambda: _hold.wait(30))
+time.sleep(0.4)
+_calls = []
+bot.update_check = lambda budget=None: (_calls.append(1), (True, "x"))[1]
+_v, _t = bot._upd_check_async(1701, 171)
+(ok if _v == bot.ACCEPT_OK else bad)("17a 已受理并排队(实得 %r)" % (_v,))
+with bot._upd_lock:                      # 模拟收割线程刚标记、还没来得及丢弃会话的那个窗口
+    bot._upd_sess[(1701, 171)]["cancelled"] = True
+_hold.set()
+_t0 = time.monotonic()
+while 1701 in bot._upd_inflight and time.monotonic() - _t0 < 15:
+    time.sleep(0.05)
+(ok if not _calls else
+ bad)("17a 已取消资格的任务即使拿到 worker 也不执行检查(实得 %d 次)" % len(_calls))
+(ok if not any("检查更新中" in t for t in tg.texts()) else
+ bad)("17a 已取消资格的任务不发进度(实得 %r)" % (tg.texts(),))
+
+# 17b 拒绝通知必须有可作废的归属
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear()
+bot.update_check = lambda budget=None: (True, "x")
+_held = threading.Event()
+bot.update_check = lambda budget=None: (_held.wait(20), (True, "x"))[1]
+for _c in range(1710, 1710 + bot.UPD_MAX_INFLIGHT):
+    bot._upd_check_async(_c, _c)
+_v, _t = bot._upd_check_async(1799, 179)
+(ok if _v == bot.ACCEPT_FULL and _t else
+ bad)("17b 超出上限得到 FULL 且带归属(实得 %r/%s)" % (_v, bool(_t)))
+_sess = bot._upd_sess.get((1799, 179))
+(ok if _sess and _sess.get("kind") == "notice" else
+ bad)("17b 拒绝通知有自己的会话记录(kind=%r)" % ((_sess or {}).get("kind"),))
+(ok if _sess and _sess.get("deadline") else bad)("17b 拒绝通知带期限")
+bot._upd_invalidate(1799, 179)
+(ok if bot._upd_sess.get((1799, 179), {}).get("token") is None else
+ bad)("17b 拒绝通知可被导航作废")
+tg = Tg(); with_tg(tg)
+bot._upd_notify(1799, 179, "迟到的拒绝通知", _t, time.monotonic() + 10)
+time.sleep(0.5)
+(ok if not any("迟到的拒绝通知" in t for t in tg.texts()) else
+ bad)("17b 作废之后迟到的拒绝通知不再写入(实得 %r)" % (tg.texts(),))
+_held.set()
+_t0 = time.monotonic()
+while bot._upd_inflight and time.monotonic() - _t0 < 15:
+    time.sleep(0.05)
+
+# 17c 连点不新开工作: 待发表按消息合并
+with bot._upd_lock:
+    bot._upd_inflight.clear(); bot._upd_sess.clear(); bot._upd_notify_pending.clear()
+_gate = threading.Event()
+_seen_note = [0]
+_lk = threading.Lock()
+
+
+class _SlowTg(Tg):
+    def post(self, method, params, deadline=None):
+        t = params.get("text") or ""
+        if "还在跑" in t:
+            with _lk:
+                _seen_note[0] += 1
+            _gate.wait(10)
+        return Tg.post(self, method, params, deadline)
+
+
+tg = _SlowTg(); with_tg(tg)
+_submits = [0]
+_real_note_submit = bot._upd_notify_exec.submit
+
+
+def _counting_submit(fn, *a, **k):
+    _submits[0] += 1
+    return _real_note_submit(fn, *a, **k)
+
+
+bot._upd_notify_exec.submit = _counting_submit
+_hold2 = threading.Event()
+bot.update_check = lambda budget=None: (_hold2.wait(25), (True, "终态17c"))[1]
+bot._upd_check_async(1720, 172)
+time.sleep(0.2)
+_base_threads = threading.active_count()
+_peak_pending = 0
+for _ in range(20):
+    bot.handle_cb(1720, 172, "upd_check")
+    _peak_pending = max(_peak_pending, len(bot._upd_notify_pending))
+time.sleep(0.5)
+_grew = threading.active_count() - _base_threads
+(ok if _peak_pending <= 1 else
+ bad)("17c 待发通知按消息合并(峰值 %d 条, 应 ≤1)" % _peak_pending)
+(ok if _grew <= 2 else
+ bad)("17c 连点 20 次不新开线程(线程 +%d, 应 ≤2)" % _grew)
+(ok if _seen_note[0] <= 1 else
+ bad)("17c 实际发出的忙提示 ≤1 条(实得 %d)" % _seen_note[0])
+(ok if _submits[0] <= 1 else
+ bad)("17c 连点 20 次只给通知执行器排 1 份工作(实得 %d 份)" % _submits[0])
+bot._upd_notify_exec.submit = _real_note_submit
+_gate.set(); _hold2.set()
+_t0 = time.monotonic()
+while 1720 in bot._upd_inflight and time.monotonic() - _t0 < 20:
+    time.sleep(0.05)
+(ok if 1720 not in bot._upd_inflight and not bot._upd_notify_pending else
+ bad)("17c 结束后在飞表与待发表都清空")
 
 print()
 print("-" * 62)

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Bot「🔄 更新」检查的完整链路: 消息长度预算 / 全链路终态 / 后台与归属 / 有界等待与清理。
+
+用户反复遇到「检查更新中…」永不结束。三个根因(都已在隔离环境复现):
+
+  1. **整段 git log 拼进一条消息**。跨度大时超 Telegram 4096 字符上限, editMessageText 与
+     补发都失败 —— 页面就停在"检查更新中…"。实测 v1.11.3→v1.11.14 约 10.6k 字符。
+  2. **异常处理只包到前半段**。`try` 只罩住 fetch/describe/tag,后面的 rev-parse /
+     merge-base / log 超时会直接抛给回调, 回调拿不到终态。
+  3. **同步跑在主 getUpdates 循环里**。fetch 的超时预算是 120s(+unshallow 180s),
+     这段时间整个 bot 不响应任何菜单。
+
+本支不连真实 Telegram、不用真实 token、不访问生产, git 用**克隆到临时目录的隔离仓库**
+(只读本地对象, 不碰共享 refs/tag/remote), 也从不调用真实升级入口。
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import threading
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import tmpguard          # noqa: E402
+
+PASS, FAIL = [0], [0]
+
+
+def ok(m):
+    PASS[0] += 1
+    print("[OK]   %s" % m)
+
+
+def bad(m):
+    FAIL[0] += 1
+    print("[FAIL] %s" % m)
+
+
+os.environ.setdefault("PDG_BOT_TOKEN", "111111:TESTONLY-not-a-real-token")
+os.environ.setdefault("PDG_BOT_ALLOWED", "1")
+_spec = importlib.util.spec_from_file_location(
+    "pdg_bot_updcheck", os.path.join(ROOT, "deploy/bot/pdg-bot.py"))
+bot = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bot)
+
+TG_LIMIT = 4096                      # Telegram 文本硬上限
+WD = tmpguard.mkdtemp(prefix="pdg-updcheck.")
+REPO = os.path.join(WD, "repo")
+subprocess.run(["git", "clone", "-q", "--no-hardlinks", ROOT, REPO], check=True,
+               env={**os.environ, "GIT_TERMINAL_PROMPT": "0"})
+subprocess.run(["git", "-C", REPO, "fetch", "-q", "--tags", "origin"], check=False)
+bot.PDG_REPO = REPO
+_REAL_GIT = bot._git
+_REAL_UPDATE_CHECK = bot.update_check      # 后面几节会拿桩替换它, 用完要还回来
+
+
+def at(rev):
+    return subprocess.run(["git", "-C", REPO, "checkout", "-q", "--detach", rev]).returncode == 0
+
+
+def no_fetch():
+    bot._fetch_release_tags = lambda deadline=None: (True, "")
+
+
+# ── 假 Telegram 接收端: 校验长度与形态, 不是一律返回成功 ────────────────────────
+class Tg:
+    """记录每一次 API 调用; 超长/HTML 形态不对就像真 API 一样返回 ok=False。"""
+
+    def __init__(self):
+        self.calls = []
+        self.lock = threading.Lock()
+        self.fail_edit = 0          # 前 N 次 editMessageText 强制失败
+        self.unreachable = False    # 完全不可达
+        self.delay = 0.0
+
+    def post(self, method, params):
+        if self.delay:
+            time.sleep(self.delay)
+        with self.lock:
+            self.calls.append((method, dict(params)))
+            if self.unreachable:
+                return {}
+            if method in ("editMessageText", "sendMessage"):
+                text = params.get("text", "")
+                if len(text) > TG_LIMIT:
+                    return {"ok": False, "error_code": 400,
+                            "description": "Bad Request: message is too long"}
+                if params.get("parse_mode") == "HTML" and text.count("<") != text.count(">"):
+                    return {"ok": False, "error_code": 400,
+                            "description": "Bad Request: can't parse entities"}
+                if method == "editMessageText" and self.fail_edit > 0:
+                    self.fail_edit -= 1
+                    return {"ok": False, "error_code": 400,
+                            "description": "Bad Request: message to edit not found"}
+                return {"ok": True, "result": {"message_id": params.get("message_id", 1)}}
+            return {"ok": True, "result": {}}
+
+    def texts(self, method=None):
+        with self.lock:
+            return [p.get("text", "") for m, p in self.calls if method in (None, m)]
+
+
+def with_tg(tg):
+    bot.post = tg.post
+
+
+print("══ 1. 消息长度预算: 大跨度 / 无更新 / 小跨度 / 单条超长标题 ══")
+no_fetch()
+for base, want_has in (("v1.11.3", True), ("v1.11.10", True), ("v1.11.13", True)):
+    if not at(base):
+        print("  [SKIP] 本地没有 %s —— 这一格未执行, 不计入通过" % base)
+        continue
+    has, txt = bot.update_check()
+    good = has == want_has and len(txt) <= bot.UPD_MSG_BUDGET
+    (ok if good else bad)("%-9s → has=%s 消息 %d 字符 ≤ 预算 %d"
+                          % (base, has, len(txt), bot.UPD_MSG_BUDGET))
+at("v1.11.14") or at("HEAD")
+_head = _REAL_GIT("rev-parse", "HEAD").stdout.strip()
+_tag = _REAL_GIT("rev-parse", "v1.11.14^{commit}").stdout.strip()
+if _head == _tag:
+    has, txt = bot.update_check()
+    (ok if (not has and "🟢" in txt and "❌" not in txt) else
+     bad)("已是最新 → has=False 且报绿(实得 has=%s, %r)" % (has, txt[:50]))
+else:
+    print("  [SKIP] 当前不在 v1.11.14 上, 无更新那一格未执行")
+
+# 这条标题长到「不裁就放不进预算」——于是能同时验两件事: 整条消息仍在预算内, 而且那条提交
+# 是被**裁短后展示**的, 不是整条丢掉(丢掉的话用户一条摘要也看不到)。
+_long = "abcdef0 " + "极长的中文提交标题" * 400
+msg = bot._upd_render("v1.0.0", "v9.9.9", [_long], "o/r")
+(ok if len(msg) <= bot.UPD_MSG_BUDGET else
+ bad)("单条超长标题 → 整条消息 %d ≤ %d" % (len(msg), bot.UPD_MSG_BUDGET))
+(ok if "<pre>" in msg and "极长的中文提交标题" in msg and "…" in msg else
+ bad)("单条超长标题被**裁短后展示**, 不是整条丢弃(有 <pre>=%s, 有正文=%s, 有省略号=%s)"
+      % ("<pre>" in msg, "极长的中文提交标题" in msg, "…" in msg))
+_body = msg[msg.index("<pre>") + 5:msg.index("</pre>")] if "<pre>" in msg else ""
+(ok if len(_body) <= bot.UPD_LINE_MAX * 6 else
+ bad)("展示出来的那一条长度受 UPD_LINE_MAX 约束(实得 %d 字符)" % len(_body))
+
+print()
+print("══ 2. 中文 / emoji / HTML 特殊字符: 长度达标且形态有效 ══")
+lines = ["1111111 修复 <script>alert(1)</script> & \"引号\"",
+         "2222222 🎉🚀 emoji 与 <b>标签</b>",
+         "3333333 中文标题" * 20]
+msg = bot._upd_render("v1.0.0", "v1.1.0", lines, "misaka-cpu/privdns-gateway")
+(ok if "<script>" not in msg and "&lt;script&gt;" in msg else
+ bad)("原始 HTML 被转义, 没有原样进消息")
+import re as _re                                                    # noqa: E402
+(ok if not _re.search(r"&(?!amp;|lt;|gt;|quot;|#\d+;)", msg) else
+ bad)("没有切出半个 HTML 实体")
+(ok if msg.count("<pre>") == msg.count("</pre>") == 1 else bad)("<pre> 标签成对且只有一对")
+(ok if "共 <b>3</b> 个提交" in msg else bad)("提交总数独立计算(3 条), 不是截取后的条数")
+many = ["%07x t%d" % (i, i) for i in range(500)]
+m2 = bot._upd_render("v1.0.0", "v1.1.0", many, "o/r")
+(ok if "共 <b>500</b> 个提交" in m2 and "条未在此显示" in m2 and len(m2) <= bot.UPD_MSG_BUDGET else
+ bad)("500 条 → 总数仍报 500、有未显示提示、整条 %d 字符在预算内" % len(m2))
+(ok if "compare/" in m2 and "releases/tag/" in m2 else bad)("给出官方发布说明与完整比较链接")
+
+print()
+print("══ 3. 各 Git 阶段非零 / 超时 / 输出异常: 不误报最新, 任务正确结束 ══")
+at("v1.11.3")
+
+
+class _R:
+    def __init__(self, rc=0, out="", err=""):
+        self.returncode, self.stdout, self.stderr = rc, out, err
+
+
+def stage_fault(stage, mode):
+    def g(*a, **k):
+        if a and a[0] == stage:
+            if mode == "timeout":
+                raise subprocess.TimeoutExpired(cmd=["git", *a], timeout=1)
+            if mode == "rc":
+                return _R(3, "", "boom")
+            return _R(0, "", "")           # empty
+        return _REAL_GIT(*a, **k)
+    return g
+
+
+# 注意 merge-base --is-ancestor 的契约是**只看退出码**, 正常成功时 stdout 本来就是空的 ——
+# 对它做 "空输出=故障" 的判断是错的, 所以这一格只测 timeout 与非零返回。
+STAGE_MODES = {"describe": ("timeout", "rc", "empty"),
+               "tag": ("timeout", "rc", "empty"),
+               "rev-parse": ("timeout", "rc", "empty"),
+               "merge-base": ("timeout", "rc"),
+               "log": ("timeout", "rc", "empty")}
+for stage, modes in STAGE_MODES.items():
+    for mode in modes:
+        bot._git = stage_fault(stage, mode)
+        try:
+            has, txt = bot.update_check()
+            escaped = None
+        except BaseException as e:          # noqa: BLE001
+            has, txt, escaped = None, "", type(e).__name__
+        bot._git = _REAL_GIT
+        if escaped:
+            bad("%s/%s → 异常逃出 update_check(%s)" % (stage, mode, escaped))
+        elif has:
+            bad("%s/%s → 误报有更新" % (stage, mode))
+        elif "🟢" in txt:
+            bad("%s/%s → 误报绿色: %r" % (stage, mode, txt[:60]))
+        elif "❌" in txt:
+            ok("%s/%-7s → 终态失败: %s" % (stage, mode, txt[:44]))
+        else:
+            bad("%s/%s → 既不是失败也不是绿: %r" % (stage, mode, txt[:60]))
+bot._git = _REAL_GIT
+bot._fetch_release_tags = lambda deadline=None: (False, "https://tok@github.com/x/y.git 挂了")
+has, txt = bot.update_check()
+(ok if (not has and "❌" in txt and "github.com" not in txt and "tok" not in txt) else
+ bad)("fetch 失败 → 终态失败且不回显可能含凭据的 Git URL(%r)" % txt[:60])
+no_fetch()
+
+print()
+print("══ 4. 后台执行: 不占主轮询 / 同会话重复点击受控 / 不同会话不串 ══")
+src = open(os.path.join(ROOT, "deploy/bot/pdg-bot.py"), encoding="utf-8").read()
+seg = src[src.index('if data == "upd_check":'):]
+seg = seg[:seg.index('if data == "upd_apply":')]
+(ok if "_upd_check_async" in seg and "has, txt = update_check()" not in seg else
+ bad)("upd_check 回调不再同步调 update_check")
+
+gate = threading.Event()
+started = threading.Event()
+
+
+def slow_check(budget=None):
+    started.set()
+    gate.wait(10)
+    return True, "🔄 结果 A"
+
+
+tg = Tg(); with_tg(tg)
+bot.update_check = slow_check
+t0 = time.monotonic()
+bot.handle_cb(101, 11, "upd_check")
+elapsed = time.monotonic() - t0
+(ok if elapsed < 1.0 else bad)("回调立即返回(%.2fs), 主轮询未被占用" % elapsed)
+started.wait(5)
+(ok if not bot._upd_check_async(101, 11) else bad)("同会话在飞时重复点击被拒(不无限提交)")
+bot.handle_cb(101, 11, "upd_check")
+busy = [t for t in tg.texts("editMessageText") if "还在跑" in t]
+(ok if busy else bad)("重复点击有明确反馈: %r" % (busy[0][:40] if busy else "<无>"))
+(ok if bot._upd_check_async(202, 22) else bad)("另一个会话不受影响, 可独立发起")
+gate.set(); time.sleep(0.6)
+(ok if 101 not in bot._upd_inflight and 202 not in bot._upd_inflight else
+ bad)("检查结束后占用释放(在飞表: %r)" % (dict(bot._upd_inflight),))
+res = [t for t in tg.texts("editMessageText") if "结果 A" in t]
+(ok if res else bad)("在飞期间重复点击后, 原消息仍收到真实结果(不停在「还在跑」)")
+
+print()
+print("══ 5. 交错: 返回菜单 / 旧任务晚完成 / 新任务已开始 —— 旧结果不覆盖新页面 ══")
+gate2 = threading.Event()
+bot.update_check = lambda budget=None: (gate2.wait(10), (True, "🔄 旧结果 B"))[1]
+tg = Tg(); with_tg(tg)
+bot._upd_check_async(303, 33)
+time.sleep(0.2)
+# 走**真实的** handle_cb 入口(那是作废发生的地方), 只把它渲染菜单要读的生产配置打桩掉 ——
+# 本支不读 /etc/sing-box/config.json, 也不碰任何生产文件。
+_real_status = bot.status_text
+bot.status_text = lambda: "（菜单占位）"
+try:
+    bot.handle_cb(303, 33, "menu")           # 用户返回菜单 → 该消息归属作废
+finally:
+    bot.status_text = _real_status
+gate2.set(); time.sleep(0.6)
+(ok if not any("旧结果 B" in t for t in tg.texts()) else
+ bad)("用户已返回菜单 → 旧检查结果不写回")
+(ok if not any(m == "sendMessage" and "旧结果 B" in p.get("text", "")
+               for m, p in tg.calls) else bad)("也不补发新消息把旧结果推回来")
+(ok if 303 not in bot._upd_inflight else bad)("作废后占用仍被释放")
+
+print()
+print("══ 6. 消息编辑失败 / 发送失败 / API 不可达: 回退有界, 占用能释放 ══")
+bot.update_check = lambda budget=None: (True, "🔄 结果 C")
+tg = Tg(); tg.fail_edit = 99; with_tg(tg)
+bot._upd_check_async(404, 44); time.sleep(0.8)
+n_edit = sum(1 for m, _ in tg.calls if m == "editMessageText")
+n_send = sum(1 for m, _ in tg.calls if m == "sendMessage")
+(ok if n_edit <= 2 else bad)("编辑一直失败时调用有界(editMessageText %d 次 ≤ 2)" % n_edit)
+(ok if n_send == 0 else bad)("编辑失败不补发新消息(sendMessage %d 次)" % n_send)
+(ok if 404 not in bot._upd_inflight else bad)("编辑失败后占用释放")
+
+tg = Tg(); tg.unreachable = True; with_tg(tg)
+bot._upd_check_async(505, 55); time.sleep(0.8)
+(ok if 505 not in bot._upd_inflight else bad)("API 完全不可达: 服务端任务仍结束、占用释放")
+(ok if len(tg.calls) <= 2 else bad)("不可达时投递尝试有界(%d 次)" % len(tg.calls))
+
+print()
+print("══ 7. 超时后本次 git 子进程被收干净(不是只证明外层函数返回) ══")
+probe = os.path.join(WD, "slow.sh")
+open(probe, "w", encoding="utf-8").write(
+    "#!/bin/sh\nsleep 60 &\necho $! > %s/child.pid\nwait\n" % WD)
+os.chmod(probe, 0o755)
+fake_git = os.path.join(WD, "bin")
+os.makedirs(fake_git, exist_ok=True)
+open(os.path.join(fake_git, "git"), "w", encoding="utf-8").write(
+    "#!/bin/sh\nexec %s\n" % probe)
+os.chmod(os.path.join(fake_git, "git"), 0o755)
+_oldpath = os.environ["PATH"]
+os.environ["PATH"] = fake_git + os.pathsep + _oldpath
+t0 = time.monotonic()
+try:
+    _REAL_GIT("status", t=1)
+    bad("超时没有抛出")
+except subprocess.TimeoutExpired:
+    el = time.monotonic() - t0
+    (ok if el < 15 else bad)("超时在 %.1fs 抛出(有界)" % el)
+os.environ["PATH"] = _oldpath
+time.sleep(0.5)
+try:
+    kid = int(open(os.path.join(WD, "child.pid"), encoding="utf-8").read().strip())
+    alive = os.path.exists("/proc/%d" % kid)
+    (ok if not alive else bad)("超时后本次派生的子进程(pid %d)已被收掉(alive=%s)" % (kid, alive))
+except (OSError, ValueError):
+    print("  [SKIP] 拿不到子进程 pid —— 这一格未执行, 不计入通过")
+
+print()
+print("══ 8. 检查流程从不调用实际升级入口 ══")
+called = []
+_real_start = bot.start_update
+bot.start_update = lambda: called.append("start_update") or True
+_real_sh = bot.sh
+bot.sh = lambda cmd, input=None: called.append(list(cmd)) or _R(0, "", "")
+bot._git = _REAL_GIT
+at("v1.11.3")
+no_fetch()
+has, _txt = bot.update_check()
+bot.start_update, bot.sh = _real_start, _real_sh
+(ok if not called else bad)("检查全程没有调用 start_update / pdg CLI(实得 %r)" % (called[:2],))
+(ok if 'systemd-run' in src and 'if data == "upd_apply"' in src else
+ bad)("确认更新仍走原有入口(upd_apply → start_update → systemd-run)")
+
+print()
+print("══ 9. 总时限: 后续步骤只拿剩余预算, 不每步重新获得完整等待 ══")
+bot.update_check = _REAL_UPDATE_CHECK      # 前面几节替换过, 这一节要验真实实现
+_seen = []
+
+
+def _budget_git(*a, t=60):
+    _seen.append((a[0], round(t, 2)))
+    if a[0] == "describe":
+        time.sleep(0.4)
+    return _R(0, {"describe": "v1.0.0", "tag": "v9.9.9\n", "rev-parse": "aaa",
+                  "merge-base": "", "log": "1111111 x\n"}.get(a[0], "x"))
+
+
+bot._git = _budget_git
+no_fetch()
+bot.update_check(budget=2.0)
+bot._git = _REAL_GIT
+_caps = [t for _, t in _seen]
+(ok if _caps and all(_caps[i] >= _caps[i + 1] for i in range(len(_caps) - 1)) else
+ bad)("各步骤拿到的超时单调不增(实得 %r)" % (_caps,))
+(ok if _caps and _caps[0] <= 2.0 and _caps[-1] < _caps[0] else
+ bad)("首步不超过总预算、末步明显更小(实得 %r)" % (_caps,))
+
+
+def _slow_git(*a, t=60):
+    time.sleep(1.2)
+    return _R(0, "v1.0.0")
+
+
+bot._git = _slow_git
+_t0 = time.monotonic()
+# 预算耗尽同样必须是**终态返回**, 不是抛给调用方 —— 抛出去就等于回调拿不到结果, 页面
+# 又停在"检查更新中…"。所以这里把逃逸也当一种失败来断言, 而不是让整支测试崩掉。
+try:
+    _has, _txt, _esc_name = (*bot.update_check(budget=1.0), None)
+except BaseException as _e:      # noqa: BLE001
+    _has, _txt, _esc_name = None, "", type(_e).__name__
+_el = time.monotonic() - _t0
+bot._git = _REAL_GIT
+if _esc_name:
+    bad("预算耗尽 → 异常逃出 update_check(%s), 回调拿不到终态" % _esc_name)
+else:
+    (ok if (not _has and "❌" in _txt and "超时" in _txt) else
+     bad)("预算耗尽 → 终态超时失败(实得 has=%s %r)" % (_has, _txt[:44]))
+(ok if _el < 10 else bad)("预算耗尽后很快返回(%.2fs), 没有把任务吊住" % _el)
+
+print()
+print("-" * 62)
+print("test-bot-update-check.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+sys.exit(1 if FAIL[0] else 0)

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -536,6 +536,24 @@ def _reset_state():
     with bot._upd_lock:
         bot._upd_inflight.clear()
         bot._upd_sess.clear()
+        bot._upd_jobs.clear()
+        bot._upd_notify_pending.clear()
+        bot._upd_notify_live.clear()
+
+
+def _tables():
+    """五张表的当下规模。判"零残留"要看**全部**, 不能只看在飞表。"""
+    with bot._upd_lock:
+        return (len(bot._upd_sess), len(bot._upd_jobs), len(bot._upd_inflight),
+                len(bot._upd_notify_pending), len(bot._upd_notify_live))
+
+
+def _drain(limit=20):
+    """等到本轮真的都结束再看表 —— 不是先清空映射再宣布零残留。"""
+    t0 = time.monotonic()
+    while _tables() != (0, 0, 0, 0, 0) and time.monotonic() - t0 < limit:
+        time.sleep(0.02)
+    return _tables()
 
 
 def _settle(chat, limit=20):
@@ -921,6 +939,493 @@ while 1720 in bot._upd_inflight and time.monotonic() - _t0 < 20:
     time.sleep(0.05)
 (ok if 1720 not in bot._upd_inflight and not bot._upd_notify_pending else
  bad)("17c 结束后在飞表与待发表都清空")
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 18. 绝对期限贯穿**真实**请求: 自建回环服务, 走真实 post 的建连/复用/读响应
+# ──────────────────────────────────────────────────────────────────────────────
+# 只换端点(127.0.0.1 上自己起的服务、自造数据), post() 的逻辑一个字不改 ——
+# 换掉 post 就等于没验这条路径。绝不连 api.telegram.org / 9090 / 任何生产口。
+print()
+print("══ 18. 绝对期限贯穿真实请求(自建回环服务; 建连 / 复用 / 读响应) ══")
+
+import http.client as _hc                                          # noqa: E402
+import socketserver                                                # noqa: E402
+
+_LB_BODY = b'{"ok":true,"result":{"message_id":1}}'
+
+
+class _LbHandler(socketserver.StreamRequestHandler):
+    def handle(self):
+        while True:
+            if not self.rfile.readline():
+                return
+            n = 0
+            while True:
+                h = self.rfile.readline()
+                if h in (b"\r\n", b"\n", b""):
+                    break
+                if h.lower().startswith(b"content-length:"):
+                    n = int(h.split(b":")[1])
+            if n:
+                self.rfile.read(n)
+            _LB.hits.append(time.monotonic())
+            _LB.conns.add(id(self.connection))
+            try:
+                time.sleep(_LB.head_delay)
+                self.wfile.write(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n"
+                                 b"Content-Type: application/json\r\n\r\n" % len(_LB_BODY))
+                self.wfile.flush()
+                if _LB.drip:
+                    # 每块之间都比 socket 空闲超时短 —— 空闲超时永远不触发, 但总时长超期限
+                    for i in range(0, len(_LB_BODY), 4):
+                        self.wfile.write(_LB_BODY[i:i + 4])
+                        self.wfile.flush()
+                        time.sleep(_LB.drip)
+                else:
+                    self.wfile.write(_LB_BODY)
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return                       # 客户端按期限先走了 —— 预期内, 不是异常
+
+
+class _Lb(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+    head_delay = 0.0
+    drip = 0.0
+    hits: list = []
+    conns: set = set()
+
+
+_LB = _Lb(("127.0.0.1", 0), _LbHandler)
+_LB_PORT = _LB.server_address[1]
+threading.Thread(target=_LB.serve_forever, daemon=True).start()
+
+
+class _LbClient:
+    @staticmethod
+    def HTTPSConnection(host, timeout=None):
+        return _hc.HTTPConnection("127.0.0.1", _LB_PORT, timeout=timeout)
+
+
+class _LbHttp:
+    client = _LbClient
+
+
+_real_http, bot.http = bot.http, _LbHttp
+bot.post = _REAL_POST                        # 走真实 post: 建连、复用、重连、读响应
+
+
+def _lb_reset():
+    c = getattr(bot._tls, "conn", None)
+    if c:
+        try:
+            c.close()
+        except Exception:      # noqa: BLE001
+            pass
+    bot._tls.conn = None
+    _LB.hits.clear()
+    _LB.conns.clear()
+    _LB.head_delay = 0.0
+    _LB.drip = 0.0
+
+
+# 18a 复用的连接必须按**本次**剩余预算重设 socket 超时
+_lb_reset()
+bot.post("m", {}, time.monotonic() + 150)                    # 建连: 剩余 150 → 取 70
+_t_new = bot._tls.conn.timeout
+bot.post("m", {}, time.monotonic() + 2.0)                    # 复用: 剩余只剩 2s
+_t_reuse = bot._tls.conn.timeout
+_t_sock = bot._tls.conn.sock.gettimeout() if bot._tls.conn.sock else None
+(ok if _t_new == bot.API_TIMEOUT else
+ bad)("18a 建连时 socket 超时取默认上限(实得 %s)" % _t_new)
+(ok if _t_reuse is not None and _t_reuse <= 2.0 else
+ bad)("18a 复用连接按剩余预算重设 conn.timeout(实得 %s, 应 ≤2.0)" % _t_reuse)
+(ok if _t_sock is not None and _t_sock <= 2.0 else
+ bad)("18a 已连上的那条 socket 也被重设(实得 %s, 应 ≤2.0) —— conn.timeout 只在建连时生效"
+      % _t_sock)
+
+# 18b deadline=None 的调用不继承上一任务留下的短超时
+_lb_reset()
+bot.post("m", {}, time.monotonic() + 3.0)                    # 更新任务: 留下 3s 的连接
+_cached_to = bot._tls.conn.timeout
+_LB.head_delay = 5.0                                         # 服务端慢 5s: 70s 上限等得起
+_LB.hits.clear()
+_t0 = time.monotonic()
+_r = bot.post("m", {})                                       # 非更新调用: 上限应是 70s
+_el = time.monotonic() - _t0
+(ok if _cached_to is not None and _cached_to <= 3.0 else
+ bad)("18b 上一任务确实留下了短超时的缓存连接(实得 %s)" % _cached_to)
+(ok if len(_LB.hits) == 1 and _r.get("ok") else
+ bad)("18b deadline=None 不继承短超时: 一次传输就成功(实得 %d 次传输, ok=%s)"
+      % (len(_LB.hits), bool(_r.get("ok"))))
+(ok if _el >= 5.0 else
+ bad)("18b 它真的等满了服务端的 5s(实得 %.2fs) —— 没被 3s 误判超时" % _el)
+
+# 18c socket 空闲超时以内持续小块返回: 整个读取仍受绝对期限约束
+_lb_reset()
+_LB.drip = 0.25                                              # 每块间隔 0.25s ≪ 空闲超时
+_dl = time.monotonic() + 1.5
+_t0 = time.monotonic()
+_r = bot.post("m", {}, _dl)
+_el = time.monotonic() - _t0
+_fd_after = len(os.listdir("/proc/self/fd"))
+(ok if not _r.get("ok") else
+ bad)("18c 响应读取超过绝对期限 → 判失败, 不冒充成功(实得 ok=%s)" % bool(_r.get("ok")))
+(ok if _el < 1.5 + 1.0 else
+ bad)("18c 超期后立刻结束, 不读到底(耗时 %.2fs, 期限 1.50s)" % _el)
+(ok if getattr(bot._tls, "conn", None) is None else
+ bad)("18c 超期时真的把连接收掉了(不是只让外层返回、把线程留在 socket 上)")
+_lb_reset()
+_LB.drip = 0.25
+_dl = time.monotonic() + 1.5
+bot.post("m", {}, _dl)
+time.sleep(1.0)
+_fd_now = len(os.listdir("/proc/self/fd"))
+(ok if _fd_now <= _fd_after + 2 else
+ bad)("18c 超期收尾不漏 FD(前 %d → 后 %d)" % (_fd_after, _fd_now))
+
+# 18d 本地超时 / 请求完成 / 投递确认分开记账 —— 不把"本地放弃"说成"对端没收到"
+_lb_reset()
+_LB.drip = 0.25
+_dl = time.monotonic() + 1.5
+_r = bot.post("m", {}, _dl)
+_reached = len(_LB.hits)                     # 对端**确实**收到了这个请求
+(ok if _reached == 1 and not _r.get("ok") else
+ bad)("18d 请求已到达对端(%d 次)但本地判超时(ok=%s) —— 两件事分开记, 不谎称撤回"
+      % (_reached, bool(_r.get("ok"))))
+_lb_reset()
+_r = bot.post("m", {}, time.monotonic() + 30)
+(ok if _r.get("ok") and len(_LB.hits) == 1 else
+ bad)("18d 正常路径: 一次传输, 投递确认为成功(实得 %d 次/ok=%s)"
+      % (len(_LB.hits), bool(_r.get("ok"))))
+
+# 18e keep-alive 真的复用: 按块读之后必须自己把响应收尾, 否则连接停在 "Request-sent",
+# 下一次调用撞 ResponseNotReady 再重连 —— 表面还是成功, 每次都白跑一个来回。
+_lb_reset()
+for _ in range(4):
+    bot.post("m", {}, time.monotonic() + 30)
+(ok if len(_LB.hits) == 4 else
+ bad)("18e 4 次调用 = 4 次传输, 没有隐性重连(实得 %d)" % len(_LB.hits))
+(ok if len(_LB.conns) == 1 else
+ bad)("18e 4 次调用共用一条 TCP 连接(实得 %d 条) —— keep-alive 名副其实"
+      % len(_LB.conns))
+
+_lb_reset()
+_LB.shutdown()
+bot.http = _real_http
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 19. 已撤销的写回权限不得被重新赋予
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("══ 19. 撤销即撤销: 空 token 不是写回权 / 排队期间导航 / 过期不恢复权限 ══")
+
+# 19a 空 token 直接被写入通道拒掉(None == None 曾经放行)
+_reset_state()
+_tg19 = Tg(); bot.post = _tg19.post
+with bot._upd_lock:
+    _j = bot._upd_new_sess(1901, 191, time.monotonic() + 60)
+bot._upd_invalidate(1901, 191)
+_r19, _why19 = bot._upd_emit(1901, 191, None, "progress", "🔄 空 token", bot.BACK)
+(ok if not _r19 and _why19 == "superseded" else
+ bad)("19a token=None 被拒(实得 %r/%r)" % (_r19, _why19))
+(ok if not [c for c in _tg19.calls if c[0] == "editMessageText"] else
+ bad)("19a 一个字都没写出去(实得 %s)"
+      % [c[1].get("text", "")[:16] for c in _tg19.calls if c[0] == "editMessageText"])
+with bot._upd_lock:
+    bot._upd_drop_sess(1901, 191, _j)
+
+# 19b 排队期间导航 → worker 启动时直接结束: 不跑 Git、不发进度、不发终态
+_reset_state()
+_tg19b = Tg(); bot.post = _tg19b.post
+_ran19 = [0]
+
+
+def _count_check(budget=None):
+    _ran19[0] += 1
+    return True, "🔄 旧结果(不该出现)"
+
+
+bot.update_check = _count_check
+_entered19 = threading.Semaphore(0)
+_hold19 = threading.Event()
+for _ in range(4):
+    bot._EXEC.submit(lambda: (_entered19.release(), _hold19.wait(30)))
+_full19 = all(_entered19.acquire(timeout=10) for _ in range(4))
+(ok if _full19 else bad)("19b 4 个 worker 已**确认**进入(信号量到齐, 不靠 sleep 推断)")
+_acc19, _ = bot._upd_check_async(1902, 192)
+_sess19 = bot._upd_sess.get((1902, 192)) or {}
+(ok if _acc19 == "ok" and not _sess19.get("started") else
+ bad)("19b 任务确实在队列里等(受理 %r, started=%s)" % (_acc19, _sess19.get("started")))
+bot._upd_invalidate(1902, 192)                       # 用户返回菜单
+_tg19b.calls.clear()
+_ran19[0] = 0
+_hold19.set()                                        # 放行 worker: 排队任务现在才启动
+_settle(1902)
+time.sleep(0.4)
+_w19 = [c[1].get("text", "")[:18] for c in _tg19b.calls if c[0] == "editMessageText"]
+(ok if _ran19[0] == 0 else
+ bad)("19b 导航之后不再执行 Git/检查(实得 %d 次)" % _ran19[0])
+(ok if not _w19 else bad)("19b 导航之后不发进度、不发终态(实得 %s)" % _w19)
+(ok if _drain() == (0, 0, 0, 0, 0) else
+ bad)("19b 结束后五张表零残留(实得 %s)" % (_drain(),))
+
+# 19c 已导航作废的排队任务过期: 保留撤销事实, 不靠新建通知恢复写回权
+_reset_state()
+_tg19c = Tg(); bot.post = _tg19c.post
+with bot._upd_lock:
+    _j19c = bot._upd_new_sess(1903, 193, time.monotonic() + bot.UPD_DELIVER_BUDGET - 1.0)
+    bot._upd_inflight[1903] = _j19c
+bot._upd_invalidate(1903, 193)
+_t0 = time.monotonic()
+while (1903, 193) in bot._upd_sess and time.monotonic() - _t0 < 15:
+    time.sleep(0.05)
+time.sleep(0.6)
+_w19c = [c[1].get("text", "")[:18] for c in _tg19c.calls if c[0] == "editMessageText"]
+(ok if (1903, 193) not in bot._upd_sess else
+ bad)("19c 过期任务被清掉, 没有换一条新会话续命")
+(ok if not _w19c else
+ bad)("19c 过期提示不写回已经翻走的页面(实得 %s)" % _w19c)
+(ok if _drain() == (0, 0, 0, 0, 0) else
+ bad)("19c 五张表零残留(实得 %s)" % (_drain(),))
+
+# 19d 没被导航过的排队任务过期: 该给的终态说明照给(19c 不能把它一并压掉)
+_reset_state()
+_tg19d = Tg(); bot.post = _tg19d.post
+with bot._upd_lock:
+    _j19d = bot._upd_new_sess(1904, 194, time.monotonic() + bot.UPD_DELIVER_BUDGET - 1.0)
+    bot._upd_inflight[1904] = _j19d
+_t0 = time.monotonic()
+while not [c for c in _tg19d.calls if c[0] == "editMessageText"] and time.monotonic() - _t0 < 15:
+    time.sleep(0.05)
+_w19d = [c[1].get("text", "")[:20] for c in _tg19d.calls if c[0] == "editMessageText"]
+(ok if _w19d and "排队过久" in _w19d[0] else
+ bad)("19d 未被导航的过期任务仍有终态说明(实得 %s)" % _w19d)
+(ok if _drain() == (0, 0, 0, 0, 0) else
+ bad)("19d 五张表零残留(实得 %s)" % (_drain(),))
+
+# 19e 收割器在**真实窗口**(快照后释放锁、fut.cancel() 期间)不覆盖后来的新任务
+_reset_state()
+bot.post = Tg().post
+_inwin = threading.Event()
+_gowin = threading.Event()
+
+
+class _WinFut:
+    """收割器在锁外调 cancel() —— 产品里真实存在的那段窗口。"""
+
+    def cancel(self):
+        _inwin.set()
+        _gowin.wait(15)
+        return True
+
+
+with bot._upd_lock:
+    _oldj = bot._upd_new_sess(1905, 195, time.monotonic() + bot.UPD_DELIVER_BUDGET - 1.0)
+    bot._upd_sess[(1905, 195)]["fut"] = _WinFut()
+    bot._upd_inflight[1905] = _oldj
+(ok if _inwin.wait(15) else bad)("19e 收割器已**确认**进入窗口(不靠 sleep 撞)")
+with bot._upd_lock:                                  # 产品里 _upd_new_sess 永远在锁内
+    _newj = bot._upd_new_sess(1905, 195, time.monotonic() + 120)
+    _newt = bot._upd_sess[(1905, 195)]["token"]
+    bot._upd_inflight[1905] = _newj
+_gowin.set()
+time.sleep(1.2)
+_cur19 = bot._upd_sess.get((1905, 195))
+(ok if _cur19 is not None and _cur19.get("job") == _newj else
+ bad)("19e 新会话没被旧任务覆盖(实得 job 一致=%s)"
+      % (_cur19 is not None and _cur19.get("job") == _newj))
+(ok if _cur19 is not None and _cur19.get("token") == _newt else
+ bad)("19e 新会话的写回权保留")
+(ok if _cur19 is not None and _cur19.get("kind") == "check" else
+ bad)("19e 新会话没被 notice 顶掉(实得 kind=%r)" % (_cur19 and _cur19.get("kind")))
+(ok if bot._upd_inflight.get(1905) == _newj else
+ bad)("19e 新任务的名额没被旧任务让出去")
+(ok if _oldj not in bot._upd_jobs else
+ bad)("19e 旧任务只清掉了**自己**的身份")
+with bot._upd_lock:
+    bot._upd_drop_sess(1905, 195, _newj)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 20. 通知的完整收尾与真实全局准入
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("══ 20. 通知生命周期: 成功/失败/过期/作废/提交失败 + 全局上限 + 两阶段合并 ══")
+
+# 20a 五条结束路径都精确释放自己的状态
+for _name, _setup in (
+        ("成功投递", "ok"),
+        ("持续失败", "fail"),
+        ("已过期", "expired"),
+        ("导航作废", "revoked"),
+):
+    _reset_state()
+    _tg20 = Tg()
+    if _setup == "fail":
+        _tg20.unreachable = True
+    bot.post = _tg20.post
+    with bot._upd_lock:
+        _j20 = bot._upd_new_sess(2001, 200, time.monotonic() + bot.UPD_NOTICE_BUDGET,
+                                 kind="notice")
+        _t20 = bot._upd_sess[(2001, 200)]["token"]
+    _dl20 = time.monotonic() + (-1.0 if _setup == "expired" else 5.0)
+    if _setup == "revoked":
+        bot._upd_invalidate(2001, 200)
+    bot._upd_notify(2001, 200, "⏳ 忙", _t20, _dl20, _j20)
+    (ok if _drain(10) == (0, 0, 0, 0, 0) else
+     bad)("20a 通知「%s」结束后五张表零残留(实得 %s)" % (_name, _drain(0.1)))
+
+# 20a' 提交失败也要收尾
+_reset_state()
+bot.post = Tg().post
+_real_sub20 = bot._upd_notify_exec.submit
+bot._upd_notify_exec.submit = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("submit 拒绝"))
+with bot._upd_lock:
+    _j20s = bot._upd_new_sess(2002, 200, time.monotonic() + bot.UPD_NOTICE_BUDGET,
+                              kind="notice")
+    _t20s = bot._upd_sess[(2002, 200)]["token"]
+_r20s = bot._upd_notify(2002, 200, "⏳", _t20s, time.monotonic() + 5, _j20s)
+bot._upd_notify_exec.submit = _real_sub20
+(ok if _r20s is False else bad)("20a' 提交失败如实返回 False(实得 %r)" % _r20s)
+(ok if _tables() == (0, 0, 0, 0, 0) else
+ bad)("20a' 提交失败后零残留(实得 %s)" % (_tables(),))
+
+# 20b 忙提示复用的是**检查**会话的身份 —— 通知收尾不得把在跑的检查一起收掉
+_reset_state()
+bot.post = Tg().post
+with bot._upd_lock:
+    _cj20 = bot._upd_new_sess(2003, 200, time.monotonic() + 120)      # kind='check'
+    _ct20 = bot._upd_sess[(2003, 200)]["token"]
+    bot._upd_inflight[2003] = _cj20
+# 忙提示照实把**检查**会话的身份传进去 —— 归属由 _upd_notice_release 判, 不靠调用方先挑
+bot._upd_notify(2003, 200, "⏳ 上一次还在跑", _ct20, time.monotonic() + 5, _cj20)
+_t0 = time.monotonic()
+while bot._upd_notify_live and time.monotonic() - _t0 < 10:
+    time.sleep(0.02)
+_alive20 = bot._upd_sess.get((2003, 200))
+(ok if _alive20 is not None and _alive20.get("job") == _cj20 else
+ bad)("20b 通知收尾没有动正在跑的检查会话")
+(ok if bot._upd_inflight.get(2003) == _cj20 else
+ bad)("20b 在跑的检查名额也没被通知收掉")
+with bot._upd_lock:
+    bot._upd_drop_sess(2003, 200, _cj20)
+
+# 20c 替换 notice 清旧身份, 不误删新身份
+_reset_state()
+with bot._upd_lock:
+    _a20 = bot._upd_new_sess(2004, 200, time.monotonic() + 30, kind="notice")
+    _b20 = bot._upd_new_sess(2004, 200, time.monotonic() + 30, kind="notice")
+(ok if len(bot._upd_jobs) == 1 and _a20 not in bot._upd_jobs else
+ bad)("20c 替换会话摘掉旧身份(jobs=%d, 旧身份仍在=%s)"
+      % (len(bot._upd_jobs), _a20 in bot._upd_jobs))
+(ok if bot._upd_jobs.get(_b20) == (2004, 200) else
+ bad)("20c 新身份完好")
+with bot._upd_lock:
+    bot._upd_notice_release(2004, 200, _a20)          # 旧身份的收尾不能误删新会话
+(ok if bot._upd_sess.get((2004, 200), {}).get("job") == _b20 else
+ bad)("20c 旧身份收尾不误删新会话")
+with bot._upd_lock:
+    bot._upd_drop_sess(2004, 200, _b20)
+
+# 20d 全局上限: 待发 + 在飞 有真实上限, 不是只限执行线程数
+_reset_state()
+bot.post = Tg().post
+_block20 = threading.Event()
+_real_emit20 = bot._upd_emit
+bot._upd_emit = lambda *a, **k: (_block20.wait(25), (True, "ok"))[1]
+_accepted20 = 0
+for _i in range(300):
+    with bot._upd_lock:
+        _jj = bot._upd_new_sess(2005, 3000 + _i, time.monotonic() + 60, kind="notice")
+        _tt = bot._upd_sess[(2005, 3000 + _i)]["token"]
+    if bot._upd_notify(2005, 3000 + _i, "⏳", _tt, time.monotonic() + 60, _jj):
+        _accepted20 += 1
+time.sleep(0.4)
+_pend20, _live20 = len(bot._upd_notify_pending), len(bot._upd_notify_live)
+(ok if _live20 <= bot.UPD_NOTICE_MAX else
+ bad)("20d 在跑的通知受全局上限约束(实得 %d ≤ %d)" % (_live20, bot.UPD_NOTICE_MAX))
+(ok if set(bot._upd_notify_pending) <= bot._upd_notify_live else
+ bad)("20d 待发表恒为在飞集合的子集(准入才数得准; 待发 %d / 在飞 %d)" % (_pend20, _live20))
+(ok if _accepted20 == bot.UPD_NOTICE_MAX else
+ bad)("20d 300 次点击恰好受理到上限 %d 条(实得 %d), 其余当场拒绝"
+      % (bot.UPD_NOTICE_MAX, _accepted20))
+(ok if len(bot._upd_sess) <= bot.UPD_NOTICE_MAX else
+ bad)("20d 满载被拒的通知没有留下会话(sess=%d ≤ %d)"
+      % (len(bot._upd_sess), bot.UPD_NOTICE_MAX))
+_block20.set()
+bot._upd_emit = _real_emit20
+_reset_state()
+
+# 20e 合并覆盖**排队**与**投递在飞**两个阶段
+_reset_state()
+bot.post = Tg().post
+_inflight20 = threading.Event()
+_hold20 = threading.Event()
+_emits20 = [0]
+
+
+def _gate_emit(chat, mid, token, phase, text, kb):
+    _emits20[0] += 1
+    _inflight20.set()
+    _hold20.wait(20)
+    return True, "ok"
+
+
+bot._upd_emit = _gate_emit
+_subs20 = [0]
+_real_sub20b = bot._upd_notify_exec.submit
+
+
+def _count_sub20(fn, *a, **k):
+    _subs20[0] += 1
+    return _real_sub20b(fn, *a, **k)
+
+
+bot._upd_notify_exec.submit = _count_sub20
+with bot._upd_lock:
+    _j20e = bot._upd_new_sess(2006, 206, time.monotonic() + 60, kind="notice")
+    _t20e = bot._upd_sess[(2006, 206)]["token"]
+bot._upd_notify(2006, 206, "⏳ 第一条", _t20e, time.monotonic() + 60, _j20e)
+(ok if _inflight20.wait(10) else bad)("20e 第一条通知**确认**已进入投递(不靠 sleep)")
+(ok if not bot._upd_notify_pending else
+ bad)("20e 此刻待发表已空(处于「在飞」阶段, 合并只看待发就会漏)")
+for _ in range(10):
+    bot._upd_notify(2006, 206, "⏳ 追加", _t20e, time.monotonic() + 60, _j20e)
+(ok if _subs20[0] == 1 else
+ bad)("20e 在飞阶段的重复通知合并进同一份工作(提交 %d 份, 应 1)" % _subs20[0])
+_hold20.set()
+bot._upd_emit = _real_emit20
+bot._upd_notify_exec.submit = _real_sub20b
+_t0 = time.monotonic()
+while bot._upd_notify_live and time.monotonic() - _t0 < 15:
+    time.sleep(0.02)
+(ok if _emits20[0] <= 2 else
+ bad)("20e 11 次通知最多落地 2 次(在飞 1 + 合并后的 1; 实得 %d)" % _emits20[0])
+(ok if _drain() == (0, 0, 0, 0, 0) else bad)("20e 结束后五张表零残留(实得 %s)" % (_drain(),))
+
+# 20f 同一聊天多条历史消息 / 多个聊天: 各自独立, 结束后都不留残留
+_reset_state()
+_tg20f = Tg(); bot.post = _tg20f.post
+for _chat, _mid in ((2007, 71), (2007, 72), (2007, 73), (2008, 71), (2009, 71)):
+    with bot._upd_lock:
+        _jj = bot._upd_new_sess(_chat, _mid, time.monotonic() + 30, kind="notice")
+        _tt = bot._upd_sess[(_chat, _mid)]["token"]
+    bot._upd_notify(_chat, _mid, "⏳ %d/%d" % (_chat, _mid), _tt,
+                    time.monotonic() + 30, _jj)
+_res20f = _drain(15)
+_mids20f = sorted({c[1].get("message_id") for c in _tg20f.calls
+                   if c[0] == "editMessageText"})
+(ok if _res20f == (0, 0, 0, 0, 0) else
+ bad)("20f 3 条历史消息 + 3 个聊天结束后零残留(实得 %s)" % (_res20f,))
+(ok if _mids20f == [71, 72, 73] else
+ bad)("20f 每条消息各写各的, 不串(实得 mid %s)" % _mids20f)
+
+_reset_state()
+bot.post = _REAL_POST
+bot.update_check = _REAL_UPDATE_CHECK
 
 print()
 print("-" * 62)

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -956,21 +956,25 @@ _LB_BODY = b'{"ok":true,"result":{"message_id":1}}'
 
 class _LbHandler(socketserver.StreamRequestHandler):
     def handle(self):
-        while True:
-            if not self.rfile.readline():
-                return
-            n = 0
+        # 整个 handle 都要罩住, **读请求那半段也算**: 客户端按期限先走时会 RST, 于是第一句
+        # rfile.readline() 就抛 ConnectionResetError。异常从这里逃出去, socketserver 会把
+        # 完整 traceback 打到 stderr —— 负控看到 "Traceback" 就把整次正控判成崩溃, 一格本来
+        # 有牙的对照被记成无效。服务端收摊的噪音不能冒充正控崩溃。
+        try:
             while True:
-                h = self.rfile.readline()
-                if h in (b"\r\n", b"\n", b""):
-                    break
-                if h.lower().startswith(b"content-length:"):
-                    n = int(h.split(b":")[1])
-            if n:
-                self.rfile.read(n)
-            _LB.hits.append(time.monotonic())
-            _LB.conns.add(id(self.connection))
-            try:
+                if not self.rfile.readline():
+                    return
+                n = 0
+                while True:
+                    h = self.rfile.readline()
+                    if h in (b"\r\n", b"\n", b""):
+                        break
+                    if h.lower().startswith(b"content-length:"):
+                        n = int(h.split(b":")[1])
+                if n:
+                    self.rfile.read(n)
+                _LB.hits.append(time.monotonic())
+                _LB.conns.add(id(self.connection))
                 time.sleep(_LB.head_delay)
                 self.wfile.write(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n"
                                  b"Content-Type: application/json\r\n\r\n" % len(_LB_BODY))
@@ -984,8 +988,8 @@ class _LbHandler(socketserver.StreamRequestHandler):
                 else:
                     self.wfile.write(_LB_BODY)
                     self.wfile.flush()
-            except (BrokenPipeError, ConnectionResetError, OSError):
-                return                       # 客户端按期限先走了 —— 预期内, 不是异常
+        except Exception:      # noqa: BLE001
+            return             # 客户端按期限先走了 / 连接被重置 —— 都是预期内的收摊
 
 
 class _Lb(socketserver.ThreadingTCPServer):
@@ -1422,6 +1426,326 @@ _mids20f = sorted({c[1].get("message_id") for c in _tg20f.calls
  bad)("20f 3 条历史消息 + 3 个聊天结束后零残留(实得 %s)" % (_res20f,))
 (ok if _mids20f == [71, 72, 73] else
  bad)("20f 每条消息各写各的, 不串(实得 mid %s)" % _mids20f)
+
+_reset_state()
+bot.post = _REAL_POST
+bot.update_check = _REAL_UPDATE_CHECK
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 21. 绝对期限覆盖**完整响应**, 不只是普通响应体
+# ──────────────────────────────────────────────────────────────────────────────
+# 沿 http.client 的调用栈, 一次响应至少有四类阻塞点:
+#   状态行(_read_status→fp.readline)、响应头(begin→parse_headers 的多次 readline) —— 在
+#   getresponse() **里面**; 分块头/尾部(_read_next_chunk_size / _read_and_discard_trailer
+#   的 readline)、响应体(read1→fp.read1) —— 在 read1() **里面**。调用方在循环里查期限,
+#   一次也查不到前三类。socket 超时也顶不上: 它只管"多久没收到字节"。
+# 这一节用**裸 socket** 回环服务逐字节控制每个阶段的节奏, 自造响应, 不连任何真实服务。
+print()
+print("══ 21. 期限覆盖完整响应: 状态行 / 响应头 / 分块头与尾部 / close 下的响应体 ══")
+
+import socket as _sock                                             # noqa: E402
+
+_RB_BODY = b'{"ok":true,"result":{"message_id":1}}'
+_RB = {"mode": "fast", "gap": 0.8, "got": threading.Event(),
+       "phase": threading.Event(), "conns": set()}
+
+
+def _rb_serve(cli):
+    """裸应答: 每个阶段的节奏都由 mode 决定; 每段间隔都**小于** socket 空闲超时。"""
+    f = cli.makefile("rb")
+    try:
+        while True:
+            if not f.readline():
+                return
+            n = 0
+            while True:
+                h = f.readline()
+                if h in (b"\r\n", b"\n", b""):
+                    break
+                if h.lower().startswith(b"content-length:"):
+                    n = int(h.split(b":")[1])
+            if n:
+                f.read(n)
+            _RB["conns"].add(id(cli))
+            _RB["got"].set()
+            m, g = _RB["mode"], _RB["gap"]
+            if m == "slow_status":
+                _RB["phase"].set()
+                for ch in b"HTTP/1.1 200 OK\r\n":            # 状态行逐字节
+                    cli.sendall(bytes([ch]))
+                    time.sleep(g)
+                cli.sendall(b"Content-Length: %d\r\n\r\n" % len(_RB_BODY))
+                cli.sendall(_RB_BODY)
+            elif m == "slow_headers":
+                cli.sendall(b"HTTP/1.1 200 OK\r\n")
+                _RB["phase"].set()
+                for i in range(12):                          # 响应头一条条慢吐
+                    cli.sendall(b"X-Pad-%02d: y\r\n" % i)
+                    time.sleep(g)
+                cli.sendall(b"Content-Length: %d\r\n\r\n" % len(_RB_BODY))
+                cli.sendall(_RB_BODY)
+            elif m == "slow_chunk":
+                cli.sendall(b"HTTP/1.1 200 OK\r\nConnection: close\r\n"
+                            b"Transfer-Encoding: chunked\r\n\r\n")
+                _RB["phase"].set()
+                for i in range(0, len(_RB_BODY), 6):
+                    seg = _RB_BODY[i:i + 6]
+                    time.sleep(g)                            # 分块**头**之前停顿
+                    cli.sendall(b"%x\r\n" % len(seg) + seg + b"\r\n")
+                time.sleep(g); cli.sendall(b"0\r\n")
+                time.sleep(g); cli.sendall(b"\r\n")          # 尾部也慢
+                cli.shutdown(_sock.SHUT_WR); return
+            elif m == "close_body":
+                cli.sendall(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n")
+                _RB["phase"].set()
+                for i in range(0, len(_RB_BODY), 6):
+                    time.sleep(g); cli.sendall(_RB_BODY[i:i + 6])
+                cli.shutdown(_sock.SHUT_WR); return
+            elif m == "late_complete":
+                # 末段正好落在"逐轮检查刚通过"的那一轮里 → 内容完整, 但到得比期限晚
+                cli.sendall(b"HTTP/1.1 200 OK\r\nConnection: close\r\n"
+                            b"Content-Length: %d\r\n\r\n" % len(_RB_BODY))
+                _RB["phase"].set()
+                half = len(_RB_BODY) // 2
+                time.sleep(g); cli.sendall(_RB_BODY[:half])
+                time.sleep(g); cli.sendall(_RB_BODY[half:])
+                cli.shutdown(_sock.SHUT_WR); return
+            else:
+                cli.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(_RB_BODY))
+                cli.sendall(_RB_BODY)
+    except Exception:      # noqa: BLE001
+        return                 # 客户端按期限先走 / 连接里有残字节 —— 都是预期内的收摊
+
+
+_RB_SRV = _sock.socket()
+_RB_SRV.setsockopt(_sock.SOL_SOCKET, _sock.SO_REUSEADDR, 1)
+_RB_SRV.bind(("127.0.0.1", 0))
+_RB_SRV.listen(16)
+_RB_PORT = _RB_SRV.getsockname()[1]
+
+
+def _rb_accept():
+    while True:
+        try:
+            c, _ = _RB_SRV.accept()
+        except OSError:
+            return
+        threading.Thread(target=_rb_serve, args=(c,), daemon=True).start()
+
+
+threading.Thread(target=_rb_accept, daemon=True).start()
+
+
+class _RbClient:
+    @staticmethod
+    def HTTPSConnection(host, timeout=None):
+        return _hc.HTTPConnection("127.0.0.1", _RB_PORT, timeout=timeout)
+
+
+class _RbHttp:
+    client = _RbClient
+
+
+_prev_http, bot.http = bot.http, _RbHttp
+bot.post = _REAL_POST
+
+
+def _rb_reset(mode="fast", gap=0.8):
+    c = getattr(bot._tls, "conn", None)
+    if c:
+        try:
+            c.close()
+        except Exception:      # noqa: BLE001
+            pass
+    bot._tls.conn = None
+    _RB["mode"], _RB["gap"] = mode, gap
+    _RB["got"].clear(); _RB["phase"].clear(); _RB["conns"].clear()
+
+
+def _rb_call(mode, budget, gap, full_secs, label):
+    """跑一次并核对: 服务端确实收到请求、确实进到目标阶段、且**及时终止**。
+
+    full_secs = 等完整响应大约要多久。判据同时卡两头: 既要落在预算的调度余量内,
+    又要明显小于"等完整响应"——这样放宽阈值也掩盖不了失效。
+    """
+    _rb_reset(mode, gap)
+    dl = time.monotonic() + budget
+    t0 = time.monotonic()
+    r = bot.post("m", {}, dl)
+    el = time.monotonic() - t0
+    (ok if _RB["got"].is_set() and _RB["phase"].is_set() else
+     bad)("21 %s: 服务端确实收到请求并进入目标阶段(收到=%s 阶段=%s)"
+          % (label, _RB["got"].is_set(), _RB["phase"].is_set()))
+    (ok if el <= budget + 0.6 else
+     bad)("21 %s: 及时终止(实耗 %.2fs ≤ 预算 %.2fs + 0.6s 调度余量)" % (label, el, budget))
+    (ok if el < full_secs * 0.6 else
+     bad)("21 %s: 不是等完整响应才返回(实耗 %.2fs, 等完整约 %.1fs)" % (label, el, full_secs))
+    (ok if not r.get("ok") else
+     bad)("21 %s: 超期不判成功(实得 ok=%s)" % (label, bool(r.get("ok"))))
+    return el
+
+
+# 21a 状态行慢吐 —— 阻塞在 getresponse() 里的 _read_status
+_rb_call("slow_status", 1.0, 0.25, 16 * 0.25, "慢状态行")
+# 21b 响应头慢吐 —— 阻塞在 getresponse() 里的 parse_headers
+_rb_call("slow_headers", 1.0, 0.25, 12 * 0.25, "慢响应头")
+# 21c chunked 的分块头与尾部慢吐 —— 阻塞在 read1() 内部的 readline
+_rb_call("slow_chunk", 1.0, 0.8, 8 * 0.8, "慢分块头/尾部")
+# 21d Connection: close 下慢吐响应体 —— conn.sock 已被置空, 逐轮 settimeout 一次都不会执行
+_rb_call("close_body", 1.0, 0.8, 7 * 0.8, "close+慢响应体")
+
+# 21e 逐轮检查通过之后才到齐的完整 JSON: 内容完整 ≠ 按时到达
+_rb_reset("late_complete", 0.8)
+_dl21 = time.monotonic() + 1.0
+_t0 = time.monotonic()
+_r21 = bot.post("m", {}, _dl21)
+_el21 = time.monotonic() - _t0
+(ok if _RB["phase"].is_set() else bad)("21e 服务端确实进入了响应体阶段")
+(ok if not _r21.get("ok") else
+ bad)("21e 期限后才到齐的完整 JSON 不判为按时成功(实得 ok=%s)" % bool(_r21.get("ok")))
+(ok if _el21 <= 1.0 + 0.6 else
+ bad)("21e 及时终止(实耗 %.2fs)" % _el21)
+
+# 21f 超时结束的是**实际网络工作**: 连接收掉, 守卫定时器不堆积
+def _live_timers():
+    return [t for t in threading.enumerate() if isinstance(t, threading.Timer) and t.is_alive()]
+
+
+_rb_reset("close_body", 0.8)
+_t_before = len(_live_timers())
+for _ in range(3):
+    bot.post("m", {}, time.monotonic() + 0.6)
+time.sleep(1.5)                                   # 若有守卫没被取消, 这段时间足够暴露
+_t_after = len(_live_timers())
+(ok if getattr(bot._tls, "conn", None) is None else
+ bad)("21f 超期后连接已收掉(不是只让外层返回)")
+(ok if _t_after == _t_before else
+ bad)("21f 每次调用的守卫定时器都收干净(前 %d → 后 %d, 必须相等)" % (_t_before, _t_after))
+# 正常路径也不能漏: 成功返回时守卫要被 cancel 掉, 而不是留到期限自然到点
+_rb_reset("fast")
+_t_before2 = len(_live_timers())
+for _ in range(5):
+    bot.post("m", {}, time.monotonic() + 60)      # 期限很远: 没 cancel 就会挂 60s
+time.sleep(0.3)
+_t_after2 = len(_live_timers())
+(ok if _t_after2 == _t_before2 else
+ bad)("21f 正常返回也把守卫取消掉(前 %d → 后 %d; 5 次调用 60s 期限, 不取消必然堆 5 条)"
+      % (_t_before2, _t_after2))
+
+# 21g 已验证过的行为不能被这次修复破坏
+_rb_reset("fast")
+_t0 = time.monotonic()
+_r21g = bot.post("m", {}, time.monotonic() + 30)
+_el21g = time.monotonic() - _t0
+(ok if _r21g.get("ok") and _el21g < 1.0 else
+ bad)("21g 正常 Content-Length 照常成功(ok=%s, %.2fs)" % (bool(_r21g.get("ok")), _el21g))
+_rb_reset("fast")
+for _ in range(4):
+    bot.post("m", {}, time.monotonic() + 30)
+(ok if len(_RB["conns"]) == 1 else
+ bad)("21g keep-alive 仍复用同一条连接(实得 %d 条)" % len(_RB["conns"]))
+_rb_reset("fast")
+_r21n = bot.post("m", {})                         # deadline=None: 只有空闲超时, 不设期限
+(ok if _r21n.get("ok") else bad)("21g deadline=None 的默认路径照常成功")
+(ok if bot._tls.conn is not None and bot._tls.conn.timeout == bot.API_TIMEOUT else
+ bad)("21g deadline=None 恢复默认超时 %s(实得 %s)"
+      % (bot.API_TIMEOUT, bot._tls.conn and bot._tls.conn.timeout))
+
+# 21h 本地超时与"对端已收到请求"继续分别记账
+_rb_reset("close_body", 0.8)
+_r21h = bot.post("m", {}, time.monotonic() + 1.0)
+(ok if _RB["got"].is_set() and not _r21h.get("ok") else
+ bad)("21h 请求已到达对端(%s)但本地判超时(ok=%s) —— 不谎称撤回"
+      % (_RB["got"].is_set(), bool(_r21h.get("ok"))))
+
+_rb_reset("fast")
+_RB_SRV.close()
+bot.http = _prev_http
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 22. 回收器的 cancel() 窗口: 动作前必须重读撤销状态
+# ──────────────────────────────────────────────────────────────────────────────
+# 快照与动作之间隔着一段没有锁的窗口(锁外的 fut.cancel())。拿快照时的 revoked 裁决,
+# 就会给一个**窗口内已被撤销**的任务新建 notice/token —— 等于把撤销掉的写回权发回去。
+# 注意: 这一格不能只看五张表。修前那一次表全是零, 菜单照样被盖掉了。
+print()
+print("══ 22. 回收器 cancel() 窗口的四种交错(断言写入序列与最终页面) ══")
+
+
+def _reap_case(nav, label, expect_write):
+    _reset_state()
+    _tg22 = Tg()
+    bot.post = _tg22.post
+    _inwin = threading.Event()
+    _go = threading.Event()
+
+    class _CancelFut:
+        """收割器在**锁外**调 cancel() —— 产品里真实存在的那段窗口。"""
+
+        def cancel(self):
+            _inwin.set()
+            _go.wait(15)
+            return True
+
+    chat, mid = 2200, 220
+    with bot._upd_lock:
+        job = bot._upd_new_sess(chat, mid, time.monotonic() + bot.UPD_DELIVER_BUDGET - 1.0)
+        bot._upd_sess[(chat, mid)]["fut"] = _CancelFut()
+        bot._upd_inflight[chat] = job
+    if nav == "before":
+        bot._upd_invalidate(chat, mid)              # 快照之前就撤销
+    entered = _inwin.wait(15)
+    (ok if entered else bad)("22 %s: 收割器已**确认**进入 cancel 窗口(不靠 sleep 撞)" % label)
+    newjob = newtok = None
+    if nav == "inwindow":
+        bot._upd_invalidate(chat, mid)              # 窗口内撤销, 同一个 job
+    elif nav == "newjob":
+        with bot._upd_lock:                         # 产品里 _upd_new_sess 永远在锁内
+            newjob = bot._upd_new_sess(chat, mid, time.monotonic() + 120)
+            newtok = bot._upd_sess[(chat, mid)]["token"]
+            bot._upd_inflight[chat] = newjob
+    _go.set()
+    t0 = time.monotonic()
+    while bot._upd_notify_live and time.monotonic() - t0 < 15:
+        time.sleep(0.02)
+    time.sleep(0.6)
+    seq = [c[1].get("text", "")[:20] for c in _tg22.calls if c[0] == "editMessageText"]
+    cur = bot._upd_sess.get((chat, mid))
+    if expect_write:
+        (ok if seq and "排队过久" in seq[0] else
+         bad)("22 %s: 应得的过期提示照常给(写入序列 %s)" % (label, seq))
+    else:
+        (ok if not seq else
+         bad)("22 %s: 一个字都不该写回(写入序列 %s)" % (label, seq))
+    return seq, cur, newjob, newtok
+
+
+# 22a 导航发生在快照之前
+_reap_case("before", "导航在快照之前", False)
+# 22b 导航发生在快照之后、cancel() 尚未返回时(同一个 job) —— 本轮的目标缺口
+_seq22b, _cur22b, _, _ = _reap_case("inwindow", "导航在窗口内(同 job)", False)
+(ok if _cur22b is None else
+ bad)("22b 撤销过的任务没有靠新建 notice 续命(实得 kind=%r)" % (_cur22b and _cur22b.get("kind")))
+(ok if _tables() == (0, 0, 0, 0, 0) else
+ bad)("22b 状态也清干净(实得 %s)" % (_tables(),))
+# 22c 窗口内建立了新 job
+_seq22c, _cur22c, _nj22, _nt22 = _reap_case("newjob", "窗口内建立新 job", False)
+(ok if _cur22c is not None and _cur22c.get("job") == _nj22 else
+ bad)("22c 新任务的会话原样保留")
+(ok if _cur22c is not None and _cur22c.get("token") == _nt22 else
+ bad)("22c 新任务的写回权原样保留")
+(ok if _cur22c is not None and _cur22c.get("kind") == "check" else
+ bad)("22c 新任务没被 notice 顶掉(实得 kind=%r)" % (_cur22c and _cur22c.get("kind")))
+(ok if bot._upd_inflight.get(2200) == _nj22 else
+ bad)("22c 新任务的名额没被旧任务让出去")
+with bot._upd_lock:
+    if _nj22:
+        bot._upd_drop_sess(2200, 220, _nj22)
+# 22d 未导航、未替换: 正常过期仍能收到应有提示
+_seq22d, _, _, _ = _reap_case("none", "未导航未替换正常过期", True)
+(ok if _drain() == (0, 0, 0, 0, 0) else
+ bad)("22d 结束后五张表零残留(实得 %s)" % (_drain(),))
 
 _reset_state()
 bot.post = _REAL_POST

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -53,6 +53,7 @@ subprocess.run(["git", "-C", REPO, "fetch", "-q", "--tags", "origin"], check=Fal
 bot.PDG_REPO = REPO
 _REAL_GIT = bot._git
 _REAL_UPDATE_CHECK = bot.update_check      # 后面几节会拿桩替换它, 用完要还回来
+_REAL_FETCH_TAGS = bot._fetch_release_tags
 
 
 def at(rev):
@@ -237,11 +238,13 @@ bot.handle_cb(101, 11, "upd_check")
 elapsed = time.monotonic() - t0
 (ok if elapsed < 1.0 else bad)("回调立即返回(%.2fs), 主轮询未被占用" % elapsed)
 started.wait(5)
-(ok if not bot._upd_check_async(101, 11) else bad)("同会话在飞时重复点击被拒(不无限提交)")
+(ok if bot._upd_check_async(101, 11)[0] == bot.ACCEPT_BUSY else
+ bad)("同会话在飞时重复点击被拒为 BUSY(不无限提交)")
 bot.handle_cb(101, 11, "upd_check")
 busy = [t for t in tg.texts("editMessageText") if "还在跑" in t]
 (ok if busy else bad)("重复点击有明确反馈: %r" % (busy[0][:40] if busy else "<无>"))
-(ok if bot._upd_check_async(202, 22) else bad)("另一个会话不受影响, 可独立发起")
+(ok if bot._upd_check_async(202, 22)[0] == bot.ACCEPT_OK else
+ bad)("另一个会话不受影响, 可独立发起")
 gate.set(); time.sleep(0.6)
 (ok if 101 not in bot._upd_inflight and 202 not in bot._upd_inflight else
  bad)("检查结束后占用释放(在飞表: %r)" % (dict(bot._upd_inflight),))
@@ -277,14 +280,32 @@ tg = Tg(); tg.fail_edit = 99; with_tg(tg)
 bot._upd_check_async(404, 44); time.sleep(0.8)
 n_edit = sum(1 for m, _ in tg.calls if m == "editMessageText")
 n_send = sum(1 for m, _ in tg.calls if m == "sendMessage")
-(ok if n_edit <= 2 else bad)("编辑一直失败时调用有界(editMessageText %d 次 ≤ 2)" % n_edit)
+# 上界是**算出来的**, 不是拍的: 一次检查最多两次 emit(进度 + 终态), 每次 emit 走 edit_only
+# 最多两次 API 调用(HTML 一次 + 纯文本回退一次) → 2 × 2 = 4。
+_MAX_EDITS = 2 * 2
+(ok if n_edit <= _MAX_EDITS else
+ bad)("编辑一直失败时调用有界(editMessageText %d 次 ≤ %d = 2 emit × 2 次)" % (n_edit, _MAX_EDITS))
 (ok if n_send == 0 else bad)("编辑失败不补发新消息(sendMessage %d 次)" % n_send)
 (ok if 404 not in bot._upd_inflight else bad)("编辑失败后占用释放")
 
 tg = Tg(); tg.unreachable = True; with_tg(tg)
 bot._upd_check_async(505, 55); time.sleep(0.8)
 (ok if 505 not in bot._upd_inflight else bad)("API 完全不可达: 服务端任务仍结束、占用释放")
-(ok if len(tg.calls) <= 2 else bad)("不可达时投递尝试有界(%d 次)" % len(tg.calls))
+(ok if len(tg.calls) <= _MAX_EDITS else
+ bad)("不可达时投递尝试有界(%d 次 ≤ %d)" % (len(tg.calls), _MAX_EDITS))
+# 初始提示与忙反馈同样不能因为网络慢而拖住主轮询 —— 这两条也走后台。
+tg = Tg(); tg.unreachable = True; tg.delay = 0.8; with_tg(tg)
+_t0 = time.monotonic(); bot.handle_cb(506, 56, "upd_check"); _e1 = time.monotonic() - _t0
+_t0 = time.monotonic(); bot.handle_cb(506, 56, "upd_check"); _e2 = time.monotonic() - _t0
+(ok if _e1 < 0.3 and _e2 < 0.3 else
+ bad)("不可达+慢响应下, 初始提示(%.2fs)与忙反馈(%.2fs)都不占主轮询" % (_e1, _e2))
+# 有界轮询, 不用固定 sleep 撞运气: 4 次 ×0.8s 的慢响应 + 收尾, 给它 15 秒上限。
+_t0 = time.monotonic()
+while 506 in bot._upd_inflight and time.monotonic() - _t0 < 15:
+    time.sleep(0.1)
+(ok if 506 not in bot._upd_inflight else
+ bad)("慢+不可达之后占用仍释放(等了 %.1fs)" % (time.monotonic() - _t0))
+tg.delay = 0.0
 
 print()
 print("══ 7. 超时后本次 git 子进程被收干净(不是只证明外层函数返回) ══")
@@ -323,9 +344,12 @@ bot.start_update = lambda: called.append("start_update") or True
 _real_sh = bot.sh
 bot.sh = lambda cmd, input=None: called.append(list(cmd)) or _R(0, "", "")
 bot._git = _REAL_GIT
+bot.update_check = _REAL_UPDATE_CHECK      # **必须验真实实现** —— 前面几节把它换成过桩
 at("v1.11.3")
 no_fetch()
 has, _txt = bot.update_check()
+(ok if has and "有新发布" in _txt else
+ bad)("这一节确实跑的是真实 update_check(has=%s, %r)" % (has, _txt[:36]))
 bot.start_update, bot.sh = _real_start, _real_sh
 (ok if not called else bad)("检查全程没有调用 start_update / pdg CLI(实得 %r)" % (called[:2],))
 (ok if 'systemd-run' in src and 'if data == "upd_apply"' in src else
@@ -341,14 +365,21 @@ def _budget_git(*a, t=60):
     _seen.append((a[0], round(t, 2)))
     if a[0] == "describe":
         time.sleep(0.4)
-    return _R(0, {"describe": "v1.0.0", "tag": "v9.9.9\n", "rev-parse": "aaa",
-                  "merge-base": "", "log": "1111111 x\n"}.get(a[0], "x"))
+    # HEAD 与目标提交**必须不同**, 否则会在"已是最新"提前返回, log / 渲染那几步根本不跑。
+    if a[0] == "rev-parse":
+        return _R(0, "bbbbbbb" if (a[1:2] and str(a[1]).startswith("v")) else "aaaaaaa")
+    return _R(0, {"describe": "v1.0.0", "tag": "v9.9.9\n",
+                  "merge-base": "", "log": "1111111 x\n", "config": ""}.get(a[0], "x"))
 
 
 bot._git = _budget_git
 no_fetch()
-bot.update_check(budget=2.0)
+_bh, _bt = bot.update_check(budget=2.0)
 bot._git = _REAL_GIT
+(ok if _bh and "有新发布" in _bt else
+ bad)("总预算这一格确实走完了 log/渲染(has=%s, %r)" % (_bh, _bt[:36]))
+(ok if any(x[0] == "log" for x in _seen) and any(x[0] == "config" for x in _seen) else
+ bad)("走过 log 与 origin 查询(实得阶段 %r)" % ([x[0] for x in _seen],))
 _caps = [t for _, t in _seen]
 (ok if _caps and all(_caps[i] >= _caps[i + 1] for i in range(len(_caps) - 1)) else
  bad)("各步骤拿到的超时单调不增(实得 %r)" % (_caps,))
@@ -377,6 +408,246 @@ else:
     (ok if (not _has and "❌" in _txt and "超时" in _txt) else
      bad)("预算耗尽 → 终态超时失败(实得 has=%s %r)" % (_has, _txt[:44]))
 (ok if _el < 10 else bad)("预算耗尽后很快返回(%.2fs), 没有把任务吊住" % _el)
+
+print()
+print("══ 10. fetch 成功后 shallow 状态读不出 —— 不能当作非浅仓库继续报绿 ══")
+# 这一格**不能用 no_fetch 替身**: 要真的走进 _fetch_release_tags, 让 fetch 成功、
+# 紧跟的 rev-parse --is-shallow-repository 出错。
+bot.update_check = _REAL_UPDATE_CHECK
+bot._fetch_release_tags = _REAL_FETCH_TAGS      # 这一格必须走真实实现, 不能被 no_fetch 遮住
+for _rc, _out, _name in ((128, "fatal: bad", "非零返回"), (0, "", "空输出"), (0, "maybe", "非法取值")):
+    def _shallow_bad(*a, t=60, _rc=_rc, _out=_out):
+        if a[0] == "fetch":
+            return _R(0, "", "")
+        if a[0] == "rev-parse" and a[1:2] == ("--is-shallow-repository",):
+            return _R(_rc, _out, "")
+        return _REAL_GIT(*a, t=t)
+    bot._git = _shallow_bad
+    _o, _e = bot._fetch_release_tags()
+    _h, _t = bot.update_check()
+    bot._git = _REAL_GIT
+    (ok if (not _o and not _h and "❌" in _t and "🟢" not in _t) else
+     bad)("shallow %s → fetch 判失败(%s)且检查报 ❌ 不报绿(%r)" % (_name, _o, _t[:40]))
+no_fetch()
+
+print()
+print("══ 11. 全局准入 / 提交拒绝 / 排队过期 ══")
+tg = Tg(); with_tg(tg)
+_hold = threading.Event()
+bot.update_check = lambda budget=None: (_hold.wait(20), (True, "🔄 x"))[1]
+_acc = [bot._upd_check_async(900 + i, 90 + i)[0] for i in range(bot.UPD_MAX_INFLIGHT + 6)]
+_n_ok = _acc.count(bot.ACCEPT_OK)
+(ok if _n_ok == bot.UPD_MAX_INFLIGHT else
+ bad)("全局准入上限 %d(实得受理 %d)" % (bot.UPD_MAX_INFLIGHT, _n_ok))
+(ok if bot.ACCEPT_FULL in _acc else bad)("超出上限的会话得到 FULL, 不是排进无界队列")
+(ok if bot.UPD_MAX_INFLIGHT > bot._EXEC._max_workers else
+ bad)("上限独立于线程数(worker %d) —— 线程有限不等于队列有界" % bot._EXEC._max_workers)
+_hold.set()
+_t0 = time.monotonic()
+while bot._upd_inflight and time.monotonic() - _t0 < 20:
+    time.sleep(0.1)
+(ok if not bot._upd_inflight else bad)("全部结束后在飞表清空(%r)" % (dict(bot._upd_inflight),))
+
+tg = Tg(); with_tg(tg)
+_real_submit = bot._EXEC.submit
+bot._EXEC.submit = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("closed"))
+_v, _tk = bot._upd_check_async(910, 91)
+(ok if _v == bot.ACCEPT_SUBMIT_FAIL and _tk is None else
+ bad)("提交失败返回 SUBMIT_FAIL 而不是 BUSY(实得 %r)" % (_v,))
+(ok if 910 not in bot._upd_inflight else bad)("提交失败后占用不残留")
+bot.handle_cb(910, 91, "upd_check")     # 仍在"提交必失败"状态下走真实回调
+time.sleep(0.5)
+bot._EXEC.submit = _real_submit
+_txts = tg.texts("editMessageText")
+(ok if any("未受理" in t for t in _txts) and not any("还在跑" in t for t in _txts) else
+ bad)("提交失败的反馈说「未受理」, 不冒充「还在跑」(实得 %r)" % (_txts[:2],))
+
+tg = Tg(); with_tg(tg)
+bot.update_check = lambda budget=None: (True, "🔄 不该跑到这里")
+_calls = []
+_orig_uc = bot.update_check
+bot.update_check = lambda budget=None: (_calls.append(1), (True, "🔄 不该跑到这里"))[1]
+_v, _tk = bot._upd_check_async(920, 92)
+with bot._upd_lock:                      # 人为把截止时间调到只剩一点点 = 排队过久
+    bot._upd_sess[(920, 92)]["deadline"] = time.monotonic() + 1.0
+time.sleep(1.5)
+_t0 = time.monotonic()
+while 920 in bot._upd_inflight and time.monotonic() - _t0 < 10:
+    time.sleep(0.1)
+_txts = tg.texts("editMessageText")
+(ok if any("排队过久" in t for t in _txts) else
+ bad)("排队过期 → 终态说明未执行(实得 %r)" % (_txts[-1:],))
+(ok if not _calls else bad)("排队过期这一格确实提交过任务") if False else None
+(ok if 920 not in bot._upd_inflight else bad)("排队过期后占用释放")
+
+print()
+print("══ 12. 断言最终消息内容 / 目标 mid / 写入顺序 / 任务状态 ══")
+tg = Tg(); with_tg(tg)
+bot.update_check = lambda budget=None: (True, "🔄 终态-内容校验")
+bot.handle_cb(930, 93, "upd_check")
+_t0 = time.monotonic()
+while 930 in bot._upd_inflight and time.monotonic() - _t0 < 10:
+    time.sleep(0.1)
+_seq = [(m, p.get("message_id"), (p.get("text") or "")[:14]) for m, p in tg.calls]
+(ok if all(m == "editMessageText" for m, _i, _t in _seq) else
+ bad)("全程只用 editMessageText, 没有补发(实得 %r)" % (_seq,))
+(ok if all(i == 93 for _m, i, _t in _seq) else
+ bad)("所有写入都打在发起它的那条消息上(mid=93; 实得 %r)" % ([i for _m, i, _t in _seq],))
+_texts = [t for _m, _i, t in _seq]
+(ok if _texts and "检查更新中" in _texts[0] else bad)("第一条是进度(实得 %r)" % (_texts[:1],))
+(ok if _texts and "终态-内容校验" in _texts[-1] else
+ bad)("最后一条是终态内容本身(实得 %r)" % (_texts[-1:],))
+(ok if 930 not in bot._upd_inflight and (930, 93) not in bot._upd_sess else
+ bad)("任务结束后在飞表与会话表都已清理")
+
+print()
+print("══ 13. 交错(屏障控制): 终态不倒退 / 忙反馈不覆盖 / 新页面不被旧结果取代 ══")
+
+
+class GateTg:
+    """按**文案关键字**设闸的接收端: 精确控制哪一条先出发、哪一条后落地。"""
+
+    def __init__(self):
+        self.log = []
+        self.lock = threading.Lock()
+        self.gates = {}
+        self.waiters = {}          # 哪一条已经**进到网络调用里**被闸挡住了
+
+    def post(self, method, params):
+        txt = params.get("text") or ""
+        for k, g in list(self.gates.items()):
+            if k in txt:
+                with self.lock:
+                    self.waiters[k] = self.waiters.get(k, 0) + 1
+                g.wait(15)
+        with self.lock:
+            self.log.append((method, params.get("message_id"), txt[:18].replace("\n", " ")))
+        return {"ok": True, "result": {"message_id": params.get("message_id") or 999}}
+
+    def seq(self):
+        with self.lock:
+            return [t for _m, _i, t in self.log]
+
+
+def _reset_state():
+    with bot._upd_lock:
+        bot._upd_inflight.clear()
+        bot._upd_sess.clear()
+
+
+def _settle(chat, limit=20):
+    t0 = time.monotonic()
+    while chat in bot._upd_inflight and time.monotonic() - t0 < limit:
+        time.sleep(0.05)
+
+
+def _quiesce(gt, limit=8):
+    """等写入序列**稳定**下来再读 —— 只等任务释放是不够的: 被闸住的那条线程可能还没落地,
+    过早取样会让"乱序覆盖"看起来没发生(这一处我自己踩过)。"""
+    t0 = time.monotonic()
+    prev = None
+    while time.monotonic() - t0 < limit:
+        cur = tuple(gt.seq())
+        if cur == prev and cur:
+            return
+        prev = cur
+        time.sleep(0.15)
+
+
+def _wait_gate(gt, key, limit=10):
+    """等到那一条**确实进到了网络调用里**再往下走 —— 不用固定 sleep 撞窗口。"""
+    t0 = time.monotonic()
+    while gt.waiters.get(key, 0) < 1 and time.monotonic() - t0 < limit:
+        time.sleep(0.02)
+    return gt.waiters.get(key, 0) >= 1
+
+
+# 13a 结果早于初始提示完成 —— 终态不得被"检查中"覆盖
+_reset_state()
+gt = GateTg(); bot.post = gt.post
+_done = threading.Event()
+bot.update_check = lambda budget=None: (_done.set(), (True, "🔄 终态A"))[1]
+gt.gates["检查更新中"] = threading.Event()          # 卡住进度这一条
+bot.handle_cb(1001, 101, "upd_check")
+_done.wait(5); time.sleep(0.2)
+gt.gates["检查更新中"].set(); _settle(1001); _quiesce(gt)
+_s = gt.seq()
+(ok if _s and "终态A" in _s[-1] else
+ bad)("13a 结果早于进度完成 → 最后落地仍是终态(实得 %r)" % (_s,))
+
+# 13b 忙反馈**先进入网络调用**、终态随后 —— 落地顺序不得倒过来
+_reset_state()
+gt = GateTg(); bot.post = gt.post
+_rel = threading.Event()
+bot.update_check = lambda budget=None: (_rel.wait(15), (True, "🔄 终态B"))[1]
+bot.handle_cb(1002, 102, "upd_check")
+_wait_gate(gt, "检查更新中") if "检查更新中" in gt.gates else time.sleep(0.3)
+gt.gates["还在跑"] = threading.Event()
+_th = threading.Thread(target=bot.handle_cb, args=(1002, 102, "upd_check")); _th.start()
+(ok if _wait_gate(gt, "还在跑") else bad)("13b 忙反馈已进入网络调用(窗口成立)")
+_rel.set(); time.sleep(0.4)              # 终态在此期间产生
+gt.gates["还在跑"].set(); _th.join(10); _settle(1002); _quiesce(gt)
+_s = gt.seq()
+(ok if _s and "终态B" in _s[-1] else
+ bad)("13b 忙反馈先出发也不覆盖终态(实得 %r)" % (_s,))
+
+# 13d 终态**已在网络调用里**时才点第二次 —— 忙反馈必须被阶段序拒掉, 一个字都不写
+_reset_state()
+gt = GateTg(); bot.post = gt.post
+gt.gates["终态D"] = threading.Event()
+bot.update_check = lambda budget=None: (True, "🔄 终态D")
+bot.handle_cb(1004, 104, "upd_check")
+(ok if _wait_gate(gt, "终态D") else bad)("13d 终态已进入网络调用(窗口成立)")
+_th = threading.Thread(target=bot.handle_cb, args=(1004, 104, "upd_check")); _th.start()
+time.sleep(0.4)
+gt.gates["终态D"].set(); _th.join(10); _settle(1004); _quiesce(gt)
+_s = gt.seq()
+(ok if _s and "终态D" in _s[-1] else bad)("13d 最后落地仍是终态(实得 %r)" % (_s,))
+(ok if not any("还在跑" in x for x in _s) else
+ bad)("13d 终态已落地后, 忙反馈被阶段序拒掉、一个字都不写(实得 %r)" % (_s,))
+
+# 13e 连点三次 —— "还在跑"只能写一次(阶段序把重复的低阶段写入挡掉)
+_reset_state()
+gt = GateTg(); bot.post = gt.post
+_rel = threading.Event()
+bot.update_check = lambda budget=None: (_rel.wait(15), (True, "🔄 终态E"))[1]
+bot.handle_cb(1005, 105, "upd_check")
+gt.gates["还在跑"] = threading.Event()
+_ths = [threading.Thread(target=bot.handle_cb, args=(1005, 105, "upd_check")) for _ in range(3)]
+for _t in _ths:
+    _t.start()
+(ok if _wait_gate(gt, "还在跑") else bad)("13e 至少一条忙反馈进入了网络调用")
+time.sleep(0.4)
+gt.gates["还在跑"].set()
+for _t in _ths:
+    _t.join(10)
+_rel.set(); _settle(1005); _quiesce(gt)
+_s = gt.seq()
+_n_busy = sum(1 for x in _s if "还在跑" in x)
+(ok if _n_busy == 1 else
+ bad)("13e 连点三次只写一条忙反馈(实得 %d 条; 序列 %r)" % (_n_busy, _s))
+(ok if _s and "终态E" in _s[-1] else bad)("13e 最后落地仍是终态(实得 %r)" % (_s,))
+
+# 13c 已过 token 检查、正在投递时用户返回菜单 —— 新页面最终不被旧结果取代
+_reset_state()
+gt = GateTg(); bot.post = gt.post
+_rel = threading.Event()
+bot.update_check = lambda budget=None: (_rel.wait(15), (True, "🔄 旧结果C"))[1]
+bot.handle_cb(1003, 103, "upd_check"); time.sleep(0.3)
+gt.gates["旧结果C"] = threading.Event()
+_rel.set(); time.sleep(0.4)
+_rs = bot.status_text
+bot.status_text = lambda: "（主菜单C）"
+try:
+    bot.handle_cb(1003, 103, "menu")
+finally:
+    bot.status_text = _rs
+time.sleep(0.2); gt.gates["旧结果C"].set(); _settle(1003); _quiesce(gt)
+_s = gt.seq()
+(ok if _s and "主菜单C" in _s[-1] else
+ bad)("13c 导航抢写后收敛回新页面(实得 %r)" % (_s,))
+(ok if any("旧结果C" in x for x in _s) else
+ bad)("13c 如实记录: 旧结果那一次请求确实到达过, 收敛不是撤回(实得 %r)" % (_s,))
 
 print()
 print("-" * 62)


### PR DESCRIPTION
## 已复现的问题

用户反复遇到「检查更新中…」不结束。在隔离环境里逐个复现出来的根因，不是推测：

- **消息超长**：跨度大时整段 `git log` 拼进一条消息。实测 v1.11.3 → v1.11.14 约 10.6k 字符，超 Telegram 4096 上限，编辑与补发都失败，页面就停在「检查更新中…」。
- **异常不成终态**：`try` 只包到 `fetch/describe/tag`，后面的 `rev-parse / merge-base / log` 一旦超时就把异常抛给回调，回调拿不到终态。
- **同步占住轮询**：检查跑在主 `getUpdates` 循环里，这段时间整个 bot 不响应任何菜单。

顺着这条链路还复现出四类：

- **消息顺序**：阶段序只管准入不管落地，两次写入可以乱序到达；忙提示能盖掉已落地的终态。
- **导航归属**：导航把写入权置空后，排队中的任务启动时也取到空 token，`None == None` 让它重新获得写回权，跑完 Git 再把旧结果盖到用户当前页面上。
- **排队与回收**：线程池队列无界，worker 被占满时超期的检查没人裁决；回收器用快照时的撤销状态裁决，窗口内的导航撤销被无视，过期提示盖掉菜单。
- **通知生命周期**：投递完只清待发表，会话与身份留在表里；两个 worker 只限同时投递、不限排队（实测 300 次点击排出 298 条待发）；合并只覆盖排队阶段，在飞阶段会重复排一份。

绝对期限方面另外复现出：复用的连接不按剩余预算重设超时（150s 预算跑掉 109s 后仍用建连时的 70s）；响应读取只受 socket **空闲**超时约束——对端逐字节慢吐时它永远不触发，实测 1.00s 预算的调用跑到 4.26s，且期限后才到齐的完整 JSON 被判为按时成功。

## 修复行为

- **消息长度预算**：按预算裁剪，单条超长标题裁短后展示而不是整条丢弃。
- **后台检查**：受理只动内存表，主轮询不做网络调用、不等投递锁。
- **明确失败终态**：整条链路都在 `try` 里；判不出来就说判不出来，不退回「已是最新」；不回显可能含凭据的 git stderr。
- **消息顺序**：单一写入通道 = 阶段序管准入 + per-message 投递锁管落地顺序。
- **导航撤销**：稳定身份（清理用）与可撤销写入权（写回用）分开；空 token 不是写入权而是「已被撤销」；排队期间被撤销的任务启动即结束，不跑 Git、不发进度、不发终态；回收器在动作前于锁内**重读**身份与写入权再裁决。
- **响应期限**：期限覆盖状态行、响应头、分块头与尾部、响应体——前三类分别在 `getresponse()` 与 `read1()` 内部，调用方的循环够不到，由一个按绝对时刻 `shutdown` socket 的守卫兜底；读完后再判一次，内容完整不等于按时到达。
- **通知准入与精确清理**：在跑的通知有全局上限，满载当场拒绝且不留会话；合并覆盖排队与在飞两个阶段；成功 / 失败 / 过期 / 导航作废 / 提交失败五条路径都精确释放自己那一份。

## 证据分层

- **目标正控 207/0，已有 CI 证据**：`workflow_dispatch` run [34333372898](https://github.com/misaka-cpu/privdns-gateway/actions/runs/34333372898)，`attempt=1`，head 为本分支冻结提交，32/32 jobs、657/657 steps success。checkout 步骤自身输出证明实际检出对象。
- **完整负控 38/0 是本地手动证据，未登记 CI**：35 格目标变异全部有牙、反向对照零新增、正式树 sha256/mode 保护成立。这一支不在 workflow 里，**不能当作 CI 已验证**。

## 完整范围

本 PR **有生产修改**：`deploy/bot/pdg-bot.py` +783/−50，是本 PR 唯一的生产文件。整体 15 笔线性提交、0 merge、5 文件 +2898/−54（其余为正控 +1757、负控 +333、导航守卫 +19/−4、workflow 登记 +6/−0）。

审查面是这**整个范围**。最后一次推送没有改生产，不代表本 PR 没有生产修改——请按上面的全量口径审查。

## 既有告警与脚本跳过

CI 全绿不等于零跳过、零告警。完整 run 的实测（全部 32 个 job，单一表示不重复计数）：

| 项 | 本分支 | 基线 main | 说明 |
|---|---|---|---|
| GitHub step skipped | 0 | 0 | jobs API：657 步全 success |
| 脚本 `[SKIP]` 输出 | 16 | 16 | **逐条文本完全一致** |
| `SyntaxWarning` | 16 行（4 个唯一） | 16 行（4 个唯一） | 分布一致 |
| `##[warning]` / `##[error]` | 0 / 0 | 0 / 0 | |

`SyntaxWarning` 来自四处既有的正则转义（`test-firewall-template-sync.py:137`、`test-provider-query-boundary.py:2`、`test-dot-render.py:48`、`test-ratelimit-judgement.py:2`）。这些跳过与告警都是仓库的**既有边界，不是本分支引入**，本 PR 也没有处理它们。

另需说明：`[SKIP]` 计数只算行首即 `[SKIP]` 的真实跳过输出；另有 3 行含该关键字但属守卫步骤的命令回显与断言文本，不计入。

## 尚未验证的边界

1. **建连、TLS 握手、请求发送尚未证明统一硬期限**。守卫要先拿到 socket 才能武装，而 socket 是 `request()` 之后才有的；这几段目前只受 `min(API_TIMEOUT, 剩余)` 的 socket 超时约束，单次阻塞不越期，但握手的多次往返理论上仍可累计超出。**不能承诺任何网络条件下 150 秒必结束。**
2. **明文回环测试不等于真实 Telegram 或生产验收**。期限那一节用的是 127.0.0.1 上自建的明文 HTTP 服务，TLS 层的阻塞特性不在判据内。
3. **旧版本消息检查回放不等于任意旧版本完整升级事务通过**。回放的只是「检查更新」这条消息链路，不是升级事务本身。
4. **修复不会自动到达仍运行旧 Bot 的机器**。已在运行旧版本的机器需要各自更新才能拿到这些行为。
5. **SSH 更新绕过 Telegram 消息链，但第一次运行仍是旧机器上的 CLI**，不能套用最新版的全部保护措施。

这些问题是在隔离环境里复现并定位的，**不是从受影响用户现场取到的根因**；也没有部署过，历史升级问题不在本 PR 的验证范围内。
