### PR TITLE
test(bot): isolate release fixtures and make deadline assertions deterministic

### DIFF
--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -17,6 +17,7 @@ import importlib.util
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -117,15 +118,78 @@ for base, want_has in (("v1.11.3", True), ("v1.11.10", True), ("v1.11.13", True)
     good = has == want_has and len(txt) <= bot.UPD_MSG_BUDGET
     (ok if good else bad)("%-9s → has=%s 消息 %d 字符 ≤ 预算 %d"
                           % (base, has, len(txt), bot.UPD_MSG_BUDGET))
-at("v1.11.14") or at("HEAD")
-_head = _REAL_GIT("rev-parse", "HEAD").stdout.strip()
-_tag = _REAL_GIT("rev-parse", "v1.11.14^{commit}").stdout.strip()
-if _head == _tag:
+# ── 无更新 / 有更新 的状态转换: 用**完全自有**的仓库, 不看宿主发布了什么 ──────────
+# 以前这里 checkout v1.11.14 然后断言"已是最新"。那把**当期发布版本钉进了断言**:
+# v1.11.15 一发布, 从 v1.11.14 看当然"有新发布", 这一格就自动变红 —— 它红的是
+# 仓库又发了一版, 不是产品坏了。自指的判据没有价值, 每次发版都要来改一次。
+#
+# 现在给这个场景一个自己的 Git 仓库: 自造提交、自造 tag、自己说了算。
+# 注意**不能用 git worktree** —— worktree 与主仓库共享 refs/tags, 在里面建 tag 会写到
+# 共享仓库上去。必须是独立 .git 的仓库(git init), 才谈得上 tag 隔离。
+_SB = tmpguard.mkdtemp(prefix="pdg-updcheck-sandbox.")
+
+
+def _sbgit(*a, **kw):
+    return subprocess.run(["git", "-C", _SB, *a], capture_output=True, text=True, **kw)
+
+
+def _sb_commit(msg):
+    """在自有仓库里造一笔提交, 返回它的 sha。"""
+    open(os.path.join(_SB, "f.txt"), "a", encoding="utf-8").write(msg + "\n")
+    _sbgit("add", "f.txt")
+    _sbgit("commit", "-q", "-m", msg)
+    return _sbgit("rev-parse", "HEAD").stdout.strip()
+
+
+# 建仓库并钉死身份, 免得读到用户的 git config
+_sbgit("init", "-q", "-b", "main")
+for k, v in (("user.email", "fixture@example.invalid"), ("user.name", "fixture"),
+             ("commit.gpgsign", "false"), ("tag.gpgsign", "false")):
+    _sbgit("config", k, v)
+# 安全护栏: 确认待会儿动 tag 的确实是这个自有仓库, 不是共享仓库/用户仓库
+_sb_gitdir = _sbgit("rev-parse", "--absolute-git-dir").stdout.strip()
+(ok if _sb_gitdir == os.path.join(_SB, ".git") and _SB.startswith(tempfile.gettempdir())
+ else bad)("1x 版本场景用的是自己的独立仓库(独立 .git, 非 worktree/共享仓库; 实得 %s)"
+           % _sb_gitdir)
+
+_C1 = _sb_commit("base")
+_sbgit("tag", "-a", "v9.0.0", "-m", "v9.0.0")
+_C2 = _sb_commit("next")           # 后继提交, 先不打 tag
+
+_prev_repo = bot.PDG_REPO
+try:
+    bot.PDG_REPO = _SB
+    # A. HEAD 正好停在自有仓库的最新 tag 上 → 已是最新
+    _sbgit("checkout", "-q", "--detach", "v9.0.0")
     has, txt = bot.update_check()
-    (ok if (not has and "🟢" in txt and "❌" not in txt) else
-     bad)("已是最新 → has=False 且报绿(实得 has=%s, %r)" % (has, txt[:50]))
-else:
-    print("  [SKIP] 当前不在 v1.11.14 上, 无更新那一格未执行")
+    (ok if (not has and "🟢" in txt and "❌" not in txt and "v9.0.0" in txt) else
+     bad)("1A HEAD=最新 tag → has=False 且报绿并点名 v9.0.0(实得 has=%s, %r)"
+          % (has, txt[:60]))
+
+    # B. 同一个仓库里新增一个指向后继提交的更高版本 tag, HEAD 不动 → 应报有更新
+    #    这一步就是以前要"等真实发版"才能覆盖的转换, 现在一次测试里就能走完。
+    _sbgit("tag", "-a", "v9.1.0", "-m", "v9.1.0", _C2)
+    has, txt = bot.update_check()
+    (ok if (has and "v9.1.0" in txt and "🟢 已是最新" not in txt) else
+     bad)("1B 出现更高版本 tag 而 HEAD 未动 → has=True 且点名 v9.1.0, 不再报「已是最新」"
+          "(实得 has=%s, %r)" % (has, txt[:60]))
+
+    # C. HEAD 跟进到新 tag → 重新变成已是最新, 且点名的是**新**版本
+    _sbgit("checkout", "-q", "--detach", "v9.1.0")
+    has, txt = bot.update_check()
+    (ok if (not has and "🟢" in txt and "v9.1.0" in txt and "v9.0.0" not in txt) else
+     bad)("1C HEAD 跟到新 tag → has=False 且点名 v9.1.0(不是旧的 v9.0.0; 实得 has=%s, %r)"
+          % (has, txt[:60]))
+
+    # D. 宿主仓库的发布 tag 集合变了也不影响这一组 —— 它们只看自己的输入。
+    #    这里直接核对: 自有仓库里根本没有宿主那套 v1.11.x。
+    _sb_tags = _sbgit("tag", "-l", "v*", "--sort=-v:refname").stdout.split()
+    (ok if _sb_tags == ["v9.1.0", "v9.0.0"] else
+     bad)("1D 自有仓库的 tag 集合完全自定(实得 %s), 不含宿主发布 tag" % _sb_tags)
+    (ok if not any(t.startswith("v1.11.") for t in _sb_tags) else
+     bad)("1D 自有仓库不借用宿主 latest —— 宿主再发版也不会改变 A/B/C 的前提")
+finally:
+    bot.PDG_REPO = _prev_repo       # 不污染后面的故障 / 后台 / 导航 / 期限场景
 
 # 这条标题长到「不裁就放不进预算」——于是能同时验两件事: 整条消息仍在预算内, 而且那条提交
 # 是被**裁短后展示**的, 不是整条丢掉(丢掉的话用户一条摘要也看不到)。

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -13,7 +13,9 @@
 本支不连真实 Telegram、不用真实 token、不访问生产, git 用**克隆到临时目录的隔离仓库**
 (只读本地对象, 不碰共享 refs/tag/remote), 也从不调用真实升级入口。
 """
+import contextlib
 import importlib.util
+import io as _io
 import os
 import subprocess
 import sys
@@ -128,32 +130,218 @@ for base, want_has in (("v1.11.3", True), ("v1.11.10", True), ("v1.11.13", True)
 # 共享仓库上去。必须是独立 .git 的仓库(git init), 才谈得上 tag 隔离。
 _SB = tmpguard.mkdtemp(prefix="pdg-updcheck-sandbox.")
 
+_SB_CFG = (("user.email", "fixture@example.invalid"), ("user.name", "fixture"),
+           ("commit.gpgsign", "false"), ("tag.gpgsign", "false"))
+
+
+class _SbAbort(Exception):
+    """夹具初始化的**硬停**。
+
+    夹具自己出错时必须就地停住, 不能继续往下走 —— 否则后面那些产品断言会替夹具的
+    错误兜底: git init 失败了还去 config/commit/tag, 最终红的是某条产品判据,
+    看起来像产品坏了, 实际是夹具压根没建起来。
+    """
+
+    def __init__(self, reason):
+        Exception.__init__(self, reason)
+        self.reason = reason
+
+
+def _sb_die(reason):
+    raise _SbAbort(reason)
+
 
 def _sbgit(*a, **kw):
     return subprocess.run(["git", "-C", _SB, *a], capture_output=True, text=True, **kw)
 
 
+def _sb_must(run, *a):
+    """必需的 git 操作: 退出码非零就点名停住, 不静默继续。"""
+    r = run(*a)
+    if r.returncode != 0:
+        _sb_die("git %s 失败(返回 %d): %s"
+                % (" ".join(a[:2]), r.returncode, (r.stderr or r.stdout or "").strip()[:80]))
+    return r
+
+
+def _sb_check_owned(gitdir, sb):
+    """确认 Git 元数据确实属于**本轮自建**的那个独立仓库。
+
+    两件事都要成立, 任一不成立就硬停:
+      · git 目录正好是 <sb>/.git —— worktree 的 git 目录会指到主仓库的
+        .git/worktrees/... 去, 在那里打 tag 会写进共享仓库;
+      · sandbox 落在系统临时目录**之内**。
+
+    路径比较走 realpath + commonpath, **不是字符串 startswith**:
+    "/tmp/xy" 以 "/tmp/x" 开头在字符串上成立, 在路径上不成立 —— 拿前缀当边界,
+    真出事的时候正好拦不住。
+    """
+    real_git = os.path.realpath(gitdir)
+    real_sb = os.path.realpath(sb)
+    real_tmp = os.path.realpath(tempfile.gettempdir())
+    want = os.path.join(real_sb, ".git")
+    if real_git != want:
+        _sb_die("git 目录不属于本轮自建仓库(实得 %s, 期望 %s) —— 可能是 worktree 或共享仓库"
+                % (real_git, want))
+    try:
+        inside = os.path.commonpath([real_sb, real_tmp]) == real_tmp
+    except ValueError:                      # 不同盘符 / 相对路径混用
+        inside = False
+    if not inside:
+        _sb_die("沙箱不在系统临时目录内(沙箱 %s, 临时目录 %s)" % (real_sb, real_tmp))
+
+
+def _sb_init(run, sb):
+    """自建仓库的初始化。顺序是**硬的**, 每一步都拦:
+
+        git init  →  核验归属  →  写本地 config  →  (调用方再写对象)
+
+    归属核验必须排在 config 与任何对象写入**之前**: 万一 git -C 落到了别的仓库上,
+    先写 config 就已经改了别人的仓库了。
+    """
+    r = run("init", "-q", "-b", "main")
+    if r.returncode != 0:
+        _sb_die("git init 失败(返回 %d): %s"
+                % (r.returncode, (r.stderr or r.stdout or "").strip()[:80]))
+    r = run("rev-parse", "--absolute-git-dir")
+    if r.returncode != 0:
+        _sb_die("读不出 git 目录(rev-parse --absolute-git-dir 返回 %d)" % r.returncode)
+    gitdir = r.stdout.strip()
+    _sb_check_owned(gitdir, sb)             # 不合格 → 硬停, 后面一个字都不写
+    for k, v in _SB_CFG:
+        r = run("config", k, v)
+        if r.returncode != 0:
+            _sb_die("git config %s 失败(返回 %d)" % (k, r.returncode))
+    return gitdir
+
+
+def _sb_bootstrap(run, sb):
+    """真实入口: 硬停一律转成**非零退出**。"""
+    try:
+        return _sb_init(run, sb)
+    except _SbAbort as e:
+        print("[FAIL] 夹具初始化硬停: %s" % e.reason)
+        FAIL[0] += 1
+        print()
+        print("-" * 62)
+        print("test-bot-update-check.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))
+        raise SystemExit(1)
+
+
 def _sb_commit(msg):
-    """在自有仓库里造一笔提交, 返回它的 sha。"""
+    """在自有仓库里造一笔提交, 返回它的 sha。每步都查退出码。"""
     open(os.path.join(_SB, "f.txt"), "a", encoding="utf-8").write(msg + "\n")
-    _sbgit("add", "f.txt")
-    _sbgit("commit", "-q", "-m", msg)
-    return _sbgit("rev-parse", "HEAD").stdout.strip()
+    _sb_must(_sbgit, "add", "f.txt")
+    _sb_must(_sbgit, "commit", "-q", "-m", msg)
+    return _sb_must(_sbgit, "rev-parse", "HEAD").stdout.strip()
 
 
-# 建仓库并钉死身份, 免得读到用户的 git config
-_sbgit("init", "-q", "-b", "main")
-for k, v in (("user.email", "fixture@example.invalid"), ("user.name", "fixture"),
-             ("commit.gpgsign", "false"), ("tag.gpgsign", "false")):
-    _sbgit("config", k, v)
-# 安全护栏: 确认待会儿动 tag 的确实是这个自有仓库, 不是共享仓库/用户仓库
-_sb_gitdir = _sbgit("rev-parse", "--absolute-git-dir").stdout.strip()
-(ok if _sb_gitdir == os.path.join(_SB, ".git") and _SB.startswith(tempfile.gettempdir())
- else bad)("1x 版本场景用的是自己的独立仓库(独立 .git, 非 worktree/共享仓库; 实得 %s)"
-           % _sb_gitdir)
+# ── 先验安全门: 初始化失败 / 仓库身份不符, 都必须在写任何东西之前停住 ──────────
+class _SbProbe:
+    """受控桩: 记录每一次 git 调用, 并按需让某一步失败或返回别人的 git 目录。
 
+    注入只发生在这个桩里和它自己的临时目录里 —— 不拿共享仓库实测。
+    """
+
+    def __init__(self, fail_on=None, gitdir=None):
+        self.calls = []
+        self.fail_on = fail_on
+        self.gitdir = gitdir
+
+    def __call__(self, *a, **kw):
+        self.calls.append(a[0])
+        if self.fail_on == a[0]:
+            return _SbR(1, "", "injected failure")
+        if a[0] == "rev-parse":
+            return _SbR(0, self.gitdir if self.gitdir is not None else "", "")
+        return _SbR(0, "", "")
+
+    @property
+    def wrote(self):
+        """有没有做过"写"动作(配置或对象)。"""
+        return [c for c in self.calls if c in ("config", "add", "commit", "tag", "checkout")]
+
+
+class _SbR:
+    def __init__(self, rc=0, out="", err=""):
+        self.returncode, self.stdout, self.stderr = rc, out, err
+
+
+def _sb_exit_code(probe, sb):
+    """在真实入口上重放同一注入, 取它的退出码 —— 硬停必须是**非零**, 不能只打一行红字。
+
+    走的是真实 _sb_bootstrap(不是简化版), 但把它那次的 stdout 收进缓冲、计数也还原:
+    这次重放只为取退出码, 不该在日志里多出两行 [FAIL] 让人分不清哪条是真失败。
+    """
+    probe.calls = []
+    saved = (PASS[0], FAIL[0])
+    try:
+        with contextlib.redirect_stdout(_io.StringIO()):
+            _sb_bootstrap(probe, sb)
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 1
+    finally:
+        PASS[0], FAIL[0] = saved
+    return 0
+
+
+def _sb_reason(fn):
+    """跑一段应当硬停的代码, 返回它是否确实硬停了。"""
+    try:
+        fn()
+        return False
+    except _SbAbort:
+        return True
+
+
+print("══ 0. 夹具自身的安全门: 初始化失败与仓库归属 ══")
+_probe_sb = tmpguard.mkdtemp(prefix="pdg-updcheck-probe.")
+
+# 注入一: git init 返回非零
+_p1 = _SbProbe(fail_on="init")
+try:
+    _sb_init(_p1, _probe_sb)
+    bad("0a git init 失败后仍然继续了(应硬停)")
+except _SbAbort as _e:
+    (ok if "git init 失败" in _e.reason and "返回 1" in _e.reason else
+     bad)("0a git init 失败 → 具名原因(实得 %r)" % _e.reason[:60])
+(ok if _p1.calls == ["init"] else
+ bad)("0a init 失败后再没发出任何 git 命令(实得 %s)" % _p1.calls)
+(ok if not _p1.wrote else
+ bad)("0a init 失败后没有任何配置或对象写入尝试(实得 %s)" % _p1.wrote)
+(ok if _sb_exit_code(_p1, _probe_sb) == 1 else
+ bad)("0a 该硬停在真实入口上转成非零退出")
+
+# 注入二: init 成功, 但 git 目录不是本轮自建的那个(模拟 worktree/共享仓库)
+_p2 = _SbProbe(gitdir="/some/other/repo/.git")
+try:
+    _sb_init(_p2, _probe_sb)
+    bad("0b 仓库身份不符仍然继续了(应硬停)")
+except _SbAbort as _e:
+    (ok if "不属于本轮自建仓库" in _e.reason else
+     bad)("0b 身份不符 → 具名原因(实得 %r)" % _e.reason[:60])
+(ok if _p2.calls == ["init", "rev-parse"] else
+ bad)("0b 身份核验排在 config 之前(调用记录实得 %s)" % _p2.calls)
+(ok if not _p2.wrote else
+ bad)("0b 身份不符后没有任何配置或对象写入尝试(实得 %s)" % _p2.wrote)
+(ok if _sb_exit_code(_p2, _probe_sb) == 1 else
+ bad)("0b 该硬停在真实入口上转成非零退出")
+
+# 0c 路径边界用**真实路径**判定, 不是字符串前缀。
+#    构造一个与临时目录同前缀、但并不在它里面的路径: <tmpdir>foo。
+#    "/tmpfoo".startswith("/tmp") 为真 —— 拿 startswith 当边界就会放行;
+#    commonpath(["/tmpfoo", "/tmp"]) == "/" != "/tmp" —— 按路径判就拦得住。
+_tmp_real = os.path.realpath(tempfile.gettempdir())
+_outside = _tmp_real.rstrip("/") + "foo"
+(ok if _outside.startswith(_tmp_real) else
+ bad)("0c 前提: 构造的路径确实与临时目录同字符串前缀(实得 %s)" % _outside)
+(ok if _sb_reason(lambda: _sb_check_owned(os.path.join(_outside, ".git"), _outside)) else
+ bad)("0c 同前缀但不在临时目录**内**的沙箱被拦下(startswith 会放行, 路径边界不会)")
+
+_C1 = None  # 占位, 真实初始化在下面
+_sb_bootstrap(_sbgit, _SB)
 _C1 = _sb_commit("base")
-_sbgit("tag", "-a", "v9.0.0", "-m", "v9.0.0")
+_sb_must(_sbgit, "tag", "-a", "v9.0.0", "-m", "v9.0.0")
 _C2 = _sb_commit("next")           # 后继提交, 先不打 tag
 
 _prev_repo = bot.PDG_REPO

--- a/tests/test-bot-update-check.py
+++ b/tests/test-bot-update-check.py
@@ -2003,6 +2003,241 @@ _reset_state()
 bot.post = _REAL_POST
 bot.update_check = _REAL_UPDATE_CHECK
 
+# ══════════════════════════════════════════════════════════════════════════════
+# 23. 超期的完整响应不得判成功 —— 确定性场景, 不跟时序赛跑
+# ──────────────────────────────────────────────────────────────────────────────
+# §21 那几格是真实回环: 它们证明的是"慢响应下能及时终止"。但那里客户端拿到的响应
+# 是**不完整**的, 所以证不到本节这条性质: **完整、可解析、ok=true 的 JSON, 只要是在
+# 期限之后才到齐, 也不能返回成功**。
+#
+# 产品里守这条的是 post() 尾部那两句:
+#     if guard.fired:                                   raise _ApiDeadline()
+#     if deadline is not None and now >= deadline:      raise _ApiDeadline()
+# 以前验它们只能靠"连接是否被收掉"这类副作用, 而那取决于 socket 空闲超时与守卫定时器
+# 谁先到 —— 同一个变异有时红有时不红。这一节把两个变量都拿掉:
+#   · 时钟用**线程局部**垫片: 只有跑这一节的线程看到假时间, 收割器等别的线程照拿真时间;
+#   · 守卫是否触发由测试直接决定, 不等 threading.Timer 真的到点。
+# 跑的仍是**真实** post() 与真实 _api_read(), 只把"时间"和"什么时候触发守卫"变成可控输入。
+# 这是受控逻辑证据, **不冒充真实网络期限实测** —— 那部分证据在 §21。
+print()
+print("══ 23. 超期完整响应: 确定性判定(真实 post/_api_read, 受控时钟与守卫) ══")
+
+_DET_BODY = b'{"ok":true,"result":{"message_id":777}}'
+
+
+class _DetClock:
+    """只对**当前线程**撒谎的单调时钟。
+
+    直接改 bot.time.monotonic 会波及收割器与通知线程 —— 它们也在同一个模块命名空间里
+    读时间。这里用 thread-local: 没设过值的线程一律走真实时钟。
+    """
+
+    def __init__(self, real):
+        self._real = real
+        self._tl = threading.local()
+
+    def __getattr__(self, name):            # sleep / time / 其余一律透传给真模块
+        return getattr(self._real, name)
+
+    def monotonic(self):
+        v = getattr(self._tl, "v", None)
+        return self._real.monotonic() if v is None else v
+
+    def freeze(self, v):
+        self._tl.v = v
+
+    def advance(self, d):
+        self._tl.v = getattr(self._tl, "v", self._real.monotonic()) + d
+
+    def release(self):
+        self._tl.v = None
+
+
+class _DetSock:
+    """受控 socket。shutdown 记录但**不真的断流** —— 这样"守卫已触发"与"响应仍然完整"
+    可以同时成立, 才谈得上单验 guard.fired 那一支。"""
+
+    def __init__(self):
+        self.timeouts = []
+        self.shutdowns = 0
+        self.closed = 0
+
+    def settimeout(self, t):
+        self.timeouts.append(t)
+
+    def shutdown(self, how):
+        self.shutdowns += 1
+
+    def close(self):
+        self.closed += 1
+
+
+class _DetResp:
+    """真实形态的响应: read1 分块吐出**完整**的 JSON, 读完 length 归零、isclosed 为真。
+
+    推进时钟的钩子挂在 read1 **之后**: 挂在 settimeout(读之前)会让钟在最后一块读到之前
+    就越过期限, 于是 _api_read 的**逐轮**检查先抛出 —— 那验的是另一支, 而且响应根本读不完。
+    要验"读完之后才发现超期", 时间必须在**数据到手之后**才推进。
+    """
+
+    def __init__(self, chunks, after_read=None):
+        self._chunks = list(chunks)
+        self.length = sum(len(c) for c in self._chunks)
+        self._closed = False
+        self.closed_calls = 0
+        self.reads = 0
+        self._after = after_read
+
+    def read1(self, n=-1):
+        if not self._chunks:
+            self._closed = True
+            return b""
+        c = self._chunks.pop(0)
+        self.length -= len(c)
+        self.reads += 1
+        if not self._chunks:
+            self._closed = True
+        if self._after:
+            self._after(self.reads)
+        return c
+
+    def isclosed(self):
+        return self._closed
+
+    def close(self):
+        self.closed_calls += 1
+        self._closed = True
+
+
+class _DetConn:
+    def __init__(self, sock, resp):
+        self.sock = sock
+        self._resp = resp
+        self.timeout = None
+        self.requests = 0
+        self.closed = 0
+
+    def request(self, *a, **k):
+        self.requests += 1
+
+    def getresponse(self):
+        return self._resp
+
+    def close(self):
+        self.closed += 1
+
+
+def _det_run(label, budget, advance_per_read, fire_guard_at=None):
+    """跑一次真实 post(), 返回 (结果, 观测)。
+
+    budget            这次调用的绝对预算(受控时钟的秒)
+    advance_per_read  每次 settimeout(即每读一块前)把受控时钟推进多少
+    fire_guard_at     在第几次 settimeout 时直接触发守卫(None = 不触发)
+    """
+    obs = {}
+    guards = []
+    real_guard = bot._ApiGuard
+
+    def capturing_guard(sock, deadline):
+        g = real_guard(sock, deadline)
+        guards.append(g)
+        return g
+
+    def after_read(nth):
+        clock.advance(advance_per_read)     # 数据已到手, 再推进时间
+        if fire_guard_at is not None and nth == fire_guard_at and guards:
+            guards[-1]._fire()              # 直接触发, 不等 Timer 到点
+
+    half = len(_DET_BODY) // 2
+    resp = _DetResp([_DET_BODY[:half], _DET_BODY[half:]], after_read)
+    sock = _DetSock()
+    conn = _DetConn(sock, resp)
+
+    clock = _DetClock(bot.time)
+    prev_time, prev_conn = bot.time, getattr(bot._tls, "conn", None)
+    try:
+        bot.time = clock
+        bot._ApiGuard = capturing_guard
+        bot._tls.conn = conn                # 复用这条"连接", 不建新的
+        t0 = 1000.0
+        clock.freeze(t0)
+        r = bot.post("m", {}, t0 + budget)
+        obs["result"] = r
+        obs["guard_fired"] = bool(guards and guards[-1].fired)
+        # Timer.cancel() 与"到点跑完"都会 set 这个 Event; 配合 fired 才分得清是哪一种。
+        obs["timer_done"] = bool(guards and guards[-1].timer is not None
+                                 and guards[-1].timer.finished.is_set())
+        obs["reads"] = resp.reads
+        obs["requests"] = conn.requests
+        obs["settimeouts"] = len(sock.timeouts)
+        obs["shutdowns"] = sock.shutdowns
+        obs["resp_closed"] = resp.closed_calls
+        obs["body_left"] = resp.length
+        obs["clock_end"] = clock.monotonic()
+        obs["deadline"] = t0 + budget
+        obs["tls_conn"] = getattr(bot._tls, "conn", None)
+    finally:
+        clock.release()
+        bot.time = prev_time
+        bot._ApiGuard = real_guard
+        bot._tls.conn = prev_conn
+    return obs
+
+
+# A. 按时完整返回 → 允许成功
+_a = _det_run("A", budget=10.0, advance_per_read=0.1)
+(ok if _a["body_left"] == 0 and _a["resp_closed"] >= 1 else
+ bad)("23A 前提: 响应体已完整读完并收尾(剩余 %s 字节, close %s 次)"
+      % (_a["body_left"], _a["resp_closed"]))
+(ok if _a["clock_end"] < _a["deadline"] else
+ bad)("23A 前提: 读完时**未**超期(钟 %.1f < 期限 %.1f)" % (_a["clock_end"], _a["deadline"]))
+(ok if not _a["guard_fired"] else bad)("23A 前提: 守卫未触发")
+(ok if _a["result"].get("ok") is True and _a["result"]["result"]["message_id"] == 777 else
+ bad)("23A 按时完整返回 → 判成功且内容解析正确(实得 %r)" % (_a["result"],))
+(ok if _a["requests"] == 1 else bad)("23A 只发了一次请求(实得 %d)" % _a["requests"])
+(ok if _a["timer_done"] and not _a["guard_fired"] else
+ bad)("23A 正常返回把守卫定时器取消掉(且不是因为它到点跑过; finished=%s fired=%s)"
+      % (_a["timer_done"], _a["guard_fired"]))
+(ok if _a["reads"] == 2 else bad)("23A 两块都读到了(实得 %d 次)" % _a["reads"])
+
+# B. 超期完整返回, 守卫**尚未**触发 → 必须拒绝成功
+_b = _det_run("B", budget=1.0, advance_per_read=0.6)
+(ok if _b["body_left"] == 0 and _b["resp_closed"] >= 1 else
+ bad)("23B 前提: 响应体已完整读完并收尾(剩余 %s 字节)" % _b["body_left"])
+(ok if not _b["guard_fired"] else
+ bad)("23B 前提: 守卫**未**触发 —— 这一格单验读完后的期限判定")
+(ok if _b["clock_end"] >= _b["deadline"] else
+ bad)("23B 前提: 最后一块到齐时已超期(钟 %.1f ≥ 期限 %.1f)" % (_b["clock_end"], _b["deadline"]))
+(ok if _b["result"] == {} else
+ bad)("23B 超期后到齐的**完整 ok=true JSON** 不得判成功(实得 %r)" % (_b["result"],))
+(ok if _b["tls_conn"] is None else
+ bad)("23B 判失败后连接被收掉, 缓存清空(实得 %r)" % (_b["tls_conn"],))
+(ok if _b["reads"] == 2 else bad)("23B 两块都读到了(实得 %d 次)" % _b["reads"])
+(ok if _b["timer_done"] else bad)("23B 守卫定时器已收")
+
+# C. 超期完整返回, 守卫**已**触发 → 必须拒绝成功
+#    守卫的 shutdown 打在受控 socket 上、不真的断流, 所以"已触发"与"响应完整"同时成立。
+_c = _det_run("C", budget=10.0, advance_per_read=0.1, fire_guard_at=1)
+(ok if _c["body_left"] == 0 and _c["resp_closed"] >= 1 else
+ bad)("23C 前提: 响应体仍然完整读完(剩余 %s 字节)" % _c["body_left"])
+(ok if _c["guard_fired"] and _c["shutdowns"] >= 1 else
+ bad)("23C 前提: 守卫**已**触发并调了 shutdown(fired=%s, shutdown %d 次)"
+      % (_c["guard_fired"], _c["shutdowns"]))
+(ok if _c["clock_end"] < _c["deadline"] else
+ bad)("23C 前提: 读完时**未**超期(钟 %.1f < 期限 %.1f) —— 这一格单验 guard.fired 那一支"
+      % (_c["clock_end"], _c["deadline"]))
+(ok if _c["result"] == {} else
+ bad)("23C 守卫已触发时, 完整 JSON 同样不得判成功(实得 %r)" % (_c["result"],))
+(ok if _c["tls_conn"] is None else
+ bad)("23C 判失败后连接被收掉, 缓存清空(实得 %r)" % (_c["tls_conn"],))
+
+# 三格共同的边界: 受控时钟只影响本线程
+_det_probe = []
+_det_t = threading.Thread(target=lambda: _det_probe.append(bot.time.monotonic()))
+_det_t.start(); _det_t.join(5)
+(ok if _det_probe and abs(_det_probe[0] - time.monotonic()) < 5 else
+ bad)("23 受控时钟只对本线程生效, 别的线程拿到的仍是真实时间(实得 %r)" % (_det_probe[:1],))
+
 print()
 print("-" * 62)
 print("test-bot-update-check.py: 通过 %d, 失败 %d" % (PASS[0], FAIL[0]))


### PR DESCRIPTION
## 为什么改

「已是最新」那组用例原先依赖**宿主仓库自己的发布 tag**：它把 `HEAD` 与 `git describe` 出来的最新 tag 相比，据此断言「没有更新」。这个前提会随发版漂移 —— 项目一发新版本，宿主最新 tag 就不再等于测试当初挑的那个，用例于是在**代码毫无变化**的情况下变红。红得还很难看：失败信息指向产品判据，而真正的原因是夹具的前提被外部事件改掉了。

## 改了什么

**1. A/B/C 改用自有仓库的真实 Git 对象。**
不再借宿主的 tag，而是 `git init` 一个只属于本次运行的仓库，自造提交、自造 tag，自己说了算：

- **A** `HEAD` 正好停在自有仓库的最新 tag 上 → 判「已是最新」并点名 `v9.0.0`
- **B** 同一仓库里新增指向后继提交的更高 tag 而 `HEAD` 不动 → 判「有更新」并点名 `v9.1.0`
- **C** `HEAD` 跟到新 tag → 重新判「已是最新」，且点名的是 `v9.1.0` 而不是旧的 `v9.0.0`

这里**不能用 `git worktree`** —— worktree 与主仓库共享 `refs/tags`，在里面打 tag 会写到共享仓库上去。必须是独立 `.git` 的仓库，才谈得上 tag 隔离。

**2. D 验证 tag 集合确实隔离。**
断言自有仓库的 tag 集合完全自定（实得 `['v9.1.0', 'v9.0.0']`），不含宿主任何发布 tag，也不借用宿主的 latest —— 宿主再发版也不会改变 A/B/C 的前提。这是一条**隔离性断言**，不冒充「宿主新增 tag 的前后实测」。

**3. 夹具初始化补硬门：失败即停，先验归属再写任何东西。**
原先 `git init` 失败了还会继续 `config` / `commit` / `tag`，最终红的是某条产品判据，而真因是沙箱压根没建起来。现在：

- init 失败 → 具名原因，并且**此后不再发出任何 git 命令**
- 身份核验（`rev-parse --absolute-git-dir` 归属本轮目录）排在 `config` **之前**
- 两条路径都断言「失败后没有任何配置或对象写入尝试」，并在真实入口上转成非零退出
- 另加一格：与临时目录**同字符串前缀但不在其内**的路径要被拦下（`startswith` 会放行，路径边界不会）

**4. §23 改用受控时钟与守卫做确定性判定，㊳ 不再跟时序赛跑。**
「超期之后才到齐的完整响应」原先靠真实计时去撞，不稳定。现在用受控时钟 + 受控守卫，把三种情形分开钉死：

- **23A** 按时读完、未超期、守卫未触发 → 判成功，且只发一次请求、守卫定时器被取消（不是因为它到点跑过）
- **23B** 读完时已超期 → 到齐的**完整 `ok=true` JSON 不得判成功**
- **23C** 守卫已触发（已 `shutdown`）→ 完整 JSON **同样不得判成功**

受控时钟是**线程局部**的，旁路线程读到的仍是真实时间（有专门一条断言盯着）。

## 证据

| 来源 | 结果 | 次数 |
|---|---|---|
| exact-head CI（`workflow_dispatch`，head 精确等于本分支 HEAD） | 目标正控 **241/0** | 1 |
| 本地正控（独立完整 clone，冻结 SHA） | **241/0** ×3，归一化后逐字节一致 | 3 |
| 完整负控（未修改） | **38/0**，零无效格 = 1 基线 + 35 变异格 + 1 反向对照 + 1 正式树校验 | 1 |

㊳「超期不再判失败（守卫开火与读完后两处判定一起撤）」命中 5 条具名失败，其中两条是 §23 的**直接裁决**断言：

```
[FAIL] 23B 超期后到齐的**完整 ok=true JSON** 不得判成功(实得 {'ok': True, ...})
[FAIL] 23C 守卫已触发时, 完整 JSON 同样不得判成功(实得 {'ok': True, ...})
```

也就是说，把两处期限判定撤掉之后，代码真的会把超期响应判成成功 —— 判据抓得住，不是靠「连接有没有被收掉」这类间接迹象。

## 证据边界（不要读过头）

- **§23 是受控逻辑证据**：受控时钟与受控守卫下的裁决，不是真实网络时序。
- **§21 是真实明文回环**：自建 loopback，服务端确实收到请求并进入目标阶段；keep-alive 复用同一条连接。
- **完整负控只在本地执行**，未进入 CI —— CI 里绿的是正控。
- 本 PR **不覆盖**：真实 Telegram 接口验收、TLS 全阶段期限、任意旧版本升级路径。

## 范围

唯一修改 `tests/test-bot-update-check.py`（+495/−8）。产品代码、workflow、负控、版本与发布文档相对 `main` **零差异** —— **不改生产行为，也不需要生产部署**。
